### PR TITLE
fix: align macOS seatbelt sandbox with Codex whitelist policy

### DIFF
--- a/crates/loopal-sandbox/BUILD.bazel
+++ b/crates/loopal-sandbox/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "loopal-sandbox",
     srcs = glob(["src/**/*.rs"]),
+    compile_data = glob(["src/**/*.sbpl"]),
     edition = "2024",
     visibility = ["//visibility:public"],
     deps = [

--- a/crates/loopal-sandbox/src/platform/macos.rs
+++ b/crates/loopal-sandbox/src/platform/macos.rs
@@ -2,57 +2,38 @@ use std::path::Path;
 
 use loopal_config::{ResolvedPolicy, SandboxPolicy};
 
-/// System paths that must be writable for basic CLI tool operation.
-/// These are platform-invariant safe paths (device files, system temp).
-const SYSTEM_WRITABLE_PATHS: &[&str] = &[
-    "/dev",             // /dev/null, /dev/tty, /dev/urandom etc.
-    "/private/var/tmp", // POSIX /var/tmp (some tools bypass $TMPDIR)
-];
+/// Static base policy loaded from the `.sbpl` file at compile time.
+/// Contains: deny-default, process/sysctl/iokit/mach/ipc/pty rules,
+/// system writable paths, and framework executable-mapping rules.
+const BASE_POLICY: &str = include_str!("seatbelt_base.sbpl");
 
-/// Append seatbelt rules for essential system writable paths.
-fn append_system_write_rules(profile: &mut String) {
-    for path in SYSTEM_WRITABLE_PATHS {
-        profile.push_str(&format!("(allow file-write* (subpath \"{path}\"))\n"));
-    }
-}
+/// Generate a macOS Seatbelt profile string from the resolved policy.
 ///
-/// The profile allows reads everywhere but restricts writes to the
-/// configured writable paths.
+/// Composes the static base policy with dynamic sections for file-read,
+/// file-write (writable paths), and network access.
 pub fn generate_seatbelt_profile(policy: &ResolvedPolicy) -> String {
-    let mut profile = String::from("(version 1)\n");
+    if policy.policy == SandboxPolicy::Disabled {
+        return "(version 1)\n(allow default)\n".to_string();
+    }
 
-    match policy.policy {
-        SandboxPolicy::ReadOnly => {
-            profile.push_str("(deny default)\n");
-            profile.push_str("(allow process-exec)\n");
-            profile.push_str("(allow process-fork)\n");
-            profile.push_str("(allow sysctl-read)\n");
-            profile.push_str("(allow file-read*)\n");
-            profile.push_str("(allow mach-lookup)\n");
-            append_system_write_rules(&mut profile);
-        }
-        SandboxPolicy::WorkspaceWrite => {
-            profile.push_str("(deny default)\n");
-            profile.push_str("(allow process-exec)\n");
-            profile.push_str("(allow process-fork)\n");
-            profile.push_str("(allow sysctl-read)\n");
-            profile.push_str("(allow file-read*)\n");
-            profile.push_str("(allow mach-lookup)\n");
-            append_system_write_rules(&mut profile);
+    let mut profile = BASE_POLICY.to_string();
 
-            // Allow writes to configured writable paths
-            for path in &policy.writable_paths {
-                let path_str = path.to_string_lossy();
-                profile.push_str(&format!("(allow file-write* (subpath \"{path_str}\"))\n"));
-            }
-        }
-        SandboxPolicy::Disabled => {
-            profile.push_str("(allow default)\n");
+    // file-read*: full read access (Codex supports per-root restrictions,
+    // but we keep it simple for now).
+    profile.push_str("\n; --- Dynamic: file access ---\n");
+    profile.push_str("(allow file-read*)\n");
+
+    // file-write*: per-path restrictions for WorkspaceWrite
+    if policy.policy == SandboxPolicy::WorkspaceWrite {
+        for path in &policy.writable_paths {
+            let path_str = path.to_string_lossy();
+            profile.push_str(&format!("(allow file-write* (subpath \"{path_str}\"))\n"));
         }
     }
 
-    // Allow network if not restricted
+    // network
     if policy.network.allowed_domains.is_empty() && policy.network.denied_domains.is_empty() {
+        profile.push_str("\n; --- Dynamic: network ---\n");
         profile.push_str("(allow network*)\n");
     }
 

--- a/crates/loopal-sandbox/src/platform/seatbelt_base.sbpl
+++ b/crates/loopal-sandbox/src/platform/seatbelt_base.sbpl
@@ -1,0 +1,115 @@
+; Loopal macOS Seatbelt base policy
+; Inspired by Codex / Chromium sandbox policy, with relaxations for broad
+; CLI-tool compatibility.
+;
+; This file is included via include_str!() and provides the static rules.
+; Dynamic sections (file-read*, file-write*, network) are appended by Rust.
+
+(version 1)
+
+; closed-by-default
+(deny default)
+
+; --- Process ---
+(allow process-exec)
+(allow process-fork)
+(allow signal (target same-sandbox))
+(allow process-info* (target same-sandbox))
+
+; --- sysctl ---
+; Prefix-based whitelist: broader than Codex for tool compatibility,
+; but still blocks writes (except the one JVM needs).
+(allow sysctl-read
+  (sysctl-name-prefix "hw.")
+  (sysctl-name-prefix "kern.os")
+  (sysctl-name-prefix "kern.proc.")
+  (sysctl-name-prefix "machdep.cpu.")
+  (sysctl-name-prefix "net.routetable.")
+  (sysctl-name "kern.argmax")
+  (sysctl-name "kern.hostname")
+  (sysctl-name "kern.maxfilesperproc")
+  (sysctl-name "kern.maxproc")
+  (sysctl-name "kern.secure_kernel")
+  (sysctl-name "kern.usrstack64")
+  (sysctl-name "kern.version")
+  (sysctl-name "sysctl.proc_cputype")
+  (sysctl-name "vm.loadavg")
+)
+
+; JVM passes a memory buffer to this sysctl; classified as "write" but
+; conceptually it is a read.
+(allow sysctl-write
+  (sysctl-name "kern.grade_cputype"))
+
+; --- IOKit ---
+; Only RootDomainUserClient (power/hardware info). This is enough for
+; JVM, Node, Docker, and most native tools.
+(allow iokit-open
+  (iokit-registry-entry-class "RootDomainUserClient"))
+
+; --- Mach services ---
+; Whitelist of system services needed by common dev tools.
+(allow mach-lookup
+  ; Directory / user info
+  (global-name "com.apple.system.opendirectoryd.libinfo")
+  (global-name "com.apple.system.opendirectoryd.membership")
+  (global-name "com.apple.system.DirectoryService.libinfo_v1")
+  (global-name "com.apple.bsd.dirhelper")
+  ; Preferences
+  (global-name "com.apple.cfprefsd.agent")
+  (global-name "com.apple.cfprefsd.daemon")
+  (local-name "com.apple.cfprefsd.agent")
+  ; Security / TLS
+  (global-name "com.apple.SecurityServer")
+  (global-name "com.apple.trustd")
+  (global-name "com.apple.trustd.agent")
+  (global-name "com.apple.ocspd")
+  (global-name "com.apple.secinitd")
+  ; Network config
+  (global-name "com.apple.networkd")
+  (global-name "com.apple.SystemConfiguration.DNSConfiguration")
+  (global-name "com.apple.SystemConfiguration.configd")
+  ; Logging / diagnostics
+  (global-name "com.apple.system.logger")
+  (global-name "com.apple.system.notification_center")
+  (global-name "com.apple.logd")
+  (global-name "com.apple.logd.events")
+  (global-name "com.apple.diagnosticd")
+  (global-name "com.apple.runningboard")
+  ; Power management
+  (global-name "com.apple.PowerManagement.control")
+)
+
+; --- IPC ---
+; POSIX semaphores: needed by Python multiprocessing, database engines, etc.
+(allow ipc-posix-sem)
+; POSIX shared memory: allow all (many tools use shm for IPC).
+(allow ipc-posix-shm*)
+
+; --- PTY ---
+(allow pseudo-tty)
+(allow file-read* file-write* file-ioctl (literal "/dev/ptmx"))
+(allow file-read* file-write*
+  (require-all
+    (regex #"^/dev/ttys[0-9]+")
+    (extension "com.apple.sandbox.pty")))
+; PTYs created before entering seatbelt may lack the extension.
+(allow file-ioctl (regex #"^/dev/ttys[0-9]+"))
+
+; --- System writable paths ---
+(allow file-write* (subpath "/dev"))
+(allow file-write* (subpath "/private/var/tmp"))
+
+; --- Executable mapping ---
+; Allow mmap(PROT_EXEC) for system frameworks and libraries so the
+; dynamic linker can load .dylib files.
+(allow file-map-executable
+  (subpath "/Library/Apple/System/Library/Frameworks")
+  (subpath "/Library/Apple/System/Library/PrivateFrameworks")
+  (subpath "/Library/Apple/usr/lib")
+  (subpath "/System/Library/Frameworks")
+  (subpath "/System/Library/PrivateFrameworks")
+  (subpath "/usr/lib")
+  (subpath "/opt/homebrew/lib")
+  (subpath "/usr/local/lib")
+)

--- a/crates/loopal-sandbox/tests/suite/platform_macos_test.rs
+++ b/crates/loopal-sandbox/tests/suite/platform_macos_test.rs
@@ -39,21 +39,15 @@ mod macos_tests {
     }
 
     #[test]
-    fn readonly_profile_only_allows_system_writes() {
+    fn readonly_profile_has_no_user_writable_paths() {
         let policy = readonly_policy();
         let profile = generate_seatbelt_profile(&policy);
-
         assert!(profile.contains("(deny default)"));
         assert!(profile.contains("(allow file-read*)"));
-        // System writable paths are allowed (device files, /var/tmp)
+        // System paths present, but no user-configured writable paths
         assert!(profile.contains("(allow file-write* (subpath \"/dev\"))"));
         assert!(profile.contains("(allow file-write* (subpath \"/private/var/tmp\"))"));
-        // No workspace write rules beyond system paths
-        let write_count = profile.matches("file-write*").count();
-        assert_eq!(
-            write_count, 2,
-            "only system write rules expected, got: {profile}"
-        );
+        assert!(!profile.contains("/home/user"));
     }
 
     #[test]
@@ -74,5 +68,45 @@ mod macos_tests {
         let policy = workspace_policy();
         let profile = generate_seatbelt_profile(&policy);
         assert!(profile.contains("(allow network*)"));
+    }
+
+    #[test]
+    fn process_rules_aligned_with_codex() {
+        let profile = generate_seatbelt_profile(&workspace_policy());
+        // signal scoped to same-sandbox (not unrestricted)
+        assert!(profile.contains("(allow signal (target same-sandbox))"));
+        // process-info scoped to same-sandbox
+        assert!(profile.contains("(allow process-info* (target same-sandbox))"));
+        // iokit limited to RootDomainUserClient
+        assert!(profile.contains("(allow iokit-open"));
+        assert!(profile.contains("RootDomainUserClient"));
+        // sysctl-write only for JVM
+        assert!(profile.contains("kern.grade_cputype"));
+    }
+
+    #[test]
+    fn ipc_and_pty_rules_present() {
+        let profile = generate_seatbelt_profile(&workspace_policy());
+        assert!(profile.contains("(allow ipc-posix-sem)"));
+        assert!(profile.contains("(allow ipc-posix-shm*)"));
+        assert!(profile.contains("(allow pseudo-tty)"));
+        assert!(profile.contains("/dev/ptmx"));
+    }
+
+    #[test]
+    fn mach_lookup_is_whitelist() {
+        let profile = generate_seatbelt_profile(&workspace_policy());
+        // Must contain specific service names, not blanket mach-lookup
+        assert!(profile.contains("com.apple.system.opendirectoryd.libinfo"));
+        assert!(profile.contains("com.apple.trustd"));
+        assert!(profile.contains("com.apple.SystemConfiguration.DNSConfiguration"));
+    }
+
+    #[test]
+    fn file_map_executable_for_system_frameworks() {
+        let profile = generate_seatbelt_profile(&workspace_policy());
+        assert!(profile.contains("(allow file-map-executable"));
+        assert!(profile.contains("/System/Library/Frameworks"));
+        assert!(profile.contains("/usr/lib"));
     }
 }


### PR DESCRIPTION
## Summary
- Bazel/JVM crashed inside the macOS `sandbox-exec` sandbox due to missing `iokit-open`, `signal`, `pseudo-tty`, and `ipc-posix-sem` permissions
- Rewrote the seatbelt profile to align with Codex's whitelist approach: scoped `signal`/`process-info` to `same-sandbox`, whitelisted specific `sysctl`, `mach-lookup` services, and `iokit` device classes
- Extracted static policy rules into `seatbelt_base.sbpl` loaded via `include_str!`, keeping dynamic sections (writable paths, network) in Rust

## Changes
- `crates/loopal-sandbox/src/platform/seatbelt_base.sbpl` — **new**: static Seatbelt base policy (~110 lines)
- `crates/loopal-sandbox/src/platform/macos.rs` — rewritten to compose from `.sbpl` + dynamic sections
- `crates/loopal-sandbox/BUILD.bazel` — added `compile_data` for `.sbpl` files
- `crates/loopal-sandbox/tests/suite/platform_macos_test.rs` — updated tests for new profile structure

## Test plan
- [x] `bazel test //crates/loopal-sandbox:loopal-sandbox_test` — PASSED
- [x] `bazel build //crates/loopal-sandbox --config=clippy` — zero warnings
- [x] Integration: `sandbox-exec` with new profile + `bazel info` — instant success
- [x] Verified: node, python, git, cargo, curl, pty, semaphore all work under new profile
- [ ] CI passes