### PR TITLE
feat: add diff preview for MultiEdit, Write, and ApplyPatch in TUI

### DIFF
--- a/crates/loopal-tui/src/views/progress/tool_display/apply_patch.rs
+++ b/crates/loopal-tui/src/views/progress/tool_display/apply_patch.rs
@@ -1,0 +1,79 @@
+//! ApplyPatch tool rendering — shows colored diff from patch input.
+
+use ratatui::prelude::*;
+
+use loopal_session::types::SessionToolCall;
+
+use super::diff_style::{self, DIFF_MAX_LINES};
+use super::output_first_line;
+
+/// Header detail: count of file operations in the patch.
+pub fn extract_detail(input: &serde_json::Value) -> Option<String> {
+    let patch = input.get("patch")?.as_str()?;
+    let n = patch.lines().filter(|l| l.starts_with("*** ")).count();
+    Some(format!("{n} file(s)"))
+}
+
+/// Body: parse patch for file headers / +/- lines, render colored diff.
+pub fn render_body(tc: &SessionToolCall) -> Vec<Line<'static>> {
+    let Some(patch) = tc
+        .tool_input
+        .as_ref()
+        .and_then(|i| i.get("patch"))
+        .and_then(|v| v.as_str())
+    else {
+        return vec![output_first_line("patch applied")];
+    };
+
+    let hdr = diff_style::header_style();
+    let mut diff_lines: Vec<Line<'static>> = Vec::new();
+    let mut shown = 0usize;
+    let mut added = 0usize;
+    let mut removed = 0usize;
+    let mut files = 0usize;
+
+    for text in patch.lines() {
+        if text.starts_with("*** ") {
+            files += 1;
+            if shown < DIFF_MAX_LINES {
+                diff_lines.push(Line::from(Span::styled(format!("    {text}"), hdr)));
+                shown += 1;
+            }
+        } else if let Some(rest) = text.strip_prefix('-') {
+            removed += 1;
+            if shown < DIFF_MAX_LINES {
+                diff_lines.push(diff_style::removed_line(rest));
+                shown += 1;
+            }
+        } else if let Some(rest) = text.strip_prefix('+') {
+            added += 1;
+            if shown < DIFF_MAX_LINES {
+                diff_lines.push(diff_style::added_line(rest));
+                shown += 1;
+            }
+        }
+        // Context lines (space prefix) and @@ hunk markers are skipped for compactness
+    }
+
+    // Build: summary first, then diff lines, then fold indicator
+    let summary = format_patch_summary(files, added, removed);
+    let mut lines = vec![output_first_line(&summary)];
+    lines.extend(diff_lines);
+
+    let total = added + removed + files;
+    if total > DIFF_MAX_LINES {
+        lines.push(diff_style::fold_indicator(total - DIFF_MAX_LINES));
+    }
+    lines
+}
+
+fn format_patch_summary(files: usize, added: usize, removed: usize) -> String {
+    let mut parts = vec![format!("{files} file(s)")];
+    if added > 0 {
+        parts.push(format!("+{added}"));
+    }
+    if removed > 0 {
+        parts.push(format!("-{removed}"));
+    }
+    parts.join(", ")
+}

