### PR TITLE
fix: remove duplicate root agent in topology overlay

### DIFF
--- a/crates/loopal-tui/src/views/topology_overlay/mod.rs
+++ b/crates/loopal-tui/src/views/topology_overlay/mod.rs
@@ -9,8 +9,8 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, canvas::Canvas};
 
 use loopal_protocol::AgentStatus;
-use loopal_session::state::AgentViewState;
 use loopal_session::ROOT_AGENT;
+use loopal_session::state::AgentViewState;
 
 use crate::views::unified_status::spinner_frame;
 use layout::abbreviate_model;


### PR DESCRIPTION
## Summary
- Topology panel showed both virtual `root` node and real `main` agent entry — same agent displayed twice
- Filter out `ROOT_AGENT` ("main") from `live_agents` in `extract_topology()` since its state is already represented by the synthetic root node

## Changes
- `crates/loopal-tui/src/views/topology_overlay/mod.rs` — add `ROOT_AGENT` exclusion filter

## Test plan
- [ ] CI passes
- [ ] Visual: toggle topology overlay (`Ctrl+T`) with sub-agents — only one root node appears