### PR TITLE
fix: replace mouse capture with alternate scroll for terminal text selection

### DIFF
--- a/crates/loopal-tui/src/event.rs
+++ b/crates/loopal-tui/src/event.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{self, Event as CrosstermEvent, KeyEvent, MouseEvent};
+use crossterm::event::{self, Event as CrosstermEvent, KeyEvent};
 use loopal_protocol::AgentEvent;
 use tokio::sync::mpsc;
 
@@ -9,8 +9,6 @@ use crate::input::paste::PasteResult;
 pub enum AppEvent {
     /// Keyboard / terminal event
     Key(KeyEvent),
-    /// Mouse event (scroll, click, etc.)
-    Mouse(MouseEvent),
     /// Resize event
     Resize(u16, u16),
     /// Agent event from the runtime
@@ -57,18 +55,6 @@ impl EventHandler {
                     Ok(Some(CrosstermEvent::Key(key))) => {
                         if term_tx.send(AppEvent::Key(key)).await.is_err() {
                             break;
-                        }
-                    }
-                    Ok(Some(CrosstermEvent::Mouse(mouse))) => {
-                        // Only forward scroll events to avoid flooding
-                        use crossterm::event::MouseEventKind;
-                        match mouse.kind {
-                            MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
-                                if term_tx.send(AppEvent::Mouse(mouse)).await.is_err() {
-                                    break;
-                                }
-                            }
-                            _ => {} // Ignore move, drag, click etc.
                         }
                     }
                     Ok(Some(CrosstermEvent::Resize(w, h))) => {

--- a/crates/loopal-tui/src/input/mod.rs
+++ b/crates/loopal-tui/src/input/mod.rs
@@ -124,6 +124,16 @@ fn handle_normal_key(app: &mut App, key: &KeyEvent) -> InputAction {
                 multiline::line_end(&app.input, app.input_cursor, DEFAULT_WRAP_WIDTH);
             InputAction::None
         }
+        KeyCode::Up if app.scroll_offset > 0 || !app.session.lock().agent_idle => {
+            // Browsing mode (scrolled away from bottom) or agent running:
+            // scroll content area instead of input navigation.
+            app.scroll_offset = app.scroll_offset.saturating_add(3);
+            InputAction::None
+        }
+        KeyCode::Down if app.scroll_offset > 0 => {
+            app.scroll_offset = app.scroll_offset.saturating_sub(3);
+            InputAction::None
+        }
         KeyCode::Up => handle_up(app),
         KeyCode::Down => handle_down(app),
         KeyCode::Esc => handle_esc(app),

--- a/crates/loopal-tui/src/terminal.rs
+++ b/crates/loopal-tui/src/terminal.rs
@@ -1,10 +1,45 @@
+use std::fmt;
 use std::io;
 
 use crossterm::{
-    event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
+    Command,
+    event::{DisableBracketedPaste, EnableBracketedPaste},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
+
+/// Enable xterm alternate scroll mode (`\x1b[?1007h`).
+///
+/// When active in alternate screen, the terminal translates mouse wheel events
+/// into Up/Down arrow key sequences instead of forwarding raw mouse events.
+/// This preserves terminal-native text selection while still providing scroll
+/// wheel support.
+struct EnableAlternateScroll;
+
+impl Command for EnableAlternateScroll {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        write!(f, "\x1b[?1007h")
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Disable xterm alternate scroll mode (`\x1b[?1007l`).
+struct DisableAlternateScroll;
+
+impl Command for DisableAlternateScroll {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        write!(f, "\x1b[?1007l")
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> io::Result<()> {
+        Ok(())
+    }
+}
 
 /// RAII guard that ensures raw mode and alternate screen are cleaned up on drop,
 /// even if the TUI panics or returns early via `?`.
@@ -17,7 +52,7 @@ impl TerminalGuard {
         execute!(
             stdout,
             EnterAlternateScreen,
-            EnableMouseCapture,
+            EnableAlternateScroll,
             EnableBracketedPaste
         )?;
         Ok(Self)
@@ -29,9 +64,9 @@ impl Drop for TerminalGuard {
         let _ = disable_raw_mode();
         let _ = execute!(
             io::stdout(),
-            LeaveAlternateScreen,
-            DisableMouseCapture,
-            DisableBracketedPaste
+            DisableBracketedPaste,
+            DisableAlternateScroll,
+            LeaveAlternateScreen
         );
     }
 }

--- a/crates/loopal-tui/src/tui_loop.rs
+++ b/crates/loopal-tui/src/tui_loop.rs
@@ -142,18 +142,6 @@ pub async fn run_tui(
                 AppEvent::Paste(result) => {
                     paste::apply_paste_result(&mut app, result);
                 }
-                AppEvent::Mouse(mouse) => {
-                    use crossterm::event::MouseEventKind;
-                    match mouse.kind {
-                        MouseEventKind::ScrollUp => {
-                            app.scroll_offset = app.scroll_offset.saturating_add(3);
-                        }
-                        MouseEventKind::ScrollDown => {
-                            app.scroll_offset = app.scroll_offset.saturating_sub(3);
-                        }
-                        _ => {}
-                    }
-                }
                 AppEvent::Resize(_, _) => {}
                 AppEvent::Tick => {}
             }


### PR DESCRIPTION
## Summary

- Replace `EnableMouseCapture` with xterm alternate scroll mode (`\x1b[?1007h`), adopting the same approach as OpenAI Codex CLI
- Removes `AppEvent::Mouse` variant and all mouse event handling code
- Adds context-aware Up/Down key scrolling: scroll content when browsed away from bottom or agent is running, normal input/history navigation otherwise

**Root cause**: `EnableMouseCapture` hijacked all terminal mouse events (click, drag, scroll), but the TUI only used `ScrollUp`/`ScrollDown` — breaking native text selection entirely.

**Solution**: Alternate scroll mode tells the terminal to translate wheel events into Up/Down arrow key sequences while in alternate screen, preserving terminal-native text selection.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --tests` zero warnings
- [x] `cargo test --workspace` — 143 tests pass
- [ ] Manual: mouse drag selects text in terminal
- [ ] Manual: scroll wheel scrolls content during agent output
- [ ] Manual: PageUp/PageDown still work
- [ ] Manual: Up/Down keys navigate input/history when at bottom (idle)