--- a/crates/loopal-tui/src/views/progress/tool_display/diff_style.rs
+++ b/crates/loopal-tui/src/views/progress/tool_display/diff_style.rs
@@ -1,0 +1,90 @@
+//! Diff visualization primitives — colors, line rendering, and fold indicator.
+//!
+//! Shared by all file-editing tool renderers (Edit, MultiEdit, Write, ApplyPatch).
+
+use ratatui::prelude::*;
+
+/// Max diff lines before folding (shared across all diff-capable renderers).
+pub(crate) const DIFF_MAX_LINES: usize = 8;
+
+// ── Semantic colors ──
+
+pub(crate) fn removed_style() -> Style {
+    Style::default().fg(Color::Rgb(220, 80, 80))
+}
+
+pub(crate) fn added_style() -> Style {
+    Style::default().fg(Color::Rgb(80, 200, 80))
+}
+
+pub(crate) fn header_style() -> Style {
+    Style::default().fg(Color::Rgb(130, 170, 220))
+}
+
+// ── Line-level primitives ──
+
+/// A single removed line: `    - {text}` in red.
+pub(crate) fn removed_line(text: &str) -> Line<'static> {
+    Line::from(Span::styled(format!("    - {text}"), removed_style()))
+}
+
+/// A single added line: `    + {text}` in green.
+pub(crate) fn added_line(text: &str) -> Line<'static> {
+    Line::from(Span::styled(format!("    + {text}"), added_style()))
+}
+
+// ── Composite rendering ──
+
+/// Result of rendering a single old→new replacement diff.
+pub(crate) struct DiffResult {
+    pub added: usize,
+    pub removed: usize,
+    pub lines: Vec<Line<'static>>,
+}
+
+/// Render diff lines for a single old→new replacement.
+///
+/// At most `max_lines` diff lines are emitted; the caller handles folding.
+pub(crate) fn render_diff_lines(old: &str, new: &str, max_lines: usize) -> DiffResult {
+    let old_lines: Vec<&str> = if old.is_empty() {
+        Vec::new()
+    } else {
+        old.lines().collect()
+    };
+    let new_lines: Vec<&str> = if new.is_empty() {
+        Vec::new()
+    } else {
+        new.lines().collect()
+    };
+
+    let mut lines = Vec::new();
+    let mut shown = 0;
+
+    for line in &old_lines {
+        if shown >= max_lines {
+            break;
+        }
+        lines.push(removed_line(line));
+        shown += 1;
+    }
+    for line in &new_lines {
+        if shown >= max_lines {
+            break;
+        }
+        lines.push(added_line(line));
+        shown += 1;
+    }
+    DiffResult {
+        added: new_lines.len(),
+        removed: old_lines.len(),
+        lines,
+    }
+}
+
+/// Fold indicator: "    … +N lines" in dim style.
+pub(crate) fn fold_indicator(hidden: usize) -> Line<'static> {
+    Line::from(Span::styled(
+        format!("    … +{hidden} lines"),
+        super::dim_style(),
+    ))
+}

--- a/crates/loopal-tui/src/views/progress/tool_display/edit.rs
+++ b/crates/loopal-tui/src/views/progress/tool_display/edit.rs
@@ -1,13 +1,11 @@
-//! Edit tool rendering — shows inline diff with -/+ markers.
+//! Edit / MultiEdit tool rendering — shows inline diff with -/+ markers.
 
 use ratatui::prelude::*;
 
 use loopal_session::types::SessionToolCall;
 
