### PR TITLE
fix(provider): resilient HTTP client with auto-rebuild on pool corruption

### DIFF
--- a/crates/loopal-error/src/helpers.rs
+++ b/crates/loopal-error/src/helpers.rs
@@ -6,10 +6,12 @@ impl ProviderError {
         matches!(self, ProviderError::RateLimited { .. })
     }
 
-    /// Check if this error is retryable (rate limit, server errors, etc.)
+    /// Check if this error is retryable (rate limit, server errors, network errors, etc.)
     pub fn is_retryable(&self) -> bool {
         match self {
             ProviderError::RateLimited { .. } => true,
+            // Network-level errors (connection reset, timeout, DNS) are transient.
+            ProviderError::Http(_) => true,
             ProviderError::Api { status, message } => {
                 // 400 with context overflow keywords is deterministic — never retryable
                 if *status == 400

--- a/crates/loopal-provider/src/anthropic/mod.rs
+++ b/crates/loopal-provider/src/anthropic/mod.rs
@@ -8,12 +8,12 @@ mod thinking;
 use async_trait::async_trait;
 use loopal_error::{LoopalError, ProviderError};
 use loopal_provider_api::{ChatParams, ChatStream, Provider};
-use reqwest::Client;
 use serde_json::json;
 use std::collections::VecDeque;
 use std::time::Duration;
 use tokio::sync::Semaphore;
 
+use crate::resilient_client::ResilientClient;
 use crate::sse::SseStream;
 use stream::{ServerToolAccumulator, ThinkingAccumulator, ToolUseAccumulator};
 
@@ -21,7 +21,7 @@ use stream::{ServerToolAccumulator, ThinkingAccumulator, ToolUseAccumulator};
 const MAX_CONCURRENT_REQUESTS: usize = 3;
 
 pub struct AnthropicProvider {
-    client: Client,
+    client: ResilientClient,
     api_key: String,
     base_url: String,
     /// Limits concurrent in-flight requests across all agents sharing this provider.
@@ -30,13 +30,8 @@ pub struct AnthropicProvider {
 
 impl AnthropicProvider {
     pub fn new(api_key: String) -> Self {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(300))
-            .connect_timeout(Duration::from_secs(10))
-            .build()
-            .expect("failed to build HTTP client");
         Self {
-            client,
+            client: ResilientClient::new(Duration::from_secs(300), Duration::from_secs(10)),
             api_key,
             base_url: "https://api.anthropic.com".to_string(),
             request_semaphore: Semaphore::new(MAX_CONCURRENT_REQUESTS),
@@ -117,8 +112,8 @@ impl AnthropicProvider {
             "API request"
         );
 
-        let response = self
-            .client
+        let (client, client_gen) = self.client.get();
+        let response = client
             .post(format!("{}/v1/messages", self.base_url))
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", "2023-06-01")
@@ -126,7 +121,11 @@ impl AnthropicProvider {
             .json(&body)
             .send()
             .await
-            .map_err(|e| ProviderError::Http(e.to_string()))?;
+            .map_err(|e| {
+                self.client.report_network_error(client_gen);
+                ProviderError::Http(format!("{e:#}"))
+            })?;
+        self.client.report_success(client_gen);
 
         let status = response.status();
         tracing::info!(status = status.as_u16(), "API response");

--- a/crates/loopal-provider/src/google/mod.rs
+++ b/crates/loopal-provider/src/google/mod.rs
@@ -6,28 +6,23 @@ mod thinking;
 use async_trait::async_trait;
 use loopal_error::{LoopalError, ProviderError};
 use loopal_provider_api::{ChatParams, ChatStream, Provider};
-use reqwest::Client;
 use serde_json::json;
 use std::collections::VecDeque;
 use std::time::Duration;
 
+use crate::resilient_client::ResilientClient;
 use crate::sse::SseStream;
 
 pub struct GoogleProvider {
-    client: Client,
+    client: ResilientClient,
     api_key: String,
     base_url: String,
 }
 
 impl GoogleProvider {
     pub fn new(api_key: String) -> Self {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(300))
-            .connect_timeout(Duration::from_secs(10))
-            .build()
-            .expect("failed to build HTTP client");
         Self {
-            client,
+            client: ResilientClient::new(Duration::from_secs(300), Duration::from_secs(10)),
             api_key,
             base_url: "https://generativelanguage.googleapis.com/v1beta".to_string(),
         }
@@ -90,14 +85,18 @@ impl Provider for GoogleProvider {
             "API request"
         );
 
-        let response = self
-            .client
+        let (client, client_gen) = self.client.get();
+        let response = client
             .post(&url)
             .header("Content-Type", "application/json")
             .json(&body)
             .send()
             .await
-            .map_err(|e| ProviderError::Http(e.to_string()))?;
+            .map_err(|e| {
+                self.client.report_network_error(client_gen);
+                ProviderError::Http(format!("{e:#}"))
+            })?;
+        self.client.report_success(client_gen);
 
         let status = response.status();
         tracing::info!(status = status.as_u16(), "API response");

--- a/crates/loopal-provider/src/lib.rs
+++ b/crates/loopal-provider/src/lib.rs
@@ -3,6 +3,7 @@ pub mod google;
 pub mod model_info;
 pub mod openai;
 pub mod openai_compat;
+pub(crate) mod resilient_client;
 pub mod router;
 pub mod sse;
 pub mod thinking_resolver;

--- a/crates/loopal-provider/src/openai/mod.rs
+++ b/crates/loopal-provider/src/openai/mod.rs
@@ -6,28 +6,23 @@ mod thinking;
 use async_trait::async_trait;
 use loopal_error::{LoopalError, ProviderError};
 use loopal_provider_api::{ChatParams, ChatStream, Provider};
-use reqwest::Client;
 use serde_json::json;
 use std::collections::VecDeque;
 use std::time::Duration;
 
+use crate::resilient_client::ResilientClient;
 use crate::sse::SseStream;
 
 pub struct OpenAiProvider {
-    client: Client,
+    client: ResilientClient,
     api_key: String,
     base_url: String,
 }
 
 impl OpenAiProvider {
     pub fn new(api_key: String) -> Self {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(300))
-            .connect_timeout(Duration::from_secs(10))
-            .build()
-            .expect("failed to build HTTP client");
         Self {
-            client,
+            client: ResilientClient::new(Duration::from_secs(300), Duration::from_secs(10)),
             api_key,
             base_url: "https://api.openai.com".to_string(),
         }
@@ -78,15 +73,19 @@ impl Provider for OpenAiProvider {
             "API request"
         );
 
-        let response = self
-            .client
+        let (client, client_gen) = self.client.get();
+        let response = client
             .post(format!("{}/v1/responses", self.base_url))
             .header("Authorization", format!("Bearer {}", self.api_key))
             .header("Content-Type", "application/json")
             .json(&body)
             .send()
             .await
-            .map_err(|e| ProviderError::Http(e.to_string()))?;
+            .map_err(|e| {
+                self.client.report_network_error(client_gen);
+                ProviderError::Http(format!("{e:#}"))
+            })?;
+        self.client.report_success(client_gen);
 
         let status = response.status();
         tracing::info!(status = status.as_u16(), "API response");

--- a/crates/loopal-provider/src/openai_compat/mod.rs
+++ b/crates/loopal-provider/src/openai_compat/mod.rs
@@ -4,18 +4,18 @@ mod stream;
 use async_trait::async_trait;
 use loopal_error::{LoopalError, ProviderError};
 use loopal_provider_api::{ChatParams, ChatStream, Provider};
-use reqwest::Client;
 use serde_json::json;
 use std::collections::VecDeque;
 use std::time::Duration;
 
+use crate::resilient_client::ResilientClient;
 use crate::sse::SseStream;
 use stream::ToolCallAccumulator;
 
 /// OpenAI-compatible provider using Chat Completions API (`/v1/chat/completions`).
 /// For services like DeepSeek, Ollama, Together, vLLM, etc.
 pub struct OpenAiCompatProvider {
-    client: Client,
+    client: ResilientClient,
     api_key: String,
     base_url: String,
     provider_name: String,
@@ -23,13 +23,8 @@ pub struct OpenAiCompatProvider {
 
 impl OpenAiCompatProvider {
     pub fn new(api_key: String, base_url: String, name: String) -> Self {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(300))
-            .connect_timeout(Duration::from_secs(10))
-            .build()
-            .expect("failed to build HTTP client");
         Self {
-            client,
+            client: ResilientClient::new(Duration::from_secs(300), Duration::from_secs(10)),
             api_key,
             base_url,
             provider_name: name,
@@ -70,15 +65,19 @@ impl Provider for OpenAiCompatProvider {
             "API request"
         );
 
-        let response = self
-            .client
+        let (client, client_gen) = self.client.get();
+        let response = client
             .post(format!("{}/v1/chat/completions", self.base_url))
             .header("Authorization", format!("Bearer {}", self.api_key))
             .header("Content-Type", "application/json")
             .json(&body)
             .send()
             .await
-            .map_err(|e| ProviderError::Http(e.to_string()))?;
+            .map_err(|e| {
+                self.client.report_network_error(client_gen);
+                ProviderError::Http(format!("{e:#}"))
+            })?;
+        self.client.report_success(client_gen);
 
         let status = response.status();
         tracing::info!(status = status.as_u16(), "API response");

--- a/crates/loopal-provider/src/resilient_client.rs
+++ b/crates/loopal-provider/src/resilient_client.rs
@@ -1,0 +1,142 @@
+use reqwest::Client;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::time::Duration;
+
+/// HTTP client wrapper that automatically rebuilds the underlying `reqwest::Client`
+/// when consecutive network errors indicate connection pool corruption.
+///
+/// Network disruptions (proxy switches, interface changes) can poison the connection
+/// pool inside a long-lived `reqwest::Client`, causing all subsequent requests to fail
+/// instantly even after the network recovers. `ResilientClient` detects this pattern
+/// and recreates the client to restore connectivity.
+///
+/// Each `get()` call returns the current client and a generation token. The token
+/// prevents stale requests (from a pre-rebuild client) from resetting the error
+/// counter after a rebuild has already occurred.
+pub(crate) struct ResilientClient {
+    client: Mutex<Client>,
+    timeout: Duration,
+    connect_timeout: Duration,
+    consecutive_errors: AtomicU32,
+    /// Monotonically increasing generation, bumped on each rebuild.
+    generation: AtomicU64,
+}
+
+/// Number of consecutive network errors before rebuilding the client.
+const REBUILD_THRESHOLD: u32 = 2;
+
+impl ResilientClient {
+    pub fn new(timeout: Duration, connect_timeout: Duration) -> Self {
+        let client = build_client(timeout, connect_timeout);
+        Self {
+            client: Mutex::new(client),
+            timeout,
+            connect_timeout,
+            consecutive_errors: AtomicU32::new(0),
+            generation: AtomicU64::new(0),
+        }
+    }
+
+    /// Clone the current client and return it with the current generation token.
+    /// `reqwest::Client` is backed by an `Arc`, so cloning is near-free.
+    pub fn get(&self) -> (Client, u64) {
+        let guard = self.client.lock().expect("client mutex poisoned");
+        let generation = self.generation.load(Ordering::Relaxed);
+        (guard.clone(), generation)
+    }
+
+    /// Reset the consecutive error counter after a successful request.
+    /// Ignored if a rebuild occurred since this request's `get()` call.
+    pub fn report_success(&self, generation: u64) {
+        if self.generation.load(Ordering::Relaxed) == generation {
+            self.consecutive_errors.store(0, Ordering::Relaxed);
+        }
+    }
+
+    /// Increment the consecutive error counter. If the threshold is reached,
+    /// rebuild the client under the mutex to guarantee exactly-once replacement.
+    /// Ignored if a rebuild occurred since this request's `get()` call.
+    pub fn report_network_error(&self, generation: u64) {
+        if self.generation.load(Ordering::Relaxed) != generation {
+            return; // Client already rebuilt; this error is from a stale pool.
+        }
+        let count = self.consecutive_errors.fetch_add(1, Ordering::Relaxed) + 1;
+        if count >= REBUILD_THRESHOLD {
+            let mut guard = self.client.lock().expect("client mutex poisoned");
+            // Double-check under lock — another thread may have already rebuilt.
+            if self.generation.load(Ordering::Relaxed) == generation {
+                *guard = build_client(self.timeout, self.connect_timeout);
+                self.generation.fetch_add(1, Ordering::Relaxed);
+                self.consecutive_errors.store(0, Ordering::Relaxed);
+                tracing::info!(
+                    threshold = REBUILD_THRESHOLD,
+                    "rebuilt HTTP client after consecutive network errors"
+                );
+            }
+        }
+    }
+}
+
+fn build_client(timeout: Duration, connect_timeout: Duration) -> Client {
+    Client::builder()
+        .timeout(timeout)
+        .connect_timeout(connect_timeout)
+        .pool_idle_timeout(Duration::from_secs(60))
+        .tcp_keepalive(Duration::from_secs(30))
+        .build()
+        .expect("failed to build HTTP client")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rebuild_after_threshold() {
+        let rc = ResilientClient::new(Duration::from_secs(30), Duration::from_secs(5));
+        let (_, gen0) = rc.get();
+
+        // First error: below threshold, no rebuild.
+        rc.report_network_error(gen0);
+        assert_eq!(rc.generation.load(Ordering::Relaxed), 0);
+
+        // Second error: reaches threshold, triggers rebuild.
+        rc.report_network_error(gen0);
+        assert_eq!(rc.generation.load(Ordering::Relaxed), 1);
+        assert_eq!(rc.consecutive_errors.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn success_resets_counter() {
+        let rc = ResilientClient::new(Duration::from_secs(30), Duration::from_secs(5));
+        let (_, g) = rc.get();
+
+        rc.report_network_error(g);
+        assert_eq!(rc.consecutive_errors.load(Ordering::Relaxed), 1);
+
+        rc.report_success(g);
+        assert_eq!(rc.consecutive_errors.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn stale_generation_ignored() {
+        let rc = ResilientClient::new(Duration::from_secs(30), Duration::from_secs(5));
+        let (_, gen0) = rc.get();
+
+        // Force a rebuild.
+        rc.report_network_error(gen0);
+        rc.report_network_error(gen0);
+        assert_eq!(rc.generation.load(Ordering::Relaxed), 1);
+
+        // Stale success from gen0 must not reset the counter.
+        rc.report_network_error(rc.generation.load(Ordering::Relaxed));
+        rc.report_success(gen0); // stale — should be ignored
+        assert_eq!(rc.consecutive_errors.load(Ordering::Relaxed), 1);
+
+        // Stale error from gen0 must not increment or rebuild.
+        rc.report_network_error(gen0); // stale — should be ignored
+        assert_eq!(rc.consecutive_errors.load(Ordering::Relaxed), 1);
+        assert_eq!(rc.generation.load(Ordering::Relaxed), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ResilientClient` wrapper that auto-rebuilds `reqwest::Client` after 2 consecutive network errors, recovering from connection pool corruption caused by proxy switches or network changes
- Mark `ProviderError::Http` as retryable so network errors trigger the existing 6-attempt exponential backoff in `llm_retry`
- Preserve full error chain with `format!("{e:#}")` instead of `.to_string()`

## Changes
- **New**: `crates/loopal-provider/src/resilient_client.rs` — `ResilientClient` with generation-based stale request protection
- **Modified**: All 4 providers (Anthropic, OpenAI, Google, OpenAI-compat) — `Client` → `ResilientClient`
- **Modified**: `crates/loopal-error/src/helpers.rs` — `Http(_) => true` in `is_retryable()`

## Test plan
- [x] `bazel build //... --config=clippy` — zero warnings
- [x] `bazel build //... --config=rustfmt` — clean
- [x] `bazel test //...` — 48/48 tests pass
- [ ] CI passes