### PR TITLE
fix: use macos-14 runner for x86_64-apple-darwin release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14
             archive: tar.gz
           - target: aarch64-apple-darwin
             os: macos-14


### PR DESCRIPTION
## Summary
- `macos-13` runner is no longer supported by GitHub Actions
- Switch to `macos-14` (Apple Silicon) which can cross-compile x86_64 targets

## Test plan
- [ ] CI passes
- [ ] Re-tag release to verify build matrix works