### PR TITLE
feat: add --version flag and make install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-all release test test-ci clippy fmt check run debug repin clean \
+.PHONY: build build-all release install test test-ci clippy fmt check run debug repin clean \
        release-macos-arm release-macos-x86 release-linux-arm release-linux-x86 release-windows
 
 # ── Build ────────────────────────────────────────────────────────────────────
@@ -9,8 +9,15 @@ build:
 build-all:
 	bazel build //...
 
+INSTALL_DIR ?= $(HOME)/.local/bin
+
 release:
 	bazel build //:loopal -c opt
+
+install: release
+	@mkdir -p $(INSTALL_DIR)
+	cp -f bazel-bin/loopal $(INSTALL_DIR)/loopal
+	@echo "Installed to $(INSTALL_DIR)/loopal"
 
 # ── Test ─────────────────────────────────────────────────────────────────────
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(name = "loopal", about = "AI coding agent")]
+#[command(name = "loopal", about = "AI coding agent", version = "0.1.0")]
 pub struct Cli {
     /// Model to use
     #[arg(short, long)]


### PR DESCRIPTION
## Summary
- Add `--version` / `-V` flag to CLI via clap (outputs `loopal 0.1.0`)
- Add `make install` target to build optimized binary and copy to `~/.local/bin`

## Changes
- `src/cli.rs`: add `version = "0.1.0"` to clap command attribute
- `Makefile`: add `install` target with configurable `INSTALL_DIR`

## Test plan
- [ ] CI passes