### PR TITLE
fix: add dedicated tool preference warnings to Bash description

### DIFF
--- a/crates/tools/process/bash/src/lib.rs
+++ b/crates/tools/process/bash/src/lib.rs
@@ -28,7 +28,15 @@ impl Tool for BashTool {
     }
 
     fn description(&self) -> &str {
-        "Execute a bash command. Captures stdout and stderr."
+        "Execute a bash command. Captures stdout and stderr.\n\n\
+         IMPORTANT: Avoid using this tool to run `find`, `grep`, `cat`, `head`, \
+         `tail`, `sed`, `awk`, or `echo` commands unless explicitly instructed. \
+         Instead, use the appropriate dedicated tool:\n\
+         - File search: Use Glob (NOT find or ls)\n\
+         - Content search: Use Grep (NOT grep or rg)\n\
+         - Read files: Use Read (NOT cat/head/tail)\n\
+         - Edit files: Use Edit (NOT sed/awk)\n\
+         - Write files: Use Write (NOT echo/cat with redirection)"
     }
 
     fn parameters_schema(&self) -> Value {


### PR DESCRIPTION
## Summary

- BashTool 的 `description()` 中增加 IMPORTANT 警告，引导模型优先使用专用工具（Glob/Grep/Read/Edit/Write）而非等价的 bash 命令（find/grep/cat/sed 等）
- 与 Claude Code 的做法对齐——将警告直接内嵌在工具描述中，确保模型每次考虑调用 Bash 时都能看到

## Test plan

- [x] `cargo check -p loopal-tool-bash` 编译通过
- [x] 改动仅涉及一个字符串常量，无功能变更