### PR TITLE
fix: route server tool input deltas + clear stale sub-agent status

### DIFF
--- a/crates/loopal-agent-hub/src/connection_ops.rs
+++ b/crates/loopal-agent-hub/src/connection_ops.rs
@@ -7,7 +7,7 @@ use loopal_ipc::TcpTransport;
 use loopal_ipc::connection::{Connection, Incoming};
 use loopal_ipc::protocol::methods;
 use loopal_ipc::transport::Transport;
-use loopal_protocol::AgentEvent;
+use loopal_protocol::{AgentEvent, AgentEventPayload};
 use tracing::info;
 
 use crate::hub::AgentHub;
@@ -169,4 +169,13 @@ async fn read_agent_events(
         }
     }
     info!(agent = agent_name, "sub-agent event stream ended");
+
+    // Emit synthetic Finished so TUI clears the agent's live status.
+    // Idempotent: if the agent already sent Finished, setting it again is a no-op.
+    let cleanup = AgentEvent::named(agent_name, AgentEventPayload::Finished);
+    let send_result =
+        tokio::time::timeout(std::time::Duration::from_secs(1), event_tx.send(cleanup)).await;
+    if send_result.is_err() || matches!(send_result, Ok(Err(_))) {
+        tracing::debug!(agent = agent_name, "cleanup Finished event not delivered");
+    }
 }

--- a/crates/loopal-context/src/compaction.rs
+++ b/crates/loopal-context/src/compaction.rs
@@ -81,32 +81,42 @@ pub fn sanitize_tool_pairs(messages: &mut Vec<Message>) {
     messages.retain(|m| m.role == MessageRole::System || !m.content.is_empty());
 }
 
+/// Server-side tool name for code execution (mirrors provider constant).
+const CODE_EXECUTION: &str = "code_execution";
+
 /// Remove orphaned ServerToolUse / ServerToolResult blocks within each assistant message.
 ///
 /// A ServerToolUse without a matching ServerToolResult (same message, matching id)
 /// is dropped — this happens when the LLM response is truncated mid-server-tool.
+/// Also strips code_execution blocks with empty input (parser bug artifact).
 fn sanitize_server_tool_pairs(messages: &mut [Message]) {
     for msg in messages
         .iter_mut()
         .filter(|m| m.role == MessageRole::Assistant)
     {
-        let result_ids: HashSet<String> = msg
-            .content
-            .iter()
-            .filter_map(|b| match b {
-                ContentBlock::ServerToolResult { tool_use_id, .. } => Some(tool_use_id.clone()),
-                _ => None,
-            })
-            .collect();
+        // Strip code_execution blocks with empty input (parser bug artifact).
+        // Their orphaned results will be removed by the pair-matching below.
+        msg.content.retain(|b| match b {
+            ContentBlock::ServerToolUse { name, input, .. } => {
+                !(name == CODE_EXECUTION && is_empty_json(input))
+            }
+            _ => true,
+        });
 
-        let use_ids: HashSet<String> = msg
-            .content
-            .iter()
-            .filter_map(|b| match b {
-                ContentBlock::ServerToolUse { id, .. } => Some(id.clone()),
-                _ => None,
-            })
-            .collect();
+        // Single pass: collect both use_ids and result_ids simultaneously.
+        let mut result_ids = HashSet::new();
+        let mut use_ids = HashSet::new();
+        for b in &msg.content {
+            match b {
+                ContentBlock::ServerToolResult { tool_use_id, .. } => {
+                    result_ids.insert(tool_use_id.clone());
+                }
+                ContentBlock::ServerToolUse { id, .. } => {
+                    use_ids.insert(id.clone());
+                }
+                _ => {}
+            }
+        }
 
         msg.content.retain(|b| match b {
             ContentBlock::ServerToolUse { id, .. } => result_ids.contains(id),
@@ -114,6 +124,10 @@ fn sanitize_server_tool_pairs(messages: &mut [Message]) {
             _ => true,
         });
     }
+}
+
+fn is_empty_json(v: &serde_json::Value) -> bool {
+    v.is_null() || v.as_object().is_some_and(|o| o.is_empty())
 }
 
 /// Strip `ContentBlock::Thinking` blocks from all assistant messages except the last one.

--- a/crates/loopal-context/tests/suite/compaction_pair_test.rs
+++ b/crates/loopal-context/tests/suite/compaction_pair_test.rs
@@ -93,8 +93,6 @@ fn compact_then_sanitize_fixes_broken_pairs() {
     }
 }
 