-use super::{dim_style, output_first_line};
-
-/// Max diff lines before folding.
-const DIFF_MAX_LINES: usize = 8;
+use super::diff_style::{self, DIFF_MAX_LINES};
+use super::output_first_line;
 
 /// Header detail: file path.
 pub fn extract_detail(input: &serde_json::Value) -> Option<String> {
@@ -16,6 +14,8 @@ pub fn extract_detail(input: &serde_json::Value) -> Option<String> {
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
 }
+
+// ── Edit (single) ──
 
 /// Body: show summary + inline diff content.
 pub fn render_body(tc: &SessionToolCall) -> Vec<Line<'static>> {
@@ -31,54 +31,60 @@ pub fn render_body(tc: &SessionToolCall) -> Vec<Line<'static>> {
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
-    let old_lines: Vec<&str> = if old.is_empty() {
-        Vec::new()
-    } else {
-        old.lines().collect()
+    let diff = diff_style::render_diff_lines(old, new, DIFF_MAX_LINES);
+    let total = diff.added + diff.removed;
+    let mut lines = vec![output_first_line(&format_summary(diff.added, diff.removed))];
+    lines.extend(diff.lines);
+    if total > DIFF_MAX_LINES {
+        lines.push(diff_style::fold_indicator(total - DIFF_MAX_LINES));
+    }
+    lines
+}
+
+// ── MultiEdit ──
+
+/// Body: iterate edits array, aggregate diff across all edits.
+pub fn render_multi_edit_body(tc: &SessionToolCall) -> Vec<Line<'static>> {
+    let edits = tc
+        .tool_input
+        .as_ref()
+        .and_then(|i| i.get("edits"))
+        .and_then(|v| v.as_array());
+    let Some(edits) = edits else {
+        return vec![output_first_line("edited")];
     };
-    let new_lines: Vec<&str> = if new.is_empty() {
-        Vec::new()
-    } else {
-        new.lines().collect()
-    };
-    let removed = old_lines.len();
-    let added = new_lines.len();
 
-    let mut lines = Vec::new();
+    let mut all_diff: Vec<Line<'static>> = Vec::new();
+    let (mut total_added, mut total_removed) = (0usize, 0usize);
+    let mut budget = DIFF_MAX_LINES;
 
-    // Summary line
-    let summary = format_summary(added, removed);
-    lines.push(output_first_line(&summary));
-
-    // Diff body: removed lines (red), then added lines (green)
-    let red = Style::default().fg(Color::Rgb(220, 80, 80));
-    let green = Style::default().fg(Color::Rgb(80, 200, 80));
-    let dim = dim_style();
-
-    let total_diff = removed + added;
-    let mut shown = 0;
-
-    for line in &old_lines {
-        if shown >= DIFF_MAX_LINES {
-            break;
-        }
-        lines.push(Line::from(Span::styled(format!("    - {line}"), red)));
-        shown += 1;
-    }
-    for line in &new_lines {
-        if shown >= DIFF_MAX_LINES {
-            break;
-        }
-        lines.push(Line::from(Span::styled(format!("    + {line}"), green)));
-        shown += 1;
-    }
-    if total_diff > shown {
-        lines.push(Line::from(Span::styled(
-            format!("    … +{} lines", total_diff - shown),
-            dim,
-        )));
+    for edit in edits {
+        let old = edit
+            .get("old_string")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let new = edit
+            .get("new_string")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let diff = diff_style::render_diff_lines(old, new, budget);
+        total_added += diff.added;
+        total_removed += diff.removed;
+        budget = budget.saturating_sub(diff.lines.len());
+        all_diff.extend(diff.lines);
     }
 
+    let summary = format!(
+        "{} edit(s): {}",
+        edits.len(),
+        format_summary(total_added, total_removed)
+    );
+    let mut lines = vec![output_first_line(&summary)];
+    lines.extend(all_diff);
+    let total = total_added + total_removed;
+    if total > DIFF_MAX_LINES {
+        lines.push(diff_style::fold_indicator(total - DIFF_MAX_LINES));
+    }
     lines
 }
 

--- a/crates/loopal-tui/src/views/progress/tool_display/mod.rs
+++ b/crates/loopal-tui/src/views/progress/tool_display/mod.rs
@@ -1,11 +1,15 @@
-//! Tool rendering — each tool displayed with expanded output, folded after N lines.
 mod agent;
+mod apply_patch;
 mod bash;
+mod diff_style;
 mod edit;
 mod glob;
 mod grep;
+mod output_format;
 mod read;
 mod write;
+
+pub(crate) use output_format::{dim_style, expand_output, output_first_line, output_style};
 
 use ratatui::prelude::*;
 
@@ -58,6 +62,7 @@ fn extract_detail(tc: &SessionToolCall) -> String {
         "Read" => read::extract_detail(input),
         "Write" => write::extract_detail(input),
         "Edit" | "MultiEdit" => edit::extract_detail(input),
+        "ApplyPatch" => apply_patch::extract_detail(input),
         "Grep" => grep::extract_detail(input),
         "Glob" => glob::extract_detail(input),
         "Ls" => input
@@ -103,7 +108,9 @@ fn render_body(tc: &SessionToolCall) -> Vec<Line<'static>> {
         "Agent" => agent::render_success_body(tc),
         "Read" => read::render_body(tc),
         "Write" => write::render_body(tc),
-        "Edit" | "MultiEdit" => edit::render_body(tc),
+        "Edit" => edit::render_body(tc),
+        "MultiEdit" => edit::render_multi_edit_body(tc),
+        "ApplyPatch" => apply_patch::render_body(tc),
         "Grep" => grep::render_body(tc),
         "Glob" => glob::render_body(tc),
         _ => render_default_body(tc),
@@ -123,43 +130,6 @@ fn render_default_body(tc: &SessionToolCall) -> Vec<Line<'static>> {
         return vec![output_first_line(trimmed)];
     }
     expand_output(result, EXPAND_MAX_LINES, output_style())
-}
-
-// ── Shared helpers (used by sub-modules via `super::`) ──
-
-/// Standard style for tool output text — light enough for dark-mode readability.
-pub(crate) fn output_style() -> Style {
-    Style::default().fg(Color::Rgb(155, 160, 170))
-}
-
-/// Dimmed style for secondary info (elapsed time, fold counts, etc.).
-pub(crate) fn dim_style() -> Style {
-    Style::default().fg(Color::Rgb(100, 105, 115))
-}
-
-/// Expand output up to `max_lines`, fold the rest.
-pub(crate) fn expand_output(content: &str, max_lines: usize, style: Style) -> Vec<Line<'static>> {
-    let all: Vec<&str> = content.lines().collect();
-    let total = all.len();
-    let mut lines = Vec::new();
-
-    for (i, text) in all.iter().take(max_lines).enumerate() {
-        let prefix = if i == 0 { "  ⎿ " } else { "    " };
-        lines.push(Line::from(Span::styled(format!("{prefix}{text}"), style)));
-    }
-
-    if total > max_lines {
-        lines.push(Line::from(Span::styled(
-            format!("    … +{} lines", total - max_lines),
-            dim_style(),
-        )));
-    }
-    lines
-}
-
-/// Single output line with ⎿ prefix.
-pub(crate) fn output_first_line(text: &str) -> Line<'static> {
-    Line::from(Span::styled(format!("  ⎿ {text}"), output_style()))
 }
 
 fn shorten_home(path: &str) -> String {

--- a/crates/loopal-tui/src/views/progress/tool_display/output_format.rs
+++ b/crates/loopal-tui/src/views/progress/tool_display/output_format.rs
@@ -1,0 +1,38 @@
+//! Tool output formatting primitives — styles, indented lines, and expand-with-fold.
+
+use ratatui::prelude::*;
+
+/// Standard style for tool output text — light enough for dark-mode readability.
+pub(crate) fn output_style() -> Style {
+    Style::default().fg(Color::Rgb(155, 160, 170))
+}
+
+/// Dimmed style for secondary info (elapsed time, fold counts, etc.).
+pub(crate) fn dim_style() -> Style {
+    Style::default().fg(Color::Rgb(100, 105, 115))
+}
+
+/// Expand output up to `max_lines`, fold the rest.
+pub(crate) fn expand_output(content: &str, max_lines: usize, style: Style) -> Vec<Line<'static>> {
+    let all: Vec<&str> = content.lines().collect();
+    let total = all.len();
+    let mut lines = Vec::new();
+
+    for (i, text) in all.iter().take(max_lines).enumerate() {
+        let prefix = if i == 0 { "  ⎿ " } else { "    " };
+        lines.push(Line::from(Span::styled(format!("{prefix}{text}"), style)));
+    }
+
+    if total > max_lines {
+        lines.push(Line::from(Span::styled(
+            format!("    … +{} lines", total - max_lines),
+            dim_style(),
+        )));
+    }
+    lines
+}
+
+/// Single output line with ⎿ prefix.
+pub(crate) fn output_first_line(text: &str) -> Line<'static> {
+    Line::from(Span::styled(format!("  ⎿ {text}"), output_style()))
+}

