### PR TITLE
fix: enable bracketed paste mode to prevent multiline paste splitting

### DIFF
--- a/crates/loopal-tui/src/event.rs
+++ b/crates/loopal-tui/src/event.rs
@@ -76,6 +76,12 @@ impl EventHandler {
                             break;
                         }
                     }
+                    Ok(Some(CrosstermEvent::Paste(text))) => {
+                        let result = PasteResult::Text(text);
+                        if term_tx.send(AppEvent::Paste(result)).await.is_err() {
+                            break;
+                        }
+                    }
                     Ok(_) => {}
                     Err(_) => break,
                 }

--- a/crates/loopal-tui/src/terminal.rs
+++ b/crates/loopal-tui/src/terminal.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture},
+    event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -14,7 +14,12 @@ impl TerminalGuard {
     pub fn new() -> io::Result<Self> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        execute!(
+            stdout,
+            EnterAlternateScreen,
+            EnableMouseCapture,
+            EnableBracketedPaste
+        )?;
         Ok(Self)
     }
 }
@@ -22,6 +27,11 @@ impl TerminalGuard {
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
         let _ = disable_raw_mode();
-        let _ = execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture);
+        let _ = execute!(
+            io::stdout(),
+            LeaveAlternateScreen,
+            DisableMouseCapture,
+            DisableBracketedPaste
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Enable `EnableBracketedPaste` in `TerminalGuard` so the terminal wraps pasted content in escape sequences, delivering multiline paste as a single `CrosstermEvent::Paste` event instead of individual `KeyCode::Enter` per line
- Handle `CrosstermEvent::Paste(text)` in the event loop, reusing the existing paste folding logic (`AppEvent::Paste` → `apply_paste_result`)

**Root cause:** Without bracketed paste mode, pasting multiline text caused each newline to be interpreted as a separate Enter key, immediately submitting each line as an independent command — a major input handling bug.

## Test plan

- [x] `cargo clippy -p loopal-tui --tests` — zero warnings
- [x] `cargo test -p loopal-tui` — 175 tests pass (32 unit + 143 integration)
- [ ] Manual: paste multiline text into TUI input, verify it appears as single input with newlines preserved
- [ ] Manual: verify Ctrl+V clipboard paste still works independently
- [ ] Manual: verify Shift+Enter still inserts newlines