### PR TITLE
refactor: enforce child process stderr isolation to protect TUI

### DIFF
--- a/crates/loopal-agent-client/src/lib.rs
+++ b/crates/loopal-agent-client/src/lib.rs
@@ -7,6 +7,12 @@ pub mod bridge;
 mod bridge_handlers;
 mod client;
 mod process;
+pub(crate) mod stderr_drain;
+
+#[doc(hidden)]
+pub mod test_support {
+    pub use crate::stderr_drain::drain_to_tracing;
+}
 
 pub use bridge::{BridgeHandles, start_bridge};
 pub use client::{AgentClient, AgentClientEvent, StartAgentParams};

--- a/crates/loopal-agent-client/src/process.rs
+++ b/crates/loopal-agent-client/src/process.rs
@@ -18,13 +18,14 @@ const SHUTDOWN_GRACE: Duration = Duration::from_secs(3);
 pub struct AgentProcess {
     child: Child,
     transport: Arc<dyn Transport>,
+    _stderr_drain: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl AgentProcess {
     /// Spawn an agent worker process with additional environment variables.
     ///
-    /// The child's stdin/stdout are captured for IPC. Stderr is inherited
-    /// (passes through to the parent's terminal for debugging/logging).
+    /// The child's stdin/stdout are captured for IPC. Stderr is piped and
+    /// drained to tracing to avoid corrupting the parent TUI terminal.
     pub async fn spawn_with_env(
         executable: Option<&str>,
         env_vars: &[(&str, &str)],
@@ -38,7 +39,7 @@ impl AgentProcess {
         cmd.arg("--serve")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
+            .stderr(Stdio::piped())
             .kill_on_drop(true);
         for (key, val) in env_vars {
             cmd.env(key, val);
@@ -55,12 +56,21 @@ impl AgentProcess {
             .take()
             .ok_or_else(|| anyhow::anyhow!("failed to capture child stdout"))?;
 
+        let stderr_drain = child
+            .stderr
+            .take()
+            .map(|stderr| tokio::spawn(crate::stderr_drain::drain_to_tracing(stderr)));
+
         let transport: Arc<dyn Transport> = Arc::new(StdioTransport::new(
             Box::new(tokio::io::BufReader::new(stdout)),
             Box::new(stdin),
         ));
 
-        Ok(Self { child, transport })
+        Ok(Self {
+            child,
+            transport,
+            _stderr_drain: stderr_drain,
+        })
     }
 
     /// Spawn an agent worker process.

--- a/crates/loopal-agent-client/src/stderr_drain.rs
+++ b/crates/loopal-agent-client/src/stderr_drain.rs
@@ -1,0 +1,16 @@
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tracing::warn;
+
+/// Consume lines from a child process stderr pipe and forward to tracing.
+///
+/// Prevents child stderr output from corrupting the TUI terminal.
+/// Runs as a spawned task — exits naturally when the pipe closes (child exits).
+pub async fn drain_to_tracing(stderr: impl AsyncRead + Unpin) {
+    let mut lines = BufReader::new(stderr).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            warn!("agent stderr: {trimmed}");
+        }
+    }
+}

--- a/crates/loopal-agent-client/tests/suite.rs
+++ b/crates/loopal-agent-client/tests/suite.rs
@@ -4,3 +4,5 @@ mod bridge_test;
 mod client_methods_test;
 #[path = "suite/client_test.rs"]
 mod client_test;
+#[path = "suite/stderr_drain_test.rs"]
+mod stderr_drain_test;

--- a/crates/loopal-agent-client/tests/suite/stderr_drain_test.rs
+++ b/crates/loopal-agent-client/tests/suite/stderr_drain_test.rs
@@ -1,0 +1,22 @@
+use tokio::io::AsyncWriteExt;
+
+use loopal_agent_client::test_support::drain_to_tracing;
+
+#[tokio::test]
+async fn drain_consumes_all_lines_without_blocking() {
+    let (read_half, mut write_half) = tokio::io::duplex(1024);
+    write_half
+        .write_all(b"error line 1\nerror line 2\n")
+        .await
+        .unwrap();
+    drop(write_half);
+    drain_to_tracing(read_half).await;
+}
+
+#[tokio::test]
+async fn drain_skips_empty_and_blank_lines() {
+    let (read_half, mut write_half) = tokio::io::duplex(1024);
+    write_half.write_all(b"\n  \nreal error\n\n").await.unwrap();
+    drop(write_half);
+    drain_to_tracing(read_half).await;
+}

--- a/crates/loopal-telemetry/src/metrics.rs
+++ b/crates/loopal-telemetry/src/metrics.rs
@@ -60,10 +60,15 @@ mod tests {
 
     #[tokio::test]
     async fn jsonl_exporter_failure_pushes_warning() {
+        let bad_dir = if cfg!(windows) {
+            "Z:\\__no_such_drive__\\otel".to_string()
+        } else {
+            "/nonexistent/otel-dir".to_string()
+        };
         let config = TelemetryConfig {
             enabled: true,
             file_export: Some(true),
-            telemetry_dir: Some("/nonexistent/otel-dir".into()),
+            telemetry_dir: Some(bad_dir),
             ..Default::default()
         };
         let mut warnings = Vec::new();

--- a/crates/loopal-telemetry/src/metrics.rs
+++ b/crates/loopal-telemetry/src/metrics.rs
@@ -9,6 +9,7 @@ use crate::resource::build_resource;
 /// Build a MeterProvider with OTLP and/or JSONL file periodic reader.
 pub(crate) fn build_meter_provider(
     config: &TelemetryConfig,
+    warnings: &mut Vec<String>,
 ) -> Result<SdkMeterProvider, opentelemetry_sdk::metrics::MetricError> {
     let interval = std::time::Duration::from_secs(60);
 
@@ -33,7 +34,7 @@ pub(crate) fn build_meter_provider(
                     .build();
                 builder = builder.with_reader(reader);
             }
-            Err(e) => eprintln!("otel: failed to create JSONL metric exporter: {e}"),
+            Err(e) => warnings.push(format!("otel: failed to create JSONL metric exporter: {e}")),
         }
     }
 
@@ -53,7 +54,23 @@ mod tests {
 
     #[tokio::test]
     async fn build_meter_provider_succeeds() {
-        let result = build_meter_provider(&enabled_config());
+        let result = build_meter_provider(&enabled_config(), &mut Vec::new());
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn jsonl_exporter_failure_pushes_warning() {
+        let config = TelemetryConfig {
+            enabled: true,
+            file_export: Some(true),
+            telemetry_dir: Some("/nonexistent/otel-dir".into()),
+            ..Default::default()
+        };
+        let mut warnings = Vec::new();
+        let _ = build_meter_provider(&config, &mut warnings);
+        assert!(
+            warnings.iter().any(|w| w.contains("JSONL metric exporter")),
+            "expected JSONL exporter warning, got: {warnings:?}"
+        );
     }
 }

--- a/crates/loopal-telemetry/src/shutdown.rs
+++ b/crates/loopal-telemetry/src/shutdown.rs
@@ -36,17 +36,17 @@ impl Drop for TelemetryGuard {
         if let Some(tp) = self.tracer_provider.take()
             && let Err(e) = tp.shutdown()
         {
-            eprintln!("otel tracer shutdown error: {e}");
+            tracing::warn!("otel tracer shutdown error: {e}");
         }
         if let Some(mp) = self.meter_provider.take()
             && let Err(e) = mp.shutdown()
         {
-            eprintln!("otel meter shutdown error: {e}");
+            tracing::warn!("otel meter shutdown error: {e}");
         }
         if let Some(lp) = self.logger_provider.take()
             && let Err(e) = lp.shutdown()
         {
-            eprintln!("otel logger shutdown error: {e}");
+            tracing::warn!("otel logger shutdown error: {e}");
         }
     }
 }

--- a/crates/loopal-telemetry/src/subscriber.rs
+++ b/crates/loopal-telemetry/src/subscriber.rs
@@ -21,6 +21,7 @@ pub fn init_subscriber(
     env_filter: EnvFilter,
 ) -> TelemetryGuard {
     let (non_blocking, log_guard) = tracing_appender::non_blocking(writer);
+    let mut init_warnings: Vec<String> = Vec::new();
 
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_writer(non_blocking)
@@ -29,10 +30,10 @@ pub fn init_subscriber(
         .with_span_events(tracing_subscriber::fmt::format::FmtSpan::NONE);
 
     let tracer_provider = if config.traces_enabled() {
-        match crate::traces::build_tracer_provider(config) {
+        match crate::traces::build_tracer_provider(config, &mut init_warnings) {
             Ok(tp) => Some(tp),
             Err(e) => {
-                eprintln!("otel: failed to build tracer provider: {e}");
+                init_warnings.push(format!("otel: failed to build tracer provider: {e}"));
                 None
             }
         }
@@ -46,13 +47,13 @@ pub fn init_subscriber(
     });
 
     let meter_provider = if config.metrics_enabled() {
-        match crate::metrics::build_meter_provider(config) {
+        match crate::metrics::build_meter_provider(config, &mut init_warnings) {
             Ok(mp) => {
                 opentelemetry::global::set_meter_provider(mp.clone());
                 Some(mp)
             }
             Err(e) => {
-                eprintln!("otel: failed to build meter provider: {e}");
+                init_warnings.push(format!("otel: failed to build meter provider: {e}"));
                 None
             }
         }
@@ -64,7 +65,7 @@ pub fn init_subscriber(
         match crate::logs::build_logger_provider(config) {
             Ok(lp) => Some(lp),
             Err(e) => {
-                eprintln!("otel: failed to build logger provider: {e}");
+                init_warnings.push(format!("otel: failed to build logger provider: {e}"));
                 None
             }
         }
@@ -82,6 +83,10 @@ pub fn init_subscriber(
         .with(env_filter)
         .with(fmt_layer)
         .init();
+
+    for msg in &init_warnings {
+        tracing::warn!("{msg}");
+    }
 
     TelemetryGuard::new(tracer_provider, meter_provider, logger_provider, log_guard)
 }

--- a/crates/loopal-telemetry/src/traces.rs
+++ b/crates/loopal-telemetry/src/traces.rs
@@ -72,10 +72,17 @@ mod tests {
 
     #[tokio::test]
     async fn jsonl_exporter_failure_pushes_warning() {
+        // Use a path that create_dir_all will fail on across all platforms:
+        // a deeply nested path under a non-existent device/root.
+        let bad_dir = if cfg!(windows) {
+            "Z:\\__no_such_drive__\\otel".to_string()
+        } else {
+            "/nonexistent/otel-dir".to_string()
+        };
         let config = TelemetryConfig {
             enabled: true,
             file_export: Some(true),
-            telemetry_dir: Some("/nonexistent/otel-dir".into()),
+            telemetry_dir: Some(bad_dir),
             ..Default::default()
         };
         let mut warnings = Vec::new();

--- a/crates/loopal-telemetry/src/traces.rs
+++ b/crates/loopal-telemetry/src/traces.rs
@@ -10,6 +10,7 @@ use crate::resource::build_resource;
 /// Build a TracerProvider with OTLP and/or JSONL file exporter.
 pub(crate) fn build_tracer_provider(
     config: &TelemetryConfig,
+    warnings: &mut Vec<String>,
 ) -> Result<SdkTracerProvider, TraceError> {
     let sampler = if (config.sample_rate() - 1.0).abs() < f64::EPSILON {
         Sampler::AlwaysOn
@@ -34,7 +35,7 @@ pub(crate) fn build_tracer_provider(
     if config.file_export_enabled() {
         match crate::file_span_exporter::JsonlSpanExporter::new(&config.telemetry_dir()) {
             Ok(exporter) => builder = builder.with_batch_exporter(exporter),
-            Err(e) => eprintln!("otel: failed to create JSONL span exporter: {e}"),
+            Err(e) => warnings.push(format!("otel: failed to create JSONL span exporter: {e}")),
         }
     }
 
@@ -54,7 +55,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_provider_succeeds_with_defaults() {
-        let result = build_tracer_provider(&enabled_config());
+        let result = build_tracer_provider(&enabled_config(), &mut Vec::new());
         assert!(result.is_ok());
     }
 
@@ -65,7 +66,23 @@ mod tests {
             sample_rate: Some(0.0),
             ..Default::default()
         };
-        let result = build_tracer_provider(&config);
+        let result = build_tracer_provider(&config, &mut Vec::new());
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn jsonl_exporter_failure_pushes_warning() {
+        let config = TelemetryConfig {
+            enabled: true,
+            file_export: Some(true),
+            telemetry_dir: Some("/nonexistent/otel-dir".into()),
+            ..Default::default()
+        };
+        let mut warnings = Vec::new();
+        let _ = build_tracer_provider(&config, &mut warnings);
+        assert!(
+            warnings.iter().any(|w| w.contains("JSONL span exporter")),
+            "expected JSONL exporter warning, got: {warnings:?}"
+        );
     }
 }

--- a/crates/loopal-tui/src/lib.rs
+++ b/crates/loopal-tui/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod text_util;
 mod tui_loop;
 pub mod views;
 
+pub use terminal::install_panic_hook;
 pub use tui_loop::{run_tui, run_tui_loop};
 
 /// Re-exports of dispatch functions for integration testing.

--- a/crates/loopal-tui/src/terminal.rs
+++ b/crates/loopal-tui/src/terminal.rs
@@ -35,3 +35,46 @@ impl Drop for TerminalGuard {
         );
     }
 }
+
+/// Restore terminal before panic output so backtraces are readable.
+///
+/// Must be called BEFORE `TerminalGuard::new()`.
+pub fn install_panic_hook() {
+    let original = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(
+            io::stdout(),
+            DisableBracketedPaste,
+            DisableMouseCapture,
+            LeaveAlternateScreen,
+        );
+        original(info);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn install_panic_hook_replaces_default() {
+        static CUSTOM_CALLED: AtomicBool = AtomicBool::new(false);
+
+        // Install a marker hook, then our hook on top
+        std::panic::set_hook(Box::new(|_| {
+            CUSTOM_CALLED.store(true, Ordering::SeqCst);
+        }));
+        super::install_panic_hook();
+
+        // Trigger panic in catch_unwind — our hook should chain to the marker
+        let _ = std::panic::catch_unwind(|| panic!("test"));
+        assert!(
+            CUSTOM_CALLED.load(Ordering::SeqCst),
+            "install_panic_hook must chain to the previous hook"
+        );
+
+        // Restore default to avoid poisoning other tests
+        let _ = std::panic::take_hook();
+    }
+}

--- a/crates/loopal-tui/src/tui_loop.rs
+++ b/crates/loopal-tui/src/tui_loop.rs
@@ -25,6 +25,7 @@ pub async fn run_tui(
     agent_event_rx: mpsc::Receiver<AgentEvent>,
     bg_store: Arc<BackgroundTaskStore>,
 ) -> anyhow::Result<()> {
+    crate::terminal::install_panic_hook();
     let _guard = TerminalGuard::new()?;
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;

--- a/src/log_writer.rs
+++ b/src/log_writer.rs
@@ -40,11 +40,7 @@ impl RotatingFileWriter {
             .create(true)
             .append(true)
             .open(&path)
-            .unwrap_or_else(|e| {
-                eprintln!("warning: cannot open log file {}: {e}", path.display());
-                // Open /dev/null so the writer always has a valid File handle.
-                File::open("/dev/null").expect("/dev/null must be openable")
-            });
+            .unwrap_or_else(|_| File::open("/dev/null").expect("/dev/null must be openable"));
 
         Self {
             state: WriterState {

--- a/tests/system_ipc_test.rs
+++ b/tests/system_ipc_test.rs
@@ -45,7 +45,7 @@ async fn system_spawn_and_initialize() {
         .arg(fixture.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::piped())
         .kill_on_drop(true)
         .spawn()
         .expect("failed to spawn agent worker");
@@ -148,7 +148,7 @@ async fn system_process_isolation_survives_kill() {
         .arg(fixture.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::piped())
         .kill_on_drop(true)
         .spawn()
         .expect("failed to spawn agent worker");


### PR DESCRIPTION
## Summary
- Agent child processes inherited TUI's stderr, causing OTel `eprintln!` to corrupt the raw-mode terminal during multi-agent runs
- Establishes architectural contract: all child process stderr must be piped + drained, never inherited
- Three layered fixes: stderr pipe isolation, context-aware error reporting, terminal panic hook

## Changes
**Stderr isolation** (`loopal-agent-client`):
- `process.rs`: `Stdio::inherit()` → `Stdio::piped()` + async drain to tracing
- New `stderr_drain.rs` module with generic `drain_to_tracing()` function
- `system_ipc_test.rs`: aligned to piped stderr

**Telemetry error reporting** (`loopal-telemetry`):
- `subscriber.rs`: deferred warning collection — accumulate during init, log via `tracing::warn!` after `.init()`
- `traces.rs` / `metrics.rs`: accept `warnings: &mut Vec<String>` instead of `eprintln!`
- `shutdown.rs`: `eprintln!` → `tracing::warn!` (safe: `WorkerGuard` alive during Drop body)
- `log_writer.rs`: silent `/dev/null` fallback (pre-tracing phase)

**Terminal state protection** (`loopal-tui`):
- `terminal.rs`: `install_panic_hook()` restores terminal before panic output
- `tui_loop.rs`: called before `TerminalGuard::new()`

**Regression tests**:
- `stderr_drain_test.rs`: drain consumes all input without blocking
- `traces.rs` / `metrics.rs`: JSONL exporter failure populates warnings vec (not eprintln)
- `terminal.rs`: panic hook chains to original hook

## Test plan
- [x] `bazel build //... --config=clippy` — zero warnings
- [x] `bazel build //... --config=rustfmt` — passes
- [x] `bazel test //:system_ipc_test` — agent IPC with piped stderr
- [x] `bazel test //crates/loopal-agent-client:loopal-agent-client_test` — drain + client tests
- [x] `bazel test //crates/loopal-telemetry:loopal-telemetry_test` — provider build + warning collection
- [x] `bazel test //crates/loopal-tui:loopal-tui_test` — TUI + panic hook tests