--- a/crates/loopal-tui/src/views/progress/tool_display/write.rs
+++ b/crates/loopal-tui/src/views/progress/tool_display/write.rs
@@ -1,9 +1,10 @@
-//! Write tool rendering.
+//! Write tool rendering — shows bytes written + content preview.
 
 use ratatui::prelude::*;
 
 use loopal_session::types::SessionToolCall;
 
+use super::diff_style::{self, DIFF_MAX_LINES};
 use super::output_first_line;
 
 /// Header detail: file path.
@@ -14,7 +15,7 @@ pub fn extract_detail(input: &serde_json::Value) -> Option<String> {
         .map(|s| s.to_string())
 }
 
-/// Body: show bytes written (from structured metadata, with string fallback).
+/// Body: show bytes written + content preview (green `+` lines via diff_style).
 pub fn render_body(tc: &SessionToolCall) -> Vec<Line<'static>> {
     let msg = tc
         .metadata
@@ -33,7 +34,24 @@ pub fn render_body(tc: &SessionToolCall) -> Vec<Line<'static>> {
             })
         })
         .unwrap_or_else(|| "written".to_string());
-    vec![output_first_line(&msg)]
+
+    let mut lines = vec![output_first_line(&msg)];
+
+    // Content preview: treat as all-new (old="", new=content)
+    if let Some(content) = tc
+        .tool_input
+        .as_ref()
+        .and_then(|i| i.get("content"))
+        .and_then(|v| v.as_str())
+    {
+        let diff = diff_style::render_diff_lines("", content, DIFF_MAX_LINES);
+        lines.extend(diff.lines);
+        if diff.added > DIFF_MAX_LINES {
+            lines.push(diff_style::fold_indicator(diff.added - DIFF_MAX_LINES));
+        }
+    }
+
+    lines
 }
 
 fn format_bytes(bytes: u64) -> String {


### PR DESCRIPTION
## Summary
- Add colored diff previews for **MultiEdit** (iterate edits array), **Write** (content preview as green `+` lines), and **ApplyPatch** (parse patch text for `***`/`+`/`-` lines)
- Extract `diff_style.rs` (shared diff visualization primitives: `DiffResult`, semantic colors, `removed_line`/`added_line`, `fold_indicator`)
- Extract `output_format.rs` from `mod.rs` to separate dispatch from output formatting, freeing 34 lines of headroom

## Changes
- `crates/loopal-tui/src/views/progress/tool_display/diff_style.rs` — **new** (91 lines)
- `crates/loopal-tui/src/views/progress/tool_display/output_format.rs` — **new** (38 lines)
- `crates/loopal-tui/src/views/progress/tool_display/apply_patch.rs` — **new** (80 lines)
- `crates/loopal-tui/src/views/progress/tool_display/edit.rs` — refactored to use `diff_style`, added `render_multi_edit_body`
- `crates/loopal-tui/src/views/progress/tool_display/write.rs` — enhanced with content preview via `render_diff_lines`
- `crates/loopal-tui/src/views/progress/tool_display/mod.rs` — register new modules, split Edit/MultiEdit dispatch

## Test plan
- [x] `bazel build //crates/loopal-tui:loopal-tui` passes
- [x] `bazel build //crates/loopal-tui:loopal-tui --config=clippy` zero warnings
- [x] `bazel build //crates/loopal-tui:loopal-tui --config=rustfmt` passes
- [x] `bazel test //crates/loopal-tui:loopal-tui_test` passes
- [ ] CI passes