-// --- ServerToolUse / ServerToolResult pair tests ---
-
 fn assistant_with_server_tool_blocks(blocks: Vec<ContentBlock>) -> Message {
     Message {
         id: None,
@@ -104,10 +102,14 @@ fn assistant_with_server_tool_blocks(blocks: Vec<ContentBlock>) -> Message {
 }
 
 fn server_tool_use(id: &str) -> ContentBlock {
+    server_tool_use_with_input(id, serde_json::json!({"code": "test()"}))
+}
+
+fn server_tool_use_with_input(id: &str, input: serde_json::Value) -> ContentBlock {
     ContentBlock::ServerToolUse {
         id: id.to_string(),
         name: "code_execution".to_string(),
-        input: serde_json::json!({}),
+        input,
     }
 }
 
@@ -165,4 +167,34 @@ fn sanitize_preserves_valid_server_tool_pairs() {
     sanitize_tool_pairs(&mut msgs);
     assert_eq!(msgs.len(), 3);
     assert_eq!(msgs[1].content.len(), 4); // all preserved
+}
+
+#[test]
+fn sanitize_strips_code_execution_with_empty_input() {
+    let mut msgs = vec![
+        Message::system("sys"),
+        assistant_with_server_tool_blocks(vec![
+            server_tool_use_with_input("ce_empty", serde_json::json!({})), // empty → stripped
+            server_tool_result("ce_empty"),
+        ]),
+        Message::user("continue"),
+    ];
+    sanitize_tool_pairs(&mut msgs);
+    // Both blocks removed: empty-input use stripped, orphaned result follows
+    assert_eq!(msgs.len(), 2); // system + user
+}
+
+#[test]
+fn sanitize_preserves_code_execution_with_valid_input() {
+    let mut msgs = vec![
+        Message::system("sys"),
+        assistant_with_server_tool_blocks(vec![
+            server_tool_use_with_input("ce_valid", serde_json::json!({"code": "print(1)"})),
+            server_tool_result("ce_valid"),
+        ]),
+        Message::user("continue"),
+    ];
+    sanitize_tool_pairs(&mut msgs);
+    assert_eq!(msgs.len(), 3);
+    assert_eq!(msgs[1].content.len(), 2); // pair preserved
 }

--- a/crates/loopal-provider/src/anthropic/accumulator.rs
+++ b/crates/loopal-provider/src/anthropic/accumulator.rs
@@ -1,4 +1,6 @@
-use loopal_provider_api::StopReason;
+use loopal_error::LoopalError;
+use loopal_provider_api::{StopReason, StreamChunk};
+use serde_json::Value;
 
 /// Accumulates partial tool-use JSON fragments across streamed deltas.
 #[derive(Default)]
@@ -29,4 +31,31 @@ pub(crate) struct ServerToolAccumulator {
     pub(crate) result_content: Option<serde_json::Value>,
     /// The original block type string, e.g. "web_search_tool_result".
     pub(crate) result_block_type: Option<String>,
+    /// Accumulates `input_json_delta` fragments for server tools (e.g. code_execution).
+    pub(crate) json_fragments: String,
+}
+
+impl ServerToolAccumulator {
+    /// Whether a server tool use block is actively being streamed (not a result block).
+    pub(crate) fn is_tool_use_active(&self) -> bool {
+        self.current.is_some() && !self.is_result
+    }
+}
+
+/// Extract usage tokens from a JSON object and push a `StreamChunk::Usage`.
+pub(crate) fn push_usage_from(usage: &Value, chunks: &mut Vec<Result<StreamChunk, LoopalError>>) {
+    let (Some(inp), Some(out)) = (
+        usage["input_tokens"].as_u64(),
+        usage["output_tokens"].as_u64(),
+    ) else {
+        return;
+    };
+    chunks.push(Ok(StreamChunk::Usage {
+        input_tokens: inp as u32,
+        output_tokens: out as u32,
+        cache_creation_input_tokens: usage["cache_creation_input_tokens"].as_u64().unwrap_or(0)
+            as u32,
+        cache_read_input_tokens: usage["cache_read_input_tokens"].as_u64().unwrap_or(0) as u32,
+        thinking_tokens: 0,
+    }));
 }

--- a/crates/loopal-provider/src/anthropic/stream_parser.rs
+++ b/crates/loopal-provider/src/anthropic/stream_parser.rs
@@ -1,4 +1,6 @@
-use super::accumulator::{ServerToolAccumulator, ThinkingAccumulator, ToolUseAccumulator};
+use super::accumulator::{
+    ServerToolAccumulator, ThinkingAccumulator, ToolUseAccumulator, push_usage_from,
+};
 use super::server_tool;
 use loopal_error::{LoopalError, ProviderError};
 use loopal_provider_api::{StopReason, StreamChunk};
@@ -26,10 +28,10 @@ pub(crate) fn parse_anthropic_event(
 
     match event_type {
         "content_block_start" => handle_block_start(&parsed, tool, thinking, server),
-        "content_block_delta" => handle_block_delta(&parsed, tool, thinking, &mut chunks),
+        "content_block_delta" => handle_block_delta(&parsed, tool, thinking, server, &mut chunks),
         "content_block_stop" => handle_block_stop(tool, thinking, server, &mut chunks),
         "message_delta" => parse_usage_and_stop(&parsed, tool, &mut chunks),
-        "message_start" => parse_message_start_usage(&parsed, &mut chunks),
+        "message_start" => push_usage_from(&parsed["message"]["usage"], &mut chunks),
         "message_stop" => {
             let reason = tool.stop_reason.take().unwrap_or(StopReason::EndTurn);
             chunks.push(Ok(StreamChunk::Done {
@@ -68,6 +70,7 @@ fn handle_block_start(
                 input,
             ));
             server.is_result = false;
+            server.json_fragments.clear();
         }
         // Any server-side tool result: web_search_tool_result, code_execution_tool_result, etc.
         other if other.ends_with("_tool_result") && other != "tool_result" => {
@@ -84,6 +87,7 @@ fn handle_block_delta(
     parsed: &Value,
     tool: &mut ToolUseAccumulator,
     thinking: &mut ThinkingAccumulator,
+    server: &mut ServerToolAccumulator,
     chunks: &mut Vec<Result<StreamChunk, LoopalError>>,
 ) {
     let delta = &parsed["delta"];
@@ -98,7 +102,12 @@ fn handle_block_delta(
         }
         "input_json_delta" => {
             if let Some(partial) = delta["partial_json"].as_str() {
-                tool.json_fragments.push_str(partial);
+                // Route to server accumulator when a server tool use block is active.
+                if server.is_tool_use_active() {
+                    server.json_fragments.push_str(partial);
+                } else {
+                    tool.json_fragments.push_str(partial);
+                }
             }
         }
         "thinking_delta" => {
@@ -124,23 +133,18 @@ fn handle_block_stop(
     chunks: &mut Vec<Result<StreamChunk, LoopalError>>,
 ) {
     if thinking.active {
-        let sig = if thinking.signature_fragments.is_empty() {
-            None
-        } else {
-            Some(std::mem::take(&mut thinking.signature_fragments))
-        };
-        if let Some(signature) = sig {
+        if !thinking.signature_fragments.is_empty() {
+            let signature = std::mem::take(&mut thinking.signature_fragments);
             chunks.push(Ok(StreamChunk::ThinkingSignature { signature }));
         }
         thinking.active = false;
     } else if server.is_result {
-        // Emit server tool result
         if let Some(tool_use_id) = server.result_tool_use_id.take() {
             let content = server.result_content.take().unwrap_or(json!(null));
             let block_type = server
                 .result_block_type
                 .take()
-                .unwrap_or_else(|| "unknown_tool_result".to_string());
+                .unwrap_or_else(|| "unknown_tool_result".into());
             chunks.push(Ok(StreamChunk::ServerToolResult {
                 block_type,
                 tool_use_id,
@@ -149,8 +153,21 @@ fn handle_block_stop(
         }
         server.is_result = false;
     } else if let Some((id, name, input)) = server.current.take() {
-        // Emit server tool use (input captured at content_block_start)
-        chunks.push(Ok(StreamChunk::ServerToolUse { id, name, input }));
+        // Deltas override block_start input (API sends empty input at start, code via deltas).
+        let final_input = if server.json_fragments.is_empty() {
+            input
+        } else {
+            serde_json::from_str(&server.json_fragments).unwrap_or_else(|e| {
+                tracing::warn!(id, name, %e, "malformed server tool input fragments");
+                input
+            })
+        };
+        server.json_fragments.clear();
+        chunks.push(Ok(StreamChunk::ServerToolUse {
+            id,
+            name,
+            input: final_input,
+        }));
     } else if let (Some(id), Some(name)) =
         (tool.current_tool_id.take(), tool.current_tool_name.take())
     {
@@ -176,25 +193,5 @@ fn parse_usage_and_stop(
             "pause_turn" => Some(StopReason::PauseTurn),
             _ => Some(StopReason::EndTurn),
         };
-    }
-}
-
-fn parse_message_start_usage(parsed: &Value, chunks: &mut Vec<Result<StreamChunk, LoopalError>>) {
-    push_usage_from(&parsed["message"]["usage"], chunks);
-}
-fn push_usage_from(usage: &Value, chunks: &mut Vec<Result<StreamChunk, LoopalError>>) {
-    if let (Some(input), Some(output)) = (
-        usage["input_tokens"].as_u64(),
-        usage["output_tokens"].as_u64(),
-    ) {
-        let cache_creation = usage["cache_creation_input_tokens"].as_u64().unwrap_or(0) as u32;
-        let cache_read = usage["cache_read_input_tokens"].as_u64().unwrap_or(0) as u32;
-        chunks.push(Ok(StreamChunk::Usage {
-            input_tokens: input as u32,
-            output_tokens: output as u32,
-            cache_creation_input_tokens: cache_creation,
-            cache_read_input_tokens: cache_read,
-            thinking_tokens: 0,
-        }));
     }
 }

--- a/crates/loopal-provider/tests/suite.rs
+++ b/crates/loopal-provider/tests/suite.rs
@@ -25,6 +25,8 @@ mod stream_anthropic_edge_test;
 mod stream_anthropic_test;
 #[path = "suite/stream_google_test.rs"]
 mod stream_google_test;
+#[path = "suite/stream_helpers.rs"]
+mod stream_helpers;
 #[path = "suite/stream_openai_edge_test.rs"]
 mod stream_openai_edge_test;
 #[path = "suite/stream_openai_test.rs"]

--- a/crates/loopal-provider/tests/suite/stream_anthropic_edge_test.rs
+++ b/crates/loopal-provider/tests/suite/stream_anthropic_edge_test.rs
@@ -1,35 +1,8 @@
-use futures::StreamExt;
-use loopal_error::LoopalError;
-use loopal_message::Message;
+use super::stream_helpers::{collect_chunks, test_chat_params};
 use loopal_provider::AnthropicProvider;
-use loopal_provider_api::{ChatParams, Provider, StreamChunk};
+use loopal_provider_api::{Provider, StreamChunk};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
-
-fn test_chat_params() -> ChatParams {
-    ChatParams {
-        model: "test-model".to_string(),
-        messages: vec![Message::user("Hello")],
-        system_prompt: "You are helpful.".to_string(),
-        tools: vec![],
-        max_tokens: 100,
-        temperature: None,
-        thinking: None,
-        debug_dump_dir: None,
-    }
-}
-
-async fn collect_chunks(
-    mut stream: std::pin::Pin<
-        Box<dyn futures::Stream<Item = Result<StreamChunk, LoopalError>> + Send + Unpin>,
-    >,
-) -> Vec<Result<StreamChunk, LoopalError>> {
-    let mut chunks = Vec::new();
-    while let Some(item) = stream.next().await {
-        chunks.push(item);
-    }
-    chunks
-}
 
 #[tokio::test]
 async fn test_sse_empty_data_handled() {
@@ -63,4 +36,110 @@ data: {\"type\":\"message_stop\"}\n\n";
     }
     assert!(got_text, "expected Text(\"OK\") chunk");
     assert!(got_done, "expected Done chunk");
+}
+
+#[tokio::test]
+async fn test_stream_code_execution_input_via_deltas() {
+    let mock_server = MockServer::start().await;
+
+    // Simulate code_execution: empty input at block_start, code streamed via deltas.
+    let sse_body = "\
+data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n\
+data: {\"type\":\"content_block_start\",\"content_block\":{\"type\":\"server_tool_use\",\"id\":\"stu_1\",\"name\":\"code_execution\",\"input\":{}}}\n\n\
+data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"code\\\":\"}}\n\n\
+data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"print(42)\\\",\\\"language\\\":\\\"python\\\"}\"}}\n\n\
+data: {\"type\":\"content_block_stop\"}\n\n\
+data: {\"type\":\"message_stop\"}\n\n";
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&mock_server)
+        .await;
+
+    let provider = AnthropicProvider::new("test-key".to_string()).with_base_url(mock_server.uri());
+    let chunks = collect_chunks(provider.stream_chat(&test_chat_params()).await.unwrap()).await;
+
+    let mut found = false;
+    for chunk in chunks.into_iter().flatten() {
+        if let StreamChunk::ServerToolUse { id, name, input } = chunk {
+            assert_eq!(id, "stu_1");
+            assert_eq!(name, "code_execution");
+            assert_eq!(input["code"], "print(42)");
+            assert_eq!(input["language"], "python");
+            found = true;
+        }
+    }
+    assert!(
+        found,
+        "expected ServerToolUse with reconstructed input from deltas"
+    );
+}
+
+#[tokio::test]
+async fn test_stream_server_tool_preserves_start_input_without_deltas() {
+    let mock_server = MockServer::start().await;
+
+    // web_search: full input at block_start, no input_json_delta events.
+    let sse_body = "\
+data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n\n\
+data: {\"type\":\"content_block_start\",\"content_block\":{\"type\":\"server_tool_use\",\"id\":\"stu_ws\",\"name\":\"web_search\",\"input\":{\"query\":\"rust async\"}}}\n\n\
+data: {\"type\":\"content_block_stop\"}\n\n\
+data: {\"type\":\"message_stop\"}\n\n";
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&mock_server)
+        .await;
+
+    let provider = AnthropicProvider::new("test-key".to_string()).with_base_url(mock_server.uri());
+    let chunks = collect_chunks(provider.stream_chat(&test_chat_params()).await.unwrap()).await;
+
+    let mut found = false;
+    for chunk in chunks.into_iter().flatten() {
+        if let StreamChunk::ServerToolUse { id, name, input } = chunk {
+            assert_eq!(id, "stu_ws");
+            assert_eq!(name, "web_search");
+            assert_eq!(input["query"], "rust async");
+            found = true;
+        }
+    }
+    assert!(found, "expected ServerToolUse with input from block_start");
+}
+
+#[tokio::test]
+async fn test_stream_server_tool_deltas_replace_block_start_input() {
+    let mock_server = MockServer::start().await;
+
+    // Block_start has stale input; deltas carry the real input. Deltas should win.
+    let sse_body = "\
+data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n\n\
+data: {\"type\":\"content_block_start\",\"content_block\":{\"type\":\"server_tool_use\",\"id\":\"stu_r\",\"name\":\"code_execution\",\"input\":{\"stale\":true}}}\n\n\
+data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"code\\\":\\\"x=1\\\"}\"}}\n\n\
+data: {\"type\":\"content_block_stop\"}\n\n\
+data: {\"type\":\"message_stop\"}\n\n";
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&mock_server)
+        .await;
+
+    let provider = AnthropicProvider::new("test-key".to_string()).with_base_url(mock_server.uri());
+    let chunks = collect_chunks(provider.stream_chat(&test_chat_params()).await.unwrap()).await;
+
+    let mut found = false;
+    for chunk in chunks.into_iter().flatten() {
+        if let StreamChunk::ServerToolUse { input, .. } = chunk {
+            // Deltas replace block_start input entirely
+            assert_eq!(input["code"], "x=1");
+            assert!(
+                input.get("stale").is_none(),
+                "block_start input should be replaced"
+            );
+            found = true;
+        }
+    }
+    assert!(found);
 }

--- a/crates/loopal-provider/tests/suite/stream_anthropic_test.rs
+++ b/crates/loopal-provider/tests/suite/stream_anthropic_test.rs
@@ -1,35 +1,9 @@
-use futures::StreamExt;
+use super::stream_helpers::{collect_chunks, test_chat_params};
 use loopal_error::{LoopalError, ProviderError};
-use loopal_message::Message;
 use loopal_provider::AnthropicProvider;
-use loopal_provider_api::{ChatParams, Provider, StreamChunk};
+use loopal_provider_api::{Provider, StreamChunk};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
-
-fn test_chat_params() -> ChatParams {
-    ChatParams {
-        model: "test-model".to_string(),
-        messages: vec![Message::user("Hello")],
-        system_prompt: "You are helpful.".to_string(),
-        tools: vec![],
-        max_tokens: 100,
-        temperature: None,
-        thinking: None,
-        debug_dump_dir: None,
-    }
-}
-
-async fn collect_chunks(
-    mut stream: std::pin::Pin<
-        Box<dyn futures::Stream<Item = Result<StreamChunk, LoopalError>> + Send + Unpin>,
-    >,
-) -> Vec<Result<StreamChunk, LoopalError>> {
-    let mut chunks = Vec::new();
-    while let Some(item) = stream.next().await {
-        chunks.push(item);
-    }
-    chunks
-}
 
 fn expect_err(result: Result<loopal_provider_api::ChatStream, LoopalError>) -> LoopalError {
     match result {

--- a/crates/loopal-provider/tests/suite/stream_google_test.rs
+++ b/crates/loopal-provider/tests/suite/stream_google_test.rs
@@ -1,35 +1,9 @@
-use futures::StreamExt;
+use super::stream_helpers::{collect_chunks, test_chat_params};
 use loopal_error::{LoopalError, ProviderError};
-use loopal_message::Message;
 use loopal_provider::GoogleProvider;
-use loopal_provider_api::{ChatParams, Provider, StreamChunk};
+use loopal_provider_api::{Provider, StreamChunk};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
-
-fn test_chat_params() -> ChatParams {
-    ChatParams {
-        model: "test-model".to_string(),
-        messages: vec![Message::user("Hello")],
-        system_prompt: "You are helpful.".to_string(),
-        tools: vec![],
-        max_tokens: 100,
-        temperature: None,
-        thinking: None,
-        debug_dump_dir: None,
-    }
-}
-
-async fn collect_chunks(
-    mut stream: std::pin::Pin<
-        Box<dyn futures::Stream<Item = Result<StreamChunk, LoopalError>> + Send + Unpin>,
-    >,
-) -> Vec<Result<StreamChunk, LoopalError>> {
-    let mut chunks = Vec::new();
-    while let Some(item) = stream.next().await {
-        chunks.push(item);
-    }
-    chunks
-}
 
 fn expect_err(result: Result<loopal_provider_api::ChatStream, LoopalError>) -> LoopalError {
     match result {

--- a/crates/loopal-provider/tests/suite/stream_helpers.rs
+++ b/crates/loopal-provider/tests/suite/stream_helpers.rs
@@ -1,0 +1,31 @@
+//! Shared helpers for provider integration tests (wiremock SSE).
+
+use futures::StreamExt;
+use loopal_error::LoopalError;
+use loopal_message::Message;
+use loopal_provider_api::{ChatParams, StreamChunk};
+
+pub fn test_chat_params() -> ChatParams {
+    ChatParams {
+        model: "test-model".to_string(),
+        messages: vec![Message::user("Hello")],
+        system_prompt: "You are helpful.".to_string(),
+        tools: vec![],
+        max_tokens: 100,
+        temperature: None,
+        thinking: None,
+        debug_dump_dir: None,
+    }
+}
+
+pub async fn collect_chunks(
+    mut stream: std::pin::Pin<
+        Box<dyn futures::Stream<Item = Result<StreamChunk, LoopalError>> + Send + Unpin>,
+    >,
+) -> Vec<Result<StreamChunk, LoopalError>> {
+    let mut chunks = Vec::new();
+    while let Some(item) = stream.next().await {
+        chunks.push(item);
+    }
+    chunks
+}

--- a/crates/loopal-provider/tests/suite/stream_openai_edge_test.rs
+++ b/crates/loopal-provider/tests/suite/stream_openai_edge_test.rs
@@ -1,35 +1,8 @@
-use futures::StreamExt;
-use loopal_error::LoopalError;
-use loopal_message::Message;
+use super::stream_helpers::{collect_chunks, test_chat_params};
 use loopal_provider::OpenAiProvider;
-use loopal_provider_api::{ChatParams, Provider, StreamChunk};
+use loopal_provider_api::{Provider, StreamChunk};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
-
-fn test_chat_params() -> ChatParams {
-    ChatParams {
-        model: "test-model".to_string(),
-        messages: vec![Message::user("Hello")],
-        system_prompt: "You are helpful.".to_string(),
-        tools: vec![],
-        max_tokens: 100,
-        temperature: None,
-        thinking: None,
-        debug_dump_dir: None,
-    }
-}
-
-async fn collect_chunks(
-    mut stream: std::pin::Pin<
-        Box<dyn futures::Stream<Item = Result<StreamChunk, LoopalError>> + Send + Unpin>,
-    >,
-) -> Vec<Result<StreamChunk, LoopalError>> {
-    let mut chunks = Vec::new();
-    while let Some(item) = stream.next().await {
-        chunks.push(item);
-    }
-    chunks
-}
 
 #[tokio::test]
 async fn test_responses_api_incomplete_event() {

--- a/crates/loopal-provider/tests/suite/stream_openai_test.rs
+++ b/crates/loopal-provider/tests/suite/stream_openai_test.rs
@@ -1,35 +1,9 @@
-use futures::StreamExt;
+use super::stream_helpers::{collect_chunks, test_chat_params};
 use loopal_error::{LoopalError, ProviderError};
-use loopal_message::Message;
 use loopal_provider::OpenAiProvider;
-use loopal_provider_api::{ChatParams, Provider, StreamChunk};
+use loopal_provider_api::{Provider, StreamChunk};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
-
-fn test_chat_params() -> ChatParams {
-    ChatParams {
-        model: "test-model".to_string(),
-        messages: vec![Message::user("Hello")],
-        system_prompt: "You are helpful.".to_string(),
-        tools: vec![],
-        max_tokens: 100,
-        temperature: None,
-        thinking: None,
-        debug_dump_dir: None,
-    }
-}
-
-async fn collect_chunks(
-    mut stream: std::pin::Pin<
-        Box<dyn futures::Stream<Item = Result<StreamChunk, LoopalError>> + Send + Unpin>,
-    >,
-) -> Vec<Result<StreamChunk, LoopalError>> {
-    let mut chunks = Vec::new();
-    while let Some(item) = stream.next().await {
-        chunks.push(item);
-    }
-    chunks
-}
 
 fn expect_err(result: Result<loopal_provider_api::ChatStream, LoopalError>) -> LoopalError {
     match result {

--- a/crates/loopal-session/tests/suite/agent_handler_edge_test.rs
+++ b/crates/loopal-session/tests/suite/agent_handler_edge_test.rs
@@ -44,3 +44,52 @@ fn test_retry_cleared_no_crash() {
     // Status unchanged from Started → Running
     assert_eq!(state.agents["w1"].observable.status, AgentStatus::Running);
 }
+
+#[test]
+fn finished_clears_running_agent() {
+    let mut state = make_state();
+    // Simulate agent in Running state (ThinkingStream sets Running)
+    apply_event(
+        &mut state,
+        AgentEvent::named("sub1", AgentEventPayload::Started),
+    );
+    apply_event(
+        &mut state,
+        AgentEvent::named(
+            "sub1",
+            AgentEventPayload::ThinkingStream { text: "...".into() },
+        ),
+    );
+    assert_eq!(state.agents["sub1"].observable.status, AgentStatus::Running);
+
+    // Simulate disconnect → synthetic Finished event
+    apply_event(
+        &mut state,
+        AgentEvent::named("sub1", AgentEventPayload::Finished),
+    );
+    assert_eq!(
+        state.agents["sub1"].observable.status,
+        AgentStatus::Finished
+    );
+}
+
+#[test]
+fn duplicate_finished_is_idempotent() {
+    let mut state = make_state();
+    apply_event(
+        &mut state,
+        AgentEvent::named("sub1", AgentEventPayload::Started),
+    );
+    apply_event(
+        &mut state,
+        AgentEvent::named("sub1", AgentEventPayload::Finished),
+    );
+    apply_event(
+        &mut state,
+        AgentEvent::named("sub1", AgentEventPayload::Finished),
+    );
+    assert_eq!(
+        state.agents["sub1"].observable.status,
+        AgentStatus::Finished
+    );
+}


### PR DESCRIPTION
## Summary
- **Bug 1**: SSE parser routed `input_json_delta` to client-side accumulator only, causing `code_execution` server tool blocks to have empty `input: {}`. Anthropic API rejected these with 400 on subsequent turns.
- **Bug 2**: Sub-agent TCP disconnect left TUI showing "Thinking" indefinitely — no cleanup event was emitted when the event stream ended.
- **Cleanup**: Extracted duplicated test helpers into shared `stream_helpers.rs` module.

## Changes
- `crates/loopal-provider/src/anthropic/{accumulator,stream_parser}.rs` — route `input_json_delta` to server accumulator, reconstruct input from fragments
- `crates/loopal-context/src/compaction.rs` — defensive filter for empty-input `code_execution` blocks
- `crates/loopal-session/src/connection_ops.rs` — emit synthetic `Finished` event on sub-agent disconnect
- New tests in `stream_anthropic_edge_test.rs`, `compaction_pair_test.rs`, `agent_handler_edge_test.rs`

## Test plan
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace --tests` — zero warnings
- [x] `cargo fmt --check` — clean
- [ ] CI passes