### PR TITLE
fix: restore Up/Down history navigation when agent is idle

### DIFF
--- a/crates/loopal-tui/src/input/mod.rs
+++ b/crates/loopal-tui/src/input/mod.rs
@@ -137,12 +137,6 @@ fn handle_normal_key(app: &mut App, key: &KeyEvent) -> InputAction {
             app.scroll_offset = app.scroll_offset.saturating_add(1);
             InputAction::None
         }
-        KeyCode::Up if app.content_overflows => {
-            // Content exceeds viewport: scroll takes priority over history.
-            // Alternate scroll sends ~3 Up arrows per notch, so step=1 ≈ 3 lines/notch.
-            app.scroll_offset = app.scroll_offset.saturating_add(1);
-            InputAction::None
-        }
         KeyCode::Down if app.scroll_offset > 0 => {
             app.scroll_offset = app.scroll_offset.saturating_sub(1);
             InputAction::None

--- a/crates/loopal-tui/tests/suite/input_edge_test.rs
+++ b/crates/loopal-tui/tests/suite/input_edge_test.rs
@@ -82,6 +82,22 @@ fn test_up_navigates_history_when_content_fits() {
     assert_eq!(app.scroll_offset, 0, "scroll_offset should stay 0");
 }
 
+#[test]
+fn test_up_navigates_history_when_content_overflows_and_idle() {
+    let mut app = make_app();
+    app.session.lock().agent_idle = true;
+    app.content_overflows = true;
+    app.input_history.push("older".into());
+    app.input_history.push("recent".into());
+    let action = handle_key(&mut app, key(KeyCode::Up));
+    assert!(matches!(action, InputAction::None));
+    assert_eq!(
+        app.input, "recent",
+        "Up should browse history even when content overflows (agent idle)"
+    );
+    assert_eq!(app.scroll_offset, 0);
+}
+
 // --- Modal Ctrl+C ---
 
 #[test]


### PR DESCRIPTION
## Summary
- Up/Down arrow keys no longer navigated input history when agent was idle — they always scrolled the content area instead
- Root cause: `content_overflows` guard unconditionally intercepted Up key for scrolling whenever conversation output exceeded viewport height
- Removed the overly broad condition; idle state now correctly routes Up/Down to history navigation

## Changes
- `crates/loopal-tui/src/input/mod.rs` — removed `KeyCode::Up if app.content_overflows` branch
- `crates/loopal-tui/tests/suite/input_edge_test.rs` — added `test_up_navigates_history_when_content_overflows_and_idle`

## Test plan
- [x] `cargo test -p loopal-tui` — 255 passed
- [x] `cargo clippy -p loopal-tui --tests` — zero warnings
- [ ] CI passes