### PR TITLE
feat: enable topology overlay by default

### DIFF
--- a/crates/loopal-tui/src/app/mod.rs
+++ b/crates/loopal-tui/src/app/mod.rs
@@ -92,7 +92,7 @@ impl App {
             input_scroll: 0,
             paste_map: HashMap::new(),
             content_overflows: false,
-            show_topology: false,
+            show_topology: true,
             focused_agent: None,
             focused_bg_task: None,
             focus_mode: FocusMode::default(),


### PR DESCRIPTION
## Summary
- Set `show_topology` default to `true` so the agent topology overlay is visible on startup
- Users can still toggle it off via `/topology` command

## Changes
- `crates/loopal-tui/src/app/mod.rs`: `show_topology` initializer `false` → `true`

## Test plan
- [ ] CI passes