### PR TITLE
refactor: remove unused cost/price dead code

### DIFF
--- a/crates/loopal-config/src/settings.rs
+++ b/crates/loopal-config/src/settings.rs
@@ -29,9 +29,6 @@ pub struct Settings {
     /// Maximum context tokens cap (0 = auto: use model's context_window).
     pub max_context_tokens: u32,
 
-    /// Maximum cost per session (USD)
-    pub max_cost: Option<f64>,
-
     /// Provider configurations
     #[serde(default)]
     pub providers: ProvidersConfig,
@@ -65,7 +62,6 @@ impl Default for Settings {
             max_turns: 50,
             permission_mode: PermissionMode::Bypass,
             max_context_tokens: 0,
-            max_cost: None,
             providers: ProvidersConfig::default(),
             hooks: Vec::new(),
             mcp_servers: IndexMap::new(),

--- a/crates/loopal-config/src/validate.rs
+++ b/crates/loopal-config/src/validate.rs
@@ -4,7 +4,6 @@ const KNOWN_KEYS: &[&str] = &[
     "max_turns",
     "permission_mode",
     "max_context_tokens",
-    "max_cost",
     "providers",
     "hooks",
     "mcp_servers",

--- a/crates/loopal-config/tests/suite/config_test.rs
+++ b/crates/loopal-config/tests/suite/config_test.rs
@@ -26,12 +26,6 @@ fn test_settings_default_max_context_tokens() {
 }
 
 #[test]
-fn test_settings_default_max_cost_none() {
-    let settings = Settings::default();
-    assert!(settings.max_cost.is_none());
-}
-
-#[test]
 fn test_settings_default_hooks_empty() {
     let settings = Settings::default();
     assert!(settings.hooks.is_empty());
@@ -52,7 +46,6 @@ fn test_settings_serde_roundtrip() {
     assert_eq!(deserialized.max_turns, settings.max_turns);
     assert_eq!(deserialized.permission_mode, settings.permission_mode);
     assert_eq!(deserialized.max_context_tokens, settings.max_context_tokens);
-    assert_eq!(deserialized.max_cost, settings.max_cost);
     assert_eq!(deserialized.hooks.len(), settings.hooks.len());
     assert_eq!(deserialized.mcp_servers.len(), settings.mcp_servers.len());
 }

--- a/crates/loopal-provider-api/src/lib.rs
+++ b/crates/loopal-provider-api/src/lib.rs
@@ -122,8 +122,6 @@ pub struct ModelInfo {
     pub display_name: String,
     pub context_window: u32,
     pub max_output_tokens: u32,
-    pub input_price_per_mtok: f64,
-    pub output_price_per_mtok: f64,
     pub thinking: ThinkingCapability,
 }
 

--- a/crates/loopal-provider/src/model_info.rs
+++ b/crates/loopal-provider/src/model_info.rs
@@ -6,8 +6,6 @@ struct ModelEntry {
     display_name: &'static str,
     context_window: u32,
     max_output_tokens: u32,
-    input_price_per_mtok: f64,
-    output_price_per_mtok: f64,
     thinking: ThinkingCapability,
 }
 
@@ -19,8 +17,6 @@ impl ModelEntry {
             display_name: self.display_name.to_string(),
             context_window: self.context_window,
             max_output_tokens: self.max_output_tokens,
-            input_price_per_mtok: self.input_price_per_mtok,
-            output_price_per_mtok: self.output_price_per_mtok,
             thinking: self.thinking,
         }
     }
@@ -33,8 +29,6 @@ static KNOWN_MODELS: &[ModelEntry] = &[
         display_name: "Claude Sonnet 4",
         context_window: 200_000,
         max_output_tokens: 64_000,
-        input_price_per_mtok: 3.0,
-        output_price_per_mtok: 15.0,
         thinking: ThinkingCapability::BudgetRequired,
     },
     ModelEntry {
@@ -43,8 +37,6 @@ static KNOWN_MODELS: &[ModelEntry] = &[
         display_name: "Claude Sonnet 4.6",
         context_window: 1_000_000,
         max_output_tokens: 64_000,
-        input_price_per_mtok: 3.0,
-        output_price_per_mtok: 15.0,
         thinking: ThinkingCapability::Adaptive,
     },
     ModelEntry {
@@ -53,8 +45,6 @@ static KNOWN_MODELS: &[ModelEntry] = &[
         display_name: "Claude Opus 4",
         context_window: 200_000,
         max_output_tokens: 32_000,
-        input_price_per_mtok: 15.0,
-        output_price_per_mtok: 75.0,
         thinking: ThinkingCapability::BudgetRequired,
     },
     ModelEntry {
@@ -63,8 +53,6 @@ static KNOWN_MODELS: &[ModelEntry] = &[
         display_name: "Claude Opus 4.6",
         context_window: 1_000_000,
         max_output_tokens: 128_000,
-        input_price_per_mtok: 5.0,
-        output_price_per_mtok: 25.0,
         thinking: ThinkingCapability::Adaptive,
     },
     ModelEntry {
@@ -73,8 +61,6 @@ static KNOWN_MODELS: &[ModelEntry] = &[
         display_name: "Claude 3.5 Haiku",
         context_window: 200_000,
         max_output_tokens: 8_192,
-        input_price_per_mtok: 0.8,
-        output_price_per_mtok: 4.0,
         thinking: ThinkingCapability::None,
     },
     ModelEntry {
@@ -83,8 +69,6 @@ static KNOWN_MODELS: &[ModelEntry] = &[
         display_name: "GPT-4o",
         context_window: 128_000,
         max_output_tokens: 16_384,
-        input_price_per_mtok: 2.5,
-        output_price_per_mtok: 10.0,
         thinking: ThinkingCapability::None,
     },
     ModelEntry {
@@ -93,8 +77,6 @@ static KNOWN_MODELS: &[ModelEntry] = &[
         display_name: "GPT-4o Mini",
         context_window: 128_000,
         max_output_tokens: 16_384,
-        input_price_per_mtok: 0.15,
-        output_price_per_mtok: 0.6,
         thinking: ThinkingCapability::None,
     },
     ModelEntry {
@@ -103,8 +85,6 @@ static KNOWN_MODELS: &[ModelEntry] = &[
         display_name: "o3-mini",
         context_window: 200_000,
         max_output_tokens: 100_000,
-        input_price_per_mtok: 1.1,
-        output_price_per_mtok: 4.4,
         thinking: ThinkingCapability::ReasoningEffort,
     },
     ModelEntry {
@@ -113,8 +93,6 @@ static KNOWN_MODELS: &[ModelEntry] = &[
         display_name: "Gemini 2.0 Flash",
         context_window: 1_000_000,
         max_output_tokens: 8_192,
-        input_price_per_mtok: 0.075,
-        output_price_per_mtok: 0.3,
         thinking: ThinkingCapability::None,
     },
     ModelEntry {
@@ -123,8 +101,6 @@ static KNOWN_MODELS: &[ModelEntry] = &[
         display_name: "Gemini 2.5 Pro",
         context_window: 1_000_000,
         max_output_tokens: 65_536,
-        input_price_per_mtok: 1.25,
-        output_price_per_mtok: 10.0,
         thinking: ThinkingCapability::ThinkingBudget,
     },
 ];

--- a/crates/loopal-provider/tests/suite/model_info_test.rs
+++ b/crates/loopal-provider/tests/suite/model_info_test.rs
@@ -34,7 +34,6 @@ fn test_get_opus_model() {
     assert_eq!(info.provider, "anthropic");
     assert_eq!(info.context_window, 200_000);
     assert_eq!(info.max_output_tokens, 32_000);
-    assert_eq!(info.input_price_per_mtok, 15.0);
 }
 
 #[test]
@@ -43,7 +42,6 @@ fn test_get_opus_4_6_model() {
     assert_eq!(info.provider, "anthropic");
     assert_eq!(info.context_window, 1_000_000);
     assert_eq!(info.max_output_tokens, 128_000);
-    assert_eq!(info.input_price_per_mtok, 5.0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Remove `input_price_per_mtok` / `output_price_per_mtok` fields from `ModelInfo` and `ModelEntry` (defined but never consumed)
- Remove `max_cost` field from `Settings` (defined but no runtime logic reads it)
- Clean up related tests and validation keys

## Changes
- `crates/loopal-provider-api/src/lib.rs` — remove price fields from `ModelInfo`
- `crates/loopal-provider/src/model_info.rs` — remove price fields from `ModelEntry` + 10 model entries
- `crates/loopal-provider/tests/suite/model_info_test.rs` — remove price assertions
- `crates/loopal-config/src/settings.rs` — remove `max_cost` field and default
- `crates/loopal-config/src/validate.rs` — remove `"max_cost"` from known keys
- `crates/loopal-config/tests/suite/config_test.rs` — remove `max_cost` test and roundtrip assertion

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test -p loopal-provider` passes
- [x] `cargo test -p loopal-config` passes
- [ ] CI passes