### PR TITLE
feat(agent): depth-limited spawning, hub budget, and fork context

### DIFF
--- a/crates/loopal-agent-client/src/client.rs
+++ b/crates/loopal-agent-client/src/client.rs
@@ -1,8 +1,8 @@
 //! IPC client — wraps `Connection` with agent protocol methods.
 
+use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Arc;
-use serde_json::Value;
 use tokio::sync::mpsc;
 use tracing::info;
 
@@ -144,7 +144,8 @@ impl AgentClient {
                         return Some(AgentClientEvent::QuestionRequest { id, params });
                     }
                     // Unknown request — respond with error
-                    let _ = self.connection
+                    let _ = self
+                        .connection
                         .respond_error(
                             id,
                             loopal_ipc::jsonrpc::METHOD_NOT_FOUND,

--- a/crates/loopal-agent-client/src/client.rs
+++ b/crates/loopal-agent-client/src/client.rs
@@ -2,7 +2,6 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-
 use serde_json::Value;
 use tokio::sync::mpsc;
 use tracing::info;
@@ -26,6 +25,8 @@ pub struct StartAgentParams {
     pub agent_type: Option<String>,
     /// Nesting depth (0 = root). Propagated from parent.
     pub depth: Option<u32>,
+    /// Compressed parent conversation for fork context inheritance.
+    pub fork_context: Option<serde_json::Value>,
 }
 
 /// High-level agent IPC client.
@@ -35,7 +36,6 @@ pub struct AgentClient {
 }
 
 impl AgentClient {
-    /// Create a client from a transport (e.g. from `AgentProcess::transport()`).
     pub fn new(transport: Arc<dyn Transport>) -> Self {
         let connection = Arc::new(Connection::new(transport));
         let incoming_rx = connection.start();
@@ -61,7 +61,7 @@ impl AgentClient {
 
     /// Send `agent/start` to begin the agent loop.
     pub async fn start_agent(&self, p: &StartAgentParams) -> anyhow::Result<String> {
-        let params = serde_json::json!({
+        let mut params = serde_json::json!({
             "cwd": p.cwd.to_string_lossy(),
             "model": p.model,
             "mode": p.mode,
@@ -73,6 +73,9 @@ impl AgentClient {
             "agent_type": p.agent_type,
             "depth": p.depth,
         });
+        if let Some(ref fc) = p.fork_context {
+            params["fork_context"] = fc.clone();
+        }
         let result = self
             .connection
             .send_request(methods::AGENT_START.name, params)
@@ -120,8 +123,7 @@ impl AgentClient {
         Ok(())
     }
 
-    /// Receive the next incoming message from the agent.
-    /// Returns `None` when the connection closes.
+    /// Receive the next incoming message. Returns `None` when the connection closes.
     pub async fn recv(&mut self) -> Option<AgentClientEvent> {
         loop {
             let incoming = self.incoming_rx.recv().await?;
@@ -142,8 +144,7 @@ impl AgentClient {
                         return Some(AgentClientEvent::QuestionRequest { id, params });
                     }
                     // Unknown request — respond with error
-                    let _ = self
-                        .connection
+                    let _ = self.connection
                         .respond_error(
                             id,
                             loopal_ipc::jsonrpc::METHOD_NOT_FOUND,

--- a/crates/loopal-agent-hub/src/agent_registry/mod.rs
+++ b/crates/loopal-agent-hub/src/agent_registry/mod.rs
@@ -125,6 +125,14 @@ impl AgentRegistry {
         self.agents.len()
     }
 
+    /// Count only sub-agents (those with a parent). Excludes root "main".
+    pub fn sub_agent_count(&self) -> usize {
+        self.agents
+            .values()
+            .filter(|a| a.info.parent.is_some())
+            .count()
+    }
+
     pub fn get_agent_connection(&self, name: &str) -> Option<Arc<Connection>> {
         self.agents.get(name).and_then(|a| a.state.connection())
     }

--- a/crates/loopal-agent-hub/src/dispatch/dispatch_handlers.rs
+++ b/crates/loopal-agent-hub/src/dispatch/dispatch_handlers.rs
@@ -162,6 +162,7 @@ pub async fn handle_spawn_agent(
     let permission_mode = params["permission_mode"].as_str().map(String::from);
     let agent_type = params["agent_type"].as_str().map(String::from);
     let depth = params["depth"].as_u64().map(|v| v as u32);
+    let fork_context = params.get("fork_context").cloned();
 
     // Parent: use explicit "parent" field from params if present (cross-hub),
     // otherwise use from_agent (local spawn).
@@ -184,6 +185,7 @@ pub async fn handle_spawn_agent(
             permission_mode,
             agent_type,
             depth,
+            fork_context,
         )
         .await
     });
@@ -195,18 +197,4 @@ pub async fn handle_spawn_agent(
 
     info!(agent = %name, %agent_id, "handle_spawn_agent done");
     Ok(json!({"agent_id": agent_id, "name": name}))
-}
-
-pub async fn handle_status(hub: &Arc<Mutex<Hub>>) -> Result<Value, String> {
-    let h = hub.lock().await;
-    let uplink_info = h.uplink.as_ref().map(|u| {
-        json!({
-            "connected": true,
-            "hub_name": u.hub_name(),
-        })
-    });
-    Ok(json!({
-        "agent_count": h.registry.agent_count(),
-        "uplink": uplink_info,
-    }))
 }

--- a/crates/loopal-agent-hub/src/dispatch/mod.rs
+++ b/crates/loopal-agent-hub/src/dispatch/mod.rs
@@ -9,6 +9,7 @@ use tokio::sync::Mutex;
 use crate::hub::Hub;
 
 mod dispatch_handlers;
+mod status_handler;
 mod topology_handlers;
 mod wait_handler;
 
@@ -22,6 +23,7 @@ pub async fn dispatch_hub_request(
     use dispatch_handlers::*;
     use topology_handlers::*;
     use wait_handler::handle_wait_agent;
+    use status_handler::handle_status;
 
     match method {
         m if m == methods::HUB_ROUTE.name => handle_route(hub, params).await,

--- a/crates/loopal-agent-hub/src/dispatch/mod.rs
+++ b/crates/loopal-agent-hub/src/dispatch/mod.rs
@@ -21,9 +21,9 @@ pub async fn dispatch_hub_request(
     from_agent: String,
 ) -> Result<Value, String> {
     use dispatch_handlers::*;
+    use status_handler::handle_status;
     use topology_handlers::*;
     use wait_handler::handle_wait_agent;
-    use status_handler::handle_status;
 
     match method {
         m if m == methods::HUB_ROUTE.name => handle_route(hub, params).await,

--- a/crates/loopal-agent-hub/src/dispatch/status_handler.rs
+++ b/crates/loopal-agent-hub/src/dispatch/status_handler.rs
@@ -1,0 +1,22 @@
+//! Hub status query handler.
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+
+use crate::hub::Hub;
+
+pub async fn handle_status(hub: &Arc<Mutex<Hub>>) -> Result<Value, String> {
+    let h = hub.lock().await;
+    let uplink_info = h.uplink.as_ref().map(|u| {
+        json!({
+            "connected": true,
+            "hub_name": u.hub_name(),
+        })
+    });
+    Ok(json!({
+        "agent_count": h.registry.agent_count(),
+        "uplink": uplink_info,
+    }))
+}

--- a/crates/loopal-agent-hub/src/hub.rs
+++ b/crates/loopal-agent-hub/src/hub.rs
@@ -26,6 +26,8 @@ pub struct Hub {
     pub uplink: Option<Arc<HubUplink>>,
     /// TCP listener port, set after `start_hub_listener`. `None` if not listening.
     pub listener_port: Option<u16>,
+    /// Max total sub-agents allowed (set from HarnessConfig at bootstrap).
+    pub max_total_agents: u32,
 }
 
 impl Hub {
@@ -35,6 +37,7 @@ impl Hub {
             ui: UiDispatcher::new(),
             uplink: None,
             listener_port: None,
+            max_total_agents: 16,
         }
     }
 
@@ -46,6 +49,7 @@ impl Hub {
             ui: UiDispatcher::new(),
             uplink: None,
             listener_port: None,
+            max_total_agents: 16,
         }
     }
 }

--- a/crates/loopal-agent-hub/src/spawn_manager.rs
+++ b/crates/loopal-agent-hub/src/spawn_manager.rs
@@ -1,7 +1,5 @@
 //! Spawn manager — Hub spawns agent processes and registers their stdio.
-
 use std::sync::Arc;
-
 use tokio::sync::{Mutex, mpsc};
 use tracing::{info, warn};
 
@@ -23,7 +21,21 @@ pub async fn spawn_and_register(
     permission_mode: Option<String>,
     agent_type: Option<String>,
     depth: Option<u32>,
+    fork_context: Option<serde_json::Value>,
 ) -> Result<String, String> {
+    // Pre-check budget BEFORE spawning process to avoid orphans.
+    if parent.is_some() {
+        let h = hub.lock().await;
+        let sub_count = h.registry.sub_agent_count();
+        if sub_count >= h.max_total_agents as usize {
+            return Err(format!(
+                "Spawn budget exhausted ({sub_count}/{} sub-agents). \
+                 Complete the task with your own tools.",
+                h.max_total_agents
+            ));
+        }
+    }
+
     info!(agent = %name, parent = ?parent, "spawn: forking process");
     let agent_proc = loopal_agent_client::AgentProcess::spawn(None)
         .await
@@ -48,6 +60,7 @@ pub async fn spawn_and_register(
             lifecycle: Some("ephemeral".to_string()), // sub-agents always exit on idle
             agent_type,
             depth,
+            fork_context,
             ..Default::default()
         })
         .await
@@ -61,7 +74,7 @@ pub async fn spawn_and_register(
     };
 
     let (conn, incoming_rx) = client.into_parts();
-    let agent_id = register_agent_connection(
+    match register_agent_connection(
         hub,
         &name,
         conn,
@@ -70,18 +83,25 @@ pub async fn spawn_and_register(
         model_for_registry.as_deref(),
         session_id.as_deref(),
     )
-    .await;
-
-    tokio::spawn(async move {
-        let _ = agent_proc.wait().await;
-    });
-
-    info!(agent = %name, "agent spawned and registered via Hub");
-    Ok(agent_id)
+    .await
+    {
+        Ok(agent_id) => {
+            tokio::spawn(async move {
+                let _ = agent_proc.wait().await;
+            });
+            info!(agent = %name, "agent spawned and registered via Hub");
+            Ok(agent_id)
+        }
+        Err(e) => {
+            warn!(agent = %name, error = %e, "registration failed, killing orphan");
+            let _ = agent_proc.shutdown().await;
+            Err(e)
+        }
+    }
 }
 
 /// Register a pre-built Connection as a named agent in Hub.
-/// Creates a completion notification channel and bridge for this agent.
+/// Performs spawn budget check atomically with registration.
 pub async fn register_agent_connection(
     hub: Arc<Mutex<Hub>>,
     name: &str,
@@ -90,7 +110,7 @@ pub async fn register_agent_connection(
     parent: Option<&str>,
     model: Option<&str>,
     session_id: Option<&str>,
-) -> String {
+) -> Result<String, String> {
     let agent_id = uuid::Uuid::new_v4().to_string();
 
     // Completion channel: Hub writes here when this agent's children finish.
@@ -99,6 +119,21 @@ pub async fn register_agent_connection(
 
     {
         let mut h = hub.lock().await;
+
+        // Budget check (atomic with registration — no TOCTOU).
+        // Count only sub-agents (those with a parent), excluding root "main".
+        if parent.is_some() {
+            let sub_count = h.registry.sub_agent_count();
+            if sub_count >= h.max_total_agents as usize {
+                warn!(agent = %name, count = sub_count, "spawn budget exhausted");
+                return Err(format!(
+                    "Spawn budget exhausted ({sub_count}/{} sub-agents). \
+                     Complete the task with your own tools.",
+                    h.max_total_agents
+                ));
+            }
+        }
+
         if let Some(p) = parent
             && !h.registry.agents.contains_key(p)
         {
@@ -112,7 +147,7 @@ pub async fn register_agent_connection(
             Some(completion_tx),
         ) {
             warn!(agent = %name, error = %e, "registration failed");
-            return agent_id;
+            return Err(format!("agent registration failed: {e}"));
         }
         h.registry
             .set_lifecycle(name, crate::AgentLifecycle::Running);
@@ -135,7 +170,7 @@ pub async fn register_agent_connection(
             tracing::warn!(agent = %name, "SubAgentSpawned event dropped (channel full)");
         }
     }
-    agent_id
+    Ok(agent_id)
 }
 
 /// Bridge: reads from Hub-internal channel, forwards to agent via IPC notification.

--- a/crates/loopal-agent-hub/tests/suite/advanced_scenarios_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/advanced_scenarios_test.rs
@@ -134,7 +134,9 @@ async fn recursive_agent_nesting_grandchild_routes_to_root() {
     let server_a = Arc::new(Connection::new(t2));
     let _ra = child_a.start();
     let sra = server_a.start();
-    let _ = register_agent_connection(hub.clone(), "child-a", server_a, sra, None, None, None).await.unwrap();
+    let _ = register_agent_connection(hub.clone(), "child-a", server_a, sra, None, None, None)
+        .await
+        .unwrap();
 
     // Grandchild B (registered as sub-agent of child-a, same Hub)
     let (t3, t4) = loopal_ipc::duplex_pair();
@@ -142,7 +144,9 @@ async fn recursive_agent_nesting_grandchild_routes_to_root() {
     let server_b = Arc::new(Connection::new(t4));
     let _rb = grandchild_b.start();
     let srb = server_b.start();
-    let _ = register_agent_connection(hub.clone(), "grandchild-b", server_b, srb, None, None, None).await.unwrap();
+    let _ = register_agent_connection(hub.clone(), "grandchild-b", server_b, srb, None, None, None)
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Grandchild B sends message to root (skipping parent)

--- a/crates/loopal-agent-hub/tests/suite/advanced_scenarios_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/advanced_scenarios_test.rs
@@ -134,7 +134,7 @@ async fn recursive_agent_nesting_grandchild_routes_to_root() {
     let server_a = Arc::new(Connection::new(t2));
     let _ra = child_a.start();
     let sra = server_a.start();
-    register_agent_connection(hub.clone(), "child-a", server_a, sra, None, None, None).await;
+    let _ = register_agent_connection(hub.clone(), "child-a", server_a, sra, None, None, None).await.unwrap();
 
     // Grandchild B (registered as sub-agent of child-a, same Hub)
     let (t3, t4) = loopal_ipc::duplex_pair();
@@ -142,7 +142,7 @@ async fn recursive_agent_nesting_grandchild_routes_to_root() {
     let server_b = Arc::new(Connection::new(t4));
     let _rb = grandchild_b.start();
     let srb = server_b.start();
-    register_agent_connection(hub.clone(), "grandchild-b", server_b, srb, None, None, None).await;
+    let _ = register_agent_connection(hub.clone(), "grandchild-b", server_b, srb, None, None, None).await.unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Grandchild B sends message to root (skipping parent)

--- a/crates/loopal-agent-hub/tests/suite/collaboration_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/collaboration_test.rs
@@ -217,7 +217,9 @@ async fn cascade_shutdown_interrupts_children() {
     let (_pa, pt) = loopal_ipc::duplex_pair();
     let parent = Arc::new(Connection::new(pt));
     let parent_rx = parent.start();
-    let _ = register_agent_connection(hub.clone(), "parent", parent, parent_rx, None, None, None).await.unwrap();
+    let _ = register_agent_connection(hub.clone(), "parent", parent, parent_rx, None, None, None)
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Register child with interrupt capture

--- a/crates/loopal-agent-hub/tests/suite/collaboration_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/collaboration_test.rs
@@ -37,7 +37,7 @@ async fn spawn_and_result_full_chain() {
     let (_ca, ct) = loopal_ipc::duplex_pair();
     let child = Arc::new(Connection::new(ct));
     let child_rx = child.start();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "worker",
         child,
@@ -88,7 +88,7 @@ async fn agent_info_running_and_finished() {
     let (_ca, ct) = loopal_ipc::duplex_pair();
     let child = Arc::new(Connection::new(ct));
     let child_rx = child.start();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "child-a",
         child,
@@ -217,7 +217,7 @@ async fn cascade_shutdown_interrupts_children() {
     let (_pa, pt) = loopal_ipc::duplex_pair();
     let parent = Arc::new(Connection::new(pt));
     let parent_rx = parent.start();
-    register_agent_connection(hub.clone(), "parent", parent, parent_rx, None, None, None).await;
+    let _ = register_agent_connection(hub.clone(), "parent", parent, parent_rx, None, None, None).await.unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Register child with interrupt capture
@@ -226,7 +226,7 @@ async fn cascade_shutdown_interrupts_children() {
     let server_conn = Arc::new(Connection::new(child_server));
     let client_rx = child_conn.start();
     let server_rx = server_conn.start();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "child",
         server_conn,

--- a/crates/loopal-agent-hub/tests/suite/completion_injection_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/completion_injection_test.rs
@@ -29,7 +29,7 @@ async fn register_agent(
     let server_conn = Arc::new(Connection::new(server_transport));
     let client_rx = client_conn.start();
     let server_rx = server_conn.start();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         name,
         server_conn,

--- a/crates/loopal-agent-hub/tests/suite/completion_output_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/completion_output_test.rs
@@ -27,7 +27,7 @@ async fn completion_output_passed_through_wait() {
     let (_ca, ct) = loopal_ipc::duplex_pair();
     let conn = Arc::new(Connection::new(ct));
     let rx = conn.start();
-    register_agent_connection(hub.clone(), "worker", conn, rx, None, None, None).await;
+    let _ = register_agent_connection(hub.clone(), "worker", conn, rx, None, None, None).await.unwrap();
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Set up waiter
@@ -69,7 +69,7 @@ async fn completion_no_output_fallback() {
     let (_ca, ct) = loopal_ipc::duplex_pair();
     let conn = Arc::new(Connection::new(ct));
     let rx = conn.start();
-    register_agent_connection(hub.clone(), "worker2", conn, rx, None, None, None).await;
+    let _ = register_agent_connection(hub.clone(), "worker2", conn, rx, None, None, None).await.unwrap();
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let hub2 = hub.clone();
@@ -105,7 +105,7 @@ async fn topology_tracks_parent_child() {
     let (_pa, pt) = loopal_ipc::duplex_pair();
     let parent_conn = Arc::new(Connection::new(pt));
     let parent_rx = parent_conn.start();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "parent",
         parent_conn,
@@ -121,7 +121,7 @@ async fn topology_tracks_parent_child() {
     let (_ca, ct) = loopal_ipc::duplex_pair();
     let child_conn = Arc::new(Connection::new(ct));
     let child_rx = child_conn.start();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "child-1",
         child_conn,

--- a/crates/loopal-agent-hub/tests/suite/completion_output_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/completion_output_test.rs
@@ -27,7 +27,9 @@ async fn completion_output_passed_through_wait() {
     let (_ca, ct) = loopal_ipc::duplex_pair();
     let conn = Arc::new(Connection::new(ct));
     let rx = conn.start();
-    let _ = register_agent_connection(hub.clone(), "worker", conn, rx, None, None, None).await.unwrap();
+    let _ = register_agent_connection(hub.clone(), "worker", conn, rx, None, None, None)
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Set up waiter
@@ -69,7 +71,9 @@ async fn completion_no_output_fallback() {
     let (_ca, ct) = loopal_ipc::duplex_pair();
     let conn = Arc::new(Connection::new(ct));
     let rx = conn.start();
-    let _ = register_agent_connection(hub.clone(), "worker2", conn, rx, None, None, None).await.unwrap();
+    let _ = register_agent_connection(hub.clone(), "worker2", conn, rx, None, None, None)
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let hub2 = hub.clone();

--- a/crates/loopal-agent-hub/tests/suite/multi_agent_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/multi_agent_test.rs
@@ -163,7 +163,7 @@ async fn wait_already_finished_agent_returns_immediately() {
     let (_t1, t2) = loopal_ipc::duplex_pair();
     let conn = Arc::new(Connection::new(t2));
     let rx = conn.start();
-    register_agent_connection(hub.clone(), "done-agent", conn, rx, None, None, None).await;
+    let _ = register_agent_connection(hub.clone(), "done-agent", conn, rx, None, None, None).await.unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Finish it
@@ -203,7 +203,7 @@ async fn multiple_waiters_on_same_agent() {
     let (_t1, t2) = loopal_ipc::duplex_pair();
     let conn = Arc::new(Connection::new(t2));
     let rx = conn.start();
-    register_agent_connection(hub.clone(), "shared-target", conn, rx, None, None, None).await;
+    let _ = register_agent_connection(hub.clone(), "shared-target", conn, rx, None, None, None).await.unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Two waiters

--- a/crates/loopal-agent-hub/tests/suite/multi_agent_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/multi_agent_test.rs
@@ -163,7 +163,9 @@ async fn wait_already_finished_agent_returns_immediately() {
     let (_t1, t2) = loopal_ipc::duplex_pair();
     let conn = Arc::new(Connection::new(t2));
     let rx = conn.start();
-    let _ = register_agent_connection(hub.clone(), "done-agent", conn, rx, None, None, None).await.unwrap();
+    let _ = register_agent_connection(hub.clone(), "done-agent", conn, rx, None, None, None)
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Finish it
@@ -203,7 +205,9 @@ async fn multiple_waiters_on_same_agent() {
     let (_t1, t2) = loopal_ipc::duplex_pair();
     let conn = Arc::new(Connection::new(t2));
     let rx = conn.start();
-    let _ = register_agent_connection(hub.clone(), "shared-target", conn, rx, None, None, None).await.unwrap();
+    let _ = register_agent_connection(hub.clone(), "shared-target", conn, rx, None, None, None)
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Two waiters

--- a/crates/loopal-agent-hub/tests/suite/parallel_spawn_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/parallel_spawn_test.rs
@@ -31,7 +31,7 @@ async fn register_agent(
     let server_conn = Arc::new(Connection::new(server_transport));
     let _client_rx = client_conn.start();
     let server_rx = server_conn.start();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         name,
         server_conn,

--- a/crates/loopal-agent-hub/tests/suite/race_condition_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/race_condition_test.rs
@@ -26,7 +26,7 @@ async fn wait_agent_after_finish_returns_cached_output() {
     let (_ca, ct) = loopal_ipc::duplex_pair();
     let conn = Arc::new(Connection::new(ct));
     let rx = conn.start();
-    register_agent_connection(hub.clone(), "fast-agent", conn, rx, None, None, None).await;
+    let _ = register_agent_connection(hub.clone(), "fast-agent", conn, rx, None, None, None).await.unwrap();
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Agent finishes BEFORE any wait_agent call
@@ -62,7 +62,7 @@ async fn emit_before_unregister_delivers_output() {
     let (_ca, ct) = loopal_ipc::duplex_pair();
     let conn = Arc::new(Connection::new(ct));
     let rx = conn.start();
-    register_agent_connection(hub.clone(), "normal", conn, rx, None, None, None).await;
+    let _ = register_agent_connection(hub.clone(), "normal", conn, rx, None, None, None).await.unwrap();
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let hub2 = hub.clone();

--- a/crates/loopal-agent-hub/tests/suite/race_condition_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/race_condition_test.rs
@@ -26,7 +26,9 @@ async fn wait_agent_after_finish_returns_cached_output() {
     let (_ca, ct) = loopal_ipc::duplex_pair();
     let conn = Arc::new(Connection::new(ct));
     let rx = conn.start();
-    let _ = register_agent_connection(hub.clone(), "fast-agent", conn, rx, None, None, None).await.unwrap();
+    let _ = register_agent_connection(hub.clone(), "fast-agent", conn, rx, None, None, None)
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Agent finishes BEFORE any wait_agent call
@@ -62,7 +64,9 @@ async fn emit_before_unregister_delivers_output() {
     let (_ca, ct) = loopal_ipc::duplex_pair();
     let conn = Arc::new(Connection::new(ct));
     let rx = conn.start();
-    let _ = register_agent_connection(hub.clone(), "normal", conn, rx, None, None, None).await.unwrap();
+    let _ = register_agent_connection(hub.clone(), "normal", conn, rx, None, None, None)
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let hub2 = hub.clone();

--- a/crates/loopal-agent-hub/tests/suite/spawn_lifecycle_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/spawn_lifecycle_test.rs
@@ -45,7 +45,8 @@ async fn register_agent_connection_makes_agent_routable() {
         None,
         None,
     )
-    .await;
+    .await
+    .unwrap();
     assert!(!agent_id.is_empty());
 
     // Should receive SubAgentSpawned event
@@ -120,7 +121,7 @@ async fn wait_agent_returns_when_agent_disconnects() {
     let _agent_rx = agent_conn.start();
     let server_rx = server_conn.start();
 
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "ephemeral",
         server_conn,
@@ -188,7 +189,7 @@ async fn spawned_agent_routes_message_to_parent() {
 
     let _child_rx = child_conn.start();
     let server_rx = server_conn.start();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "child",
         server_conn,

--- a/crates/loopal-agent-hub/tests/suite/transport_close_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/transport_close_test.rs
@@ -37,7 +37,7 @@ async fn transport_closed_after_agent_completes() {
     let _agent_rx = agent_conn.start();
     let server_rx = server_conn.start();
 
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "worker",
         server_conn,
@@ -82,7 +82,7 @@ async fn agent_receives_eof_after_hub_closes_transport() {
     let _agent_rx = agent_conn.start();
     let server_rx = server_conn.start();
 
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "worker",
         server_conn,
@@ -131,7 +131,7 @@ async fn result_delivered_before_transport_close() {
     let _agent_rx = agent_conn.start();
     let server_rx = server_conn.start();
 
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "worker",
         server_conn,
@@ -184,7 +184,7 @@ async fn child_crash_triggers_transport_close() {
     let _agent_rx = agent_conn.start();
     let server_rx = server_conn.start();
 
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "crasher",
         server_conn,
@@ -232,7 +232,7 @@ async fn agent_unregistered_after_completion() {
     let _agent_rx = agent_conn.start();
     let server_rx = server_conn.start();
 
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "ephemeral",
         server_conn,

--- a/crates/loopal-agent-hub/tests/suite/wait_nonblocking_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/wait_nonblocking_test.rs
@@ -30,7 +30,7 @@ async fn wait_agent_does_not_block_io_loop() {
 
     // Register two mock child agents
     let (_child_a_conn, child_a_server, child_a_rx) = mock_agent();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "child-a",
         child_a_server,
@@ -42,7 +42,7 @@ async fn wait_agent_does_not_block_io_loop() {
     .await;
 
     let (_child_b_conn, child_b_server, child_b_rx) = mock_agent();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "child-b",
         child_b_server,
@@ -117,7 +117,7 @@ async fn spawn_after_wait_not_blocked() {
 
     // Register a mock child that we'll wait on
     let (_child_conn, child_server, child_rx) = mock_agent();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "existing-child",
         child_server,

--- a/crates/loopal-agent-server/src/agent_setup.rs
+++ b/crates/loopal-agent-server/src/agent_setup.rs
@@ -1,7 +1,5 @@
 //! Internal agent loop setup — builds `AgentLoopParams` from resolved config.
-
 use std::sync::Arc;
-
 use loopal_agent::shared::{AgentShared, SchedulerHandle};
 use loopal_agent::task_store::TaskStore;
 use loopal_config::ResolvedConfig;
@@ -11,18 +9,12 @@ use loopal_kernel::Kernel;
 use loopal_protocol::InterruptSignal;
 use loopal_runtime::AgentLoopParams;
 use loopal_runtime::frontend::traits::AgentFrontend;
-
 use crate::params::StartParams;
 
-/// Build `AgentLoopParams` with a pre-constructed frontend (HubFrontend or IpcFrontend).
-///
-/// The caller provides the frontend and interrupt signal, decoupling agent setup
-/// from the connection/transport layer.
+/// Build `AgentLoopParams` with a pre-constructed frontend.
 #[allow(clippy::too_many_arguments)]
 pub fn build_with_frontend(
-    cwd: &std::path::Path,
-    config: &ResolvedConfig,
-    start: &StartParams,
+    cwd: &std::path::Path, config: &ResolvedConfig, start: &StartParams,
     frontend: Arc<dyn AgentFrontend>,
     interrupt: InterruptSignal,
     interrupt_tx: Arc<tokio::sync::watch::Sender<u64>>,
@@ -56,8 +48,7 @@ pub fn build_with_frontend(
         (session_manager.create_session(cwd, &model)?, Vec::new())
     };
 
-    // Channel for sub-agent lifecycle events (SubAgentSpawned).
-    // Only lifecycle events are forwarded — sub-agent internal events go via TCP.
+    // Sub-agent lifecycle events: forward SubAgentSpawned to frontend.
     let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<loopal_protocol::AgentEvent>(256);
     let lifecycle_frontend = frontend.clone();
     tokio::spawn(async move {
@@ -75,7 +66,7 @@ pub fn build_with_frontend(
         .unwrap_or_else(|_| std::env::temp_dir().join("loopal/tasks"));
 
     let (scheduler_handle, scheduled_rx) = SchedulerHandle::create();
-
+    let message_snapshot = Arc::new(std::sync::RwLock::new(Vec::new()));
     let agent_shared = Arc::new(AgentShared {
         kernel: kernel.clone(),
         task_store: Arc::new(TaskStore::new(tasks_dir)),
@@ -86,6 +77,7 @@ pub fn build_with_frontend(
         parent_event_tx: Some(event_tx),
         cancel_token: None,
         scheduler_handle,
+        message_snapshot: message_snapshot.clone(),
     });
 
     let memory_channel = crate::memory_adapter::build_memory_channel(
@@ -107,9 +99,7 @@ pub fn build_with_frontend(
     } else {
         None
     };
-
     let shared_any: Arc<dyn std::any::Any + Send + Sync> = Arc::new(agent_shared);
-
     let skills: Vec<_> = config.skills.values().map(|e| e.skill.clone()).collect();
     let skills_summary = loopal_config::format_skills_summary(&skills);
     let tool_defs = kernel.tool_definitions();
@@ -137,12 +127,28 @@ pub fn build_with_frontend(
         features,
         start.depth.unwrap_or(0),
     );
-
     crate::prompt_post::append_runtime_sections(&mut system_prompt, &kernel);
 
     let mut messages = resume_messages;
+    let mut has_fork = false;
+    if let Some(ref fc_value) = start.fork_context
+        && start.resume.is_none()
+    {
+        match serde_json::from_value::<Vec<loopal_message::Message>>(fc_value.clone()) {
+            Ok(fork_msgs) => {
+                messages.extend(fork_msgs);
+                has_fork = true;
+            }
+            Err(e) => tracing::warn!("fork context deserialization failed, skipping: {e}"),
+        }
+    }
     if let Some(prompt) = &start.prompt {
-        messages.push(loopal_message::Message::user(prompt));
+        let text = if has_fork {
+            format!("{}\n\n{prompt}", loopal_context::fork::FORK_BOILERPLATE)
+        } else {
+            prompt.to_string()
+        };
+        messages.push(loopal_message::Message::user(&text));
     }
 
     let tool_tokens = ContextBudget::estimate_tool_tokens(&tool_defs);
@@ -152,8 +158,11 @@ pub fn build_with_frontend(
         &system_prompt,
         tool_tokens,
     );
-
     let lifecycle = start.lifecycle;
+    let depth = start.depth.unwrap_or(0);
+    let tool_filter = crate::spawn_policy::build_depth_tool_filter(
+        &kernel, depth, config.settings.harness.agent_max_depth,
+    );
 
     let params = AgentLoopParams {
         config: loopal_runtime::AgentConfig {
@@ -162,7 +171,7 @@ pub fn build_with_frontend(
             system_prompt,
             mode,
             permission_mode,
-            tool_filter: None,
+            tool_filter,
             thinking_config,
             context_tokens_cap: config.settings.max_context_tokens,
             plan_state: None,
@@ -183,7 +192,8 @@ pub fn build_with_frontend(
         scheduled_rx: Some(scheduled_rx),
         auto_classifier,
         harness: config.settings.harness.clone(),
-        rewake_rx: None, // TODO: wire from AsyncHookStore when async hooks are configured
+        rewake_rx: None,
+        message_snapshot: Some(message_snapshot),
     };
     Ok(params)
 }

--- a/crates/loopal-agent-server/src/agent_setup.rs
+++ b/crates/loopal-agent-server/src/agent_setup.rs
@@ -1,5 +1,5 @@
 //! Internal agent loop setup — builds `AgentLoopParams` from resolved config.
-use std::sync::Arc;
+use crate::params::StartParams;
 use loopal_agent::shared::{AgentShared, SchedulerHandle};
 use loopal_agent::task_store::TaskStore;
 use loopal_config::ResolvedConfig;
@@ -9,12 +9,14 @@ use loopal_kernel::Kernel;
 use loopal_protocol::InterruptSignal;
 use loopal_runtime::AgentLoopParams;
 use loopal_runtime::frontend::traits::AgentFrontend;
-use crate::params::StartParams;
+use std::sync::Arc;
 
 /// Build `AgentLoopParams` with a pre-constructed frontend.
 #[allow(clippy::too_many_arguments)]
 pub fn build_with_frontend(
-    cwd: &std::path::Path, config: &ResolvedConfig, start: &StartParams,
+    cwd: &std::path::Path,
+    config: &ResolvedConfig,
+    start: &StartParams,
     frontend: Arc<dyn AgentFrontend>,
     interrupt: InterruptSignal,
     interrupt_tx: Arc<tokio::sync::watch::Sender<u64>>,
@@ -61,10 +63,8 @@ pub fn build_with_frontend(
             }
         }
     });
-
     let tasks_dir = loopal_config::session_tasks_dir(&session.id)
         .unwrap_or_else(|_| std::env::temp_dir().join("loopal/tasks"));
-
     let (scheduler_handle, scheduled_rx) = SchedulerHandle::create();
     let message_snapshot = Arc::new(std::sync::RwLock::new(Vec::new()));
     let agent_shared = Arc::new(AgentShared {
@@ -161,7 +161,9 @@ pub fn build_with_frontend(
     let lifecycle = start.lifecycle;
     let depth = start.depth.unwrap_or(0);
     let tool_filter = crate::spawn_policy::build_depth_tool_filter(
-        &kernel, depth, config.settings.harness.agent_max_depth,
+        &kernel,
+        depth,
+        config.settings.harness.agent_max_depth,
     );
 
     let params = AgentLoopParams {

--- a/crates/loopal-agent-server/src/lib.rs
+++ b/crates/loopal-agent-server/src/lib.rs
@@ -16,6 +16,7 @@ pub mod interrupt_filter;
 mod ipc_emitter;
 mod ipc_frontend;
 mod memory_adapter;
+mod memory_consolidation;
 mod mock_loader;
 mod params;
 mod prompt_post;
@@ -23,6 +24,7 @@ mod server;
 pub mod server_info;
 mod server_init;
 mod session_forward;
+mod spawn_policy;
 #[doc(hidden)]
 pub mod session_hub;
 mod session_start;

--- a/crates/loopal-agent-server/src/lib.rs
+++ b/crates/loopal-agent-server/src/lib.rs
@@ -24,10 +24,10 @@ mod server;
 pub mod server_info;
 mod server_init;
 mod session_forward;
-mod spawn_policy;
 #[doc(hidden)]
 pub mod session_hub;
 mod session_start;
+mod spawn_policy;
 mod test_server;
 
 pub use server::{run_agent_server, run_agent_server_with_mock};

--- a/crates/loopal-agent-server/src/memory_adapter.rs
+++ b/crates/loopal-agent-server/src/memory_adapter.rs
@@ -12,7 +12,7 @@ use tracing::{info, warn};
 
 use loopal_agent::shared::AgentShared;
 use loopal_agent::spawn::{SpawnParams, spawn_agent, wait_agent};
-use loopal_memory::{MEMORY_AGENT_PROMPT, MEMORY_CONSOLIDATION_PROMPT, MemoryProcessor};
+use loopal_memory::{MEMORY_AGENT_PROMPT, MemoryProcessor};
 use loopal_tool_api::MemoryChannel;
 
 // ---------------------------------------------------------------------------
@@ -46,7 +46,7 @@ impl ServerMemoryProcessor {
         Self { shared, model }
     }
 
-    fn make_agent_name(prefix: &str) -> String {
+    pub(crate) fn make_agent_name(prefix: &str) -> String {
         let ts = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -64,6 +64,7 @@ impl ServerMemoryProcessor {
             target_hub: None,
             agent_type: None,
             depth: self.shared.depth + 1,
+            fork_context: None,
         };
         spawn_agent(&self.shared, params).await?;
         match wait_agent(&self.shared, name).await {
@@ -115,64 +116,6 @@ impl MemoryProcessor for ServerMemoryProcessor {
 }
 
 // ---------------------------------------------------------------------------
-// Consolidation trigger
-// ---------------------------------------------------------------------------
-
-/// Trigger a full memory consolidation via a dedicated sub-agent.
-///
-/// Runs in the background (non-blocking). Uses a `.consolidation_lock` file
-/// as an optimistic lock to prevent concurrent sessions from triggering
-/// duplicate consolidations. The `.last_consolidation` marker is written
-/// only after the agent completes successfully.
-pub fn trigger_consolidation(shared: &Arc<AgentShared>, model: &str) {
-    let memory_dir = shared.cwd.join(".loopal/memory");
-
-    // Acquire lock — handles stale lock detection (> 1 hour) automatically.
-    let lock_path = match loopal_memory::consolidation::try_acquire_lock(&memory_dir) {
-        Some(path) => path,
-        None => {
-            info!("consolidation already in progress, skipping");
-            return;
-        }
-    };
-
-    let shared = shared.clone();
-    let model = model.to_string();
-    tokio::spawn(async move {
-        let memory_dir = shared.cwd.join(".loopal/memory");
-        let today = loopal_memory::date::today_str();
-        let name = ServerMemoryProcessor::make_agent_name("memory-consolidation");
-        let prompt = format!("{MEMORY_CONSOLIDATION_PROMPT}\n\nToday: {today}");
-        let params = SpawnParams {
-            name: name.clone(),
-            prompt,
-            model: Some(model),
-            cwd_override: None,
-            permission_mode: None,
-            target_hub: None,
-            agent_type: None,
-            depth: shared.depth + 1,
-        };
-        match spawn_agent(&shared, params).await {
-            Ok(_) => {
-                info!("memory consolidation agent spawned");
-                match wait_agent(&shared, &name).await {
-                    Ok(output) => {
-                        info!(output = %output, "memory consolidation done");
-                        // Mark done ONLY on success — if agent fails, next session retries.
-                        loopal_memory::consolidation::mark_done(&memory_dir);
-                    }
-                    Err(e) => warn!(error = %e, "memory consolidation failed"),
-                }
-            }
-            Err(e) => warn!(error = %e, "failed to spawn consolidation agent"),
-        }
-        // Always release the lock
-        loopal_memory::consolidation::release_lock(&lock_path);
-    });
-}
-
-// ---------------------------------------------------------------------------
 // Pipeline builder (entry point)
 // ---------------------------------------------------------------------------
 
@@ -197,7 +140,7 @@ pub fn build_memory_channel(
         )
     {
         info!("memory consolidation due — triggering in background");
-        trigger_consolidation(shared, model);
+        crate::memory_consolidation::trigger_consolidation(shared, model);
     }
 
     // Channel capacity from config (default: 256)

--- a/crates/loopal-agent-server/src/memory_consolidation.rs
+++ b/crates/loopal-agent-server/src/memory_consolidation.rs
@@ -1,0 +1,61 @@
+//! Memory consolidation trigger — spawns a sub-agent for periodic consolidation.
+
+use std::sync::Arc;
+
+use tracing::{info, warn};
+
+use loopal_agent::shared::AgentShared;
+use loopal_agent::spawn::{SpawnParams, spawn_agent, wait_agent};
+use loopal_memory::MEMORY_CONSOLIDATION_PROMPT;
+
+use super::memory_adapter::ServerMemoryProcessor;
+
+/// Trigger a full memory consolidation via a dedicated sub-agent.
+///
+/// Runs in the background (non-blocking). Uses a `.consolidation_lock` file
+/// as an optimistic lock to prevent concurrent consolidations.
+pub fn trigger_consolidation(shared: &Arc<AgentShared>, model: &str) {
+    let memory_dir = shared.cwd.join(".loopal/memory");
+
+    let lock_path = match loopal_memory::consolidation::try_acquire_lock(&memory_dir) {
+        Some(path) => path,
+        None => {
+            info!("consolidation already in progress, skipping");
+            return;
+        }
+    };
+
+    let shared = shared.clone();
+    let model = model.to_string();
+    tokio::spawn(async move {
+        let memory_dir = shared.cwd.join(".loopal/memory");
+        let today = loopal_memory::date::today_str();
+        let name = ServerMemoryProcessor::make_agent_name("memory-consolidation");
+        let prompt = format!("{MEMORY_CONSOLIDATION_PROMPT}\n\nToday: {today}");
+        let params = SpawnParams {
+            name: name.clone(),
+            prompt,
+            model: Some(model),
+            cwd_override: None,
+            permission_mode: None,
+            target_hub: None,
+            agent_type: None,
+            depth: shared.depth + 1,
+            fork_context: None,
+        };
+        match spawn_agent(&shared, params).await {
+            Ok(_) => {
+                info!("memory consolidation agent spawned");
+                match wait_agent(&shared, &name).await {
+                    Ok(output) => {
+                        info!(output = %output, "memory consolidation done");
+                        loopal_memory::consolidation::mark_done(&memory_dir);
+                    }
+                    Err(e) => warn!(error = %e, "memory consolidation failed"),
+                }
+            }
+            Err(e) => warn!(error = %e, "failed to spawn consolidation agent"),
+        }
+        loopal_memory::consolidation::release_lock(&lock_path);
+    });
+}

--- a/crates/loopal-agent-server/src/params.rs
+++ b/crates/loopal-agent-server/src/params.rs
@@ -20,6 +20,8 @@ pub struct StartParams {
     pub agent_type: Option<String>,
     /// Nesting depth (0 = root). Propagated from parent via IPC.
     pub depth: Option<u32>,
+    /// Fork context: compressed parent messages (JSON Value, deserialized in agent_setup).
+    pub fork_context: Option<serde_json::Value>,
 }
 
 /// Build a Kernel from config (production path: MCP, tools).

--- a/crates/loopal-agent-server/src/session_start.rs
+++ b/crates/loopal-agent-server/src/session_start.rs
@@ -67,6 +67,7 @@ pub(crate) async fn start_session(
             lifecycle,
             agent_type: params["agent_type"].as_str().map(String::from),
             depth: params["depth"].as_u64().map(|v| v as u32),
+            fork_context: params.get("fork_context").cloned(),
         };
 
         let mut config = load_config(&cwd)?;

--- a/crates/loopal-agent-server/src/spawn_policy.rs
+++ b/crates/loopal-agent-server/src/spawn_policy.rs
@@ -1,0 +1,29 @@
+use std::collections::HashSet;
+
+use loopal_kernel::Kernel;
+
+const SPAWN_TOOLS: &[&str] = &["Agent", "SendMessage", "ListHubs"];
+
+/// Build a tool whitelist that excludes spawn-related tools.
+///
+/// Returns `None` when the agent is still within the allowed depth
+/// (spawn tools remain available). Returns `Some(filter)` when
+/// `depth >= max_depth`, physically preventing further sub-agent creation.
+pub fn build_depth_tool_filter(
+    kernel: &Kernel,
+    depth: u32,
+    max_depth: u32,
+) -> Option<HashSet<String>> {
+    if depth < max_depth {
+        return None;
+    }
+    let mut allowed: HashSet<String> = kernel
+        .tool_definitions()
+        .into_iter()
+        .map(|t| t.name)
+        .collect();
+    for name in SPAWN_TOOLS {
+        allowed.remove(*name);
+    }
+    Some(allowed)
+}

--- a/crates/loopal-agent-server/tests/suite/hub_harness.rs
+++ b/crates/loopal-agent-server/tests/suite/hub_harness.rs
@@ -132,6 +132,7 @@ pub async fn build_hub_harness_with(
         lifecycle: loopal_runtime::LifecycleMode::Persistent,
         agent_type: None,
         depth: None,
+        fork_context: None,
     };
     let (hub_conn, _hub_peer) = loopal_ipc::duplex_pair();
     let hub_connection = std::sync::Arc::new(loopal_ipc::Connection::new(hub_conn));

--- a/crates/loopal-agent/src/shared.rs
+++ b/crates/loopal-agent/src/shared.rs
@@ -1,10 +1,11 @@
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use tokio_util::sync::CancellationToken;
 
 use loopal_ipc::connection::Connection;
 use loopal_kernel::Kernel;
+use loopal_message::Message;
 use loopal_protocol::{AgentEvent, Envelope, MessageSource};
 use loopal_scheduler::CronScheduler;
 
@@ -86,4 +87,7 @@ pub struct AgentShared {
     pub cancel_token: Option<CancellationToken>,
     /// Per-agent cron scheduler (tick loop cancelled on drop).
     pub scheduler_handle: SchedulerHandle,
+    /// Conversation snapshot updated by the runtime before each tool batch.
+    /// The Agent tool reads this to build fork context for child agents.
+    pub message_snapshot: Arc<RwLock<Vec<Message>>>,
 }

--- a/crates/loopal-agent/src/spawn.rs
+++ b/crates/loopal-agent/src/spawn.rs
@@ -23,6 +23,8 @@ pub struct SpawnParams {
     pub agent_type: Option<String>,
     /// Nesting depth of the child agent (parent depth + 1).
     pub depth: u32,
+    /// Compressed parent conversation to inject as initial context.
+    pub fork_context: Option<Vec<loopal_message::Message>>,
 }
 
 /// Result returned from Hub after spawning.
@@ -54,6 +56,11 @@ pub async fn spawn_agent(
     });
     if let Some(ref hub) = params.target_hub {
         request["target_hub"] = json!(hub);
+    }
+    if let Some(ref fc) = params.fork_context
+        && let Ok(val) = serde_json::to_value(fc)
+    {
+        request["fork_context"] = val;
     }
 
     tracing::info!(agent = %params.name, "sending hub/spawn_agent request");

--- a/crates/loopal-agent/src/tools/collaboration/agent.rs
+++ b/crates/loopal-agent/src/tools/collaboration/agent.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-
 use async_trait::async_trait;
 use loopal_error::LoopalError;
 use loopal_ipc::protocol::methods;
@@ -12,6 +11,8 @@ use crate::config::load_agent_configs;
 use crate::shared::AgentShared;
 use crate::spawn::{SpawnParams, spawn_agent, wait_agent};
 
+use super::agent_fork::{build_fork_context, spawn_bg_cleanup};
+
 pub struct AgentTool;
 
 #[async_trait]
@@ -20,8 +21,7 @@ impl Tool for AgentTool {
         "Agent"
     }
     fn description(&self) -> &str {
-        "Spawn a sub-agent to handle a task. Blocks until the agent completes \
-         and returns its result. Multiple Agent calls in one turn run in parallel."
+        "Spawn a sub-agent. Blocks until complete. Multiple calls run in parallel."
     }
     fn parameters_schema(&self) -> serde_json::Value {
         json!({
@@ -128,6 +128,7 @@ async fn action_spawn(
             target_hub,
             agent_type: subagent_type.map(String::from),
             depth: shared.depth + 1,
+            fork_context: build_fork_context(&shared),
         },
     )
     .await;
@@ -195,23 +196,5 @@ async fn action_status(
             serde_json::to_string_pretty(&info).unwrap_or_default(),
         )),
         Err(e) => Ok(ToolResult::error(format!("Agent '{name}': {e}"))),
-    }
-}
-
-fn spawn_bg_cleanup(
-    shared: Arc<AgentShared>,
-    name: String,
-    wt: Option<(loopal_git::WorktreeInfo, std::path::PathBuf)>,
-) {
-    if let Some((info, root)) = wt {
-        tokio::spawn(async move {
-            let timeout = std::time::Duration::from_secs(3600);
-            match tokio::time::timeout(timeout, wait_agent(&shared, &name)).await {
-                Ok(_) => {
-                    loopal_git::cleanup_if_clean(&root, &info);
-                }
-                Err(_) => tracing::warn!(agent = %name, "background agent timed out"),
-            }
-        });
     }
 }

--- a/crates/loopal-agent/src/tools/collaboration/agent.rs
+++ b/crates/loopal-agent/src/tools/collaboration/agent.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
 use async_trait::async_trait;
 use loopal_error::LoopalError;
 use loopal_ipc::protocol::methods;
 use loopal_tool_api::PermissionLevel;
 use loopal_tool_api::{Tool, ToolContext, ToolResult};
 use serde_json::json;
+use std::sync::Arc;
 
 use super::shared_extract::{create_agent_worktree, extract_shared, require_str};
 use crate::config::load_agent_configs;

--- a/crates/loopal-agent/src/tools/collaboration/agent_fork.rs
+++ b/crates/loopal-agent/src/tools/collaboration/agent_fork.rs
@@ -5,9 +5,7 @@ use std::sync::Arc;
 use crate::shared::AgentShared;
 use crate::spawn::wait_agent;
 
-pub(super) fn build_fork_context(
-    shared: &AgentShared,
-) -> Option<Vec<loopal_message::Message>> {
+pub(super) fn build_fork_context(shared: &AgentShared) -> Option<Vec<loopal_message::Message>> {
     let snapshot = shared
         .message_snapshot
         .read()

--- a/crates/loopal-agent/src/tools/collaboration/agent_fork.rs
+++ b/crates/loopal-agent/src/tools/collaboration/agent_fork.rs
@@ -1,0 +1,38 @@
+//! Fork context + background cleanup helpers for the Agent tool.
+
+use std::sync::Arc;
+
+use crate::shared::AgentShared;
+use crate::spawn::wait_agent;
+
+pub(super) fn build_fork_context(
+    shared: &AgentShared,
+) -> Option<Vec<loopal_message::Message>> {
+    let snapshot = shared
+        .message_snapshot
+        .read()
+        .unwrap_or_else(|e| e.into_inner());
+    if snapshot.is_empty() {
+        None
+    } else {
+        Some(loopal_context::fork::compress_for_fork(&snapshot))
+    }
+}
+
+pub(super) fn spawn_bg_cleanup(
+    shared: Arc<AgentShared>,
+    name: String,
+    wt: Option<(loopal_git::WorktreeInfo, std::path::PathBuf)>,
+) {
+    if let Some((info, root)) = wt {
+        tokio::spawn(async move {
+            let timeout = std::time::Duration::from_secs(3600);
+            match tokio::time::timeout(timeout, wait_agent(&shared, &name)).await {
+                Ok(_) => {
+                    loopal_git::cleanup_if_clean(&root, &info);
+                }
+                Err(_) => tracing::warn!(agent = %name, "background agent timed out"),
+            }
+        });
+    }
+}

--- a/crates/loopal-agent/src/tools/collaboration/mod.rs
+++ b/crates/loopal-agent/src/tools/collaboration/mod.rs
@@ -5,6 +5,7 @@
 //! - **ListHubs**: discover other hubs in MetaHub cluster
 
 pub mod agent;
+mod agent_fork;
 pub mod list_hubs;
 pub mod send_message;
 pub(crate) mod shared_extract;

--- a/crates/loopal-config/src/harness.rs
+++ b/crates/loopal-config/src/harness.rs
@@ -19,6 +19,13 @@ pub struct HarnessConfig {
     pub max_auto_continuations: u32,
     /// Max Stop hook feedback rounds before forcing exit (default: 2).
     pub max_stop_feedback: u32,
+    /// Max agent spawn depth (default: 2). Agents at depth >= this value
+    /// lose their spawn tools. E.g., 2 means depth 0 and 1 can spawn,
+    /// depth 2+ cannot.
+    pub agent_max_depth: u32,
+    /// Max total sub-agents across the entire Hub (default: 16).
+    /// Excludes root agent — only counts spawned children.
+    pub agent_max_total: u32,
 }
 
 impl Default for HarnessConfig {
@@ -30,6 +37,8 @@ impl Default for HarnessConfig {
             cb_max_total_denials: 20,
             max_auto_continuations: 3,
             max_stop_feedback: 2,
+            agent_max_depth: 2,
+            agent_max_total: 16,
         }
     }
 }

--- a/crates/loopal-context/src/fork.rs
+++ b/crates/loopal-context/src/fork.rs
@@ -1,0 +1,120 @@
+//! Fork context compression — prepare parent messages for child agents.
+
+use crate::token_counter::estimate_messages_tokens;
+use loopal_message::{ContentBlock, Message, MessageRole};
+
+const FORK_MAX_TOKENS: u32 = 50_000;
+const TOOL_RESULT_CAP: usize = 200;
+
+/// Compress parent conversation for fork context.
+///
+/// Strips ephemeral blocks (thinking, image, server), truncates tool results,
+/// drops the last incomplete assistant turn, and caps total tokens.
+pub fn compress_for_fork(messages: &[Message]) -> Vec<Message> {
+    if messages.is_empty() {
+        return Vec::new();
+    }
+
+    let trimmed = strip_incomplete_tail(messages);
+    let mut result: Vec<Message> = trimmed
+        .iter()
+        .map(compress_message)
+        .filter(|m| !m.content.is_empty())
+        .collect();
+
+    // Drop oldest messages until within token budget (may trim to empty).
+    let mut trimmed_budget = false;
+    while !result.is_empty() && estimate_messages_tokens(&result) > FORK_MAX_TOKENS {
+        result.remove(0);
+        trimmed_budget = true;
+    }
+    // After budget trimming, ensure we start with a User message (API requirement).
+    if trimmed_budget {
+        while !result.is_empty() && result[0].role != MessageRole::User {
+            result.remove(0);
+        }
+    }
+    result
+}
+
+/// Boilerplate prepended to the child's prompt when fork context is injected.
+pub const FORK_BOILERPLATE: &str = "\
+STOP. READ THIS FIRST.\n\n\
+You are a forked worker process. The conversation above is background \
+context from your parent agent.\n\n\
+RULES:\n\
+1. Do NOT spawn sub-agents — execute directly with your tools.\n\
+2. Stay within your assigned scope.\n\
+3. Use tools silently, then report findings once at the end.\n\
+4. Keep your report under 500 words. Be factual and concise.\n\
+5. Your response MUST begin with \"Scope:\" — no preamble.\n\n\
+Your task follows below.\n\n";
+
+fn strip_incomplete_tail(messages: &[Message]) -> &[Message] {
+    if let Some(last) = messages.last()
+        && last.role == MessageRole::Assistant
+        && has_tool_use(last)
+    {
+        return &messages[..messages.len() - 1];
+    }
+    messages
+}
+
+fn has_tool_use(msg: &Message) -> bool {
+    msg.content
+        .iter()
+        .any(|b| matches!(b, ContentBlock::ToolUse { .. }))
+}
+
+fn compress_message(msg: &Message) -> Message {
+    let content: Vec<ContentBlock> = msg
+        .content
+        .iter()
+        .filter_map(compress_block)
+        .collect();
+    Message {
+        id: msg.id.clone(),
+        role: msg.role.clone(),
+        content,
+    }
+}
+
+fn compress_block(block: &ContentBlock) -> Option<ContentBlock> {
+    match block {
+        ContentBlock::Thinking { .. }
+        | ContentBlock::Image { .. }
+        | ContentBlock::ServerToolUse { .. }
+        | ContentBlock::ServerToolResult { .. } => None,
+        ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+            metadata,
+        } => {
+            let truncated = if content.len() > TOOL_RESULT_CAP {
+                let boundary = floor_char_boundary(content, TOOL_RESULT_CAP);
+                format!("{}…[truncated]", &content[..boundary])
+            } else {
+                content.clone()
+            };
+            Some(ContentBlock::ToolResult {
+                tool_use_id: tool_use_id.clone(),
+                content: truncated,
+                is_error: *is_error,
+                metadata: metadata.clone(),
+            })
+        }
+        other => Some(other.clone()),
+    }
+}
+
+fn floor_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        return s.len();
+    }
+    let mut i = index;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}

--- a/crates/loopal-context/src/fork.rs
+++ b/crates/loopal-context/src/fork.rs
@@ -67,11 +67,7 @@ fn has_tool_use(msg: &Message) -> bool {
 }
 
 fn compress_message(msg: &Message) -> Message {
-    let content: Vec<ContentBlock> = msg
-        .content
-        .iter()
-        .filter_map(compress_block)
-        .collect();
+    let content: Vec<ContentBlock> = msg.content.iter().filter_map(compress_block).collect();
     Message {
         id: msg.id.clone(),
         role: msg.role.clone(),

--- a/crates/loopal-context/src/lib.rs
+++ b/crates/loopal-context/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod budget;
 pub mod compaction;
 pub mod degradation;
+pub mod fork;
 pub mod ingestion;
 pub mod middleware;
 pub mod pipeline;

--- a/crates/loopal-context/tests/suite.rs
+++ b/crates/loopal-context/tests/suite.rs
@@ -5,6 +5,8 @@ mod compaction_pair_test;
 mod compaction_test;
 #[path = "suite/degradation_test.rs"]
 mod degradation_test;
+#[path = "suite/fork_test.rs"]
+mod fork_test;
 #[path = "suite/ingestion_test.rs"]
 mod ingestion_test;
 #[path = "suite/pipeline_test.rs"]

--- a/crates/loopal-context/tests/suite/fork_test.rs
+++ b/crates/loopal-context/tests/suite/fork_test.rs
@@ -1,0 +1,154 @@
+use loopal_context::fork::{FORK_BOILERPLATE, compress_for_fork};
+use loopal_message::{ContentBlock, Message, MessageRole};
+
+#[test]
+fn empty_input() {
+    assert!(compress_for_fork(&[]).is_empty());
+}
+
+#[test]
+fn strips_thinking_blocks() {
+    let msgs = vec![Message {
+        id: None,
+        role: MessageRole::Assistant,
+        content: vec![
+            ContentBlock::Thinking {
+                thinking: "hmm".into(),
+                signature: None,
+            },
+            ContentBlock::Text {
+                text: "hello".into(),
+            },
+        ],
+    }];
+    let result = compress_for_fork(&msgs);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].content.len(), 1);
+    assert!(matches!(&result[0].content[0], ContentBlock::Text { .. }));
+}
+
+#[test]
+fn strips_incomplete_tail() {
+    let msgs = vec![
+        Message::user("q"),
+        Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: vec![ContentBlock::ToolUse {
+                id: "t1".into(),
+                name: "Agent".into(),
+                input: serde_json::json!({}),
+            }],
+        },
+    ];
+    let result = compress_for_fork(&msgs);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].role, MessageRole::User);
+}
+
+#[test]
+fn truncates_long_tool_result() {
+    let long_content = "x".repeat(500);
+    let msgs = vec![Message {
+        id: None,
+        role: MessageRole::User,
+        content: vec![ContentBlock::ToolResult {
+            tool_use_id: "t1".into(),
+            content: long_content,
+            is_error: false,
+            metadata: None,
+        }],
+    }];
+    let result = compress_for_fork(&msgs);
+    let ContentBlock::ToolResult { content, .. } = &result[0].content[0] else {
+        panic!("expected ToolResult");
+    };
+    assert!(content.len() < 300);
+    assert!(content.ends_with("…[truncated]"));
+}
+
+#[test]
+fn boilerplate_contains_no_spawn_rule() {
+    assert!(FORK_BOILERPLATE.contains("Do NOT spawn sub-agents"));
+}
+
+#[test]
+fn utf8_truncation_no_panic() {
+    let content = "a".repeat(100) + &"😀".repeat(50);
+    let msgs = vec![Message {
+        id: None,
+        role: MessageRole::User,
+        content: vec![ContentBlock::ToolResult {
+            tool_use_id: "t1".into(),
+            content,
+            is_error: false,
+            metadata: None,
+        }],
+    }];
+    let result = compress_for_fork(&msgs);
+    assert!(!result.is_empty());
+}
+
+#[test]
+fn result_starts_with_user_message() {
+    let msgs = vec![
+        Message::user("q1"),
+        Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: vec![ContentBlock::Text { text: "a1".into() }],
+        },
+        Message::user("q2"),
+    ];
+    let result = compress_for_fork(&msgs);
+    assert!(!result.is_empty());
+    assert_eq!(result[0].role, MessageRole::User);
+}
+
+#[test]
+fn fork_context_json_round_trip() {
+    let msgs = vec![
+        Message::user("what files exist?"),
+        Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: vec![
+                ContentBlock::Text { text: "Let me check.".into() },
+                ContentBlock::ToolUse {
+                    id: "tu1".into(),
+                    name: "Glob".into(),
+                    input: serde_json::json!({"pattern": "**/*.rs"}),
+                },
+            ],
+        },
+        Message {
+            id: None,
+            role: MessageRole::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: "tu1".into(),
+                content: "src/main.rs\nsrc/lib.rs".into(),
+                is_error: false,
+                metadata: None,
+            }],
+        },
+        Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: vec![ContentBlock::Text {
+                text: "Found 2 files.".into(),
+            }],
+        },
+    ];
+    let compressed = compress_for_fork(&msgs);
+    assert!(!compressed.is_empty());
+
+    let json_val = serde_json::to_value(&compressed).expect("serialize");
+    let recovered: Vec<Message> =
+        serde_json::from_value(json_val).expect("deserialize");
+
+    assert_eq!(recovered.len(), compressed.len());
+    for (orig, recov) in compressed.iter().zip(recovered.iter()) {
+        assert_eq!(orig.role, recov.role);
+        assert_eq!(orig.content.len(), recov.content.len());
+    }
+}

--- a/crates/loopal-context/tests/suite/fork_test.rs
+++ b/crates/loopal-context/tests/suite/fork_test.rs
@@ -113,7 +113,9 @@ fn fork_context_json_round_trip() {
             id: None,
             role: MessageRole::Assistant,
             content: vec![
-                ContentBlock::Text { text: "Let me check.".into() },
+                ContentBlock::Text {
+                    text: "Let me check.".into(),
+                },
                 ContentBlock::ToolUse {
                     id: "tu1".into(),
                     name: "Glob".into(),
@@ -143,8 +145,7 @@ fn fork_context_json_round_trip() {
     assert!(!compressed.is_empty());
 
     let json_val = serde_json::to_value(&compressed).expect("serialize");
-    let recovered: Vec<Message> =
-        serde_json::from_value(json_val).expect("deserialize");
+    let recovered: Vec<Message> = serde_json::from_value(json_val).expect("deserialize");
 
     assert_eq!(recovered.len(), compressed.len());
     for (orig, recov) in compressed.iter().zip(recovered.iter()) {

--- a/crates/loopal-meta-hub/tests/suite/e2e_tcp_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/e2e_tcp_test.rs
@@ -92,7 +92,9 @@ async fn register_mock(
     let server_rx = server.start();
     let client_rx = client.start();
 
-    let _ = register_agent_connection(hub.clone(), name, server, server_rx, None, None, None).await.unwrap();
+    let _ = register_agent_connection(hub.clone(), name, server, server_rx, None, None, None)
+        .await
+        .unwrap();
 
     let cc = client.clone();
     let mut listen = client_rx;

--- a/crates/loopal-meta-hub/tests/suite/e2e_tcp_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/e2e_tcp_test.rs
@@ -92,7 +92,7 @@ async fn register_mock(
     let server_rx = server.start();
     let client_rx = client.start();
 
-    register_agent_connection(hub.clone(), name, server, server_rx, None, None, None).await;
+    let _ = register_agent_connection(hub.clone(), name, server, server_rx, None, None, None).await.unwrap();
 
     let cc = client.clone();
     let mut listen = client_rx;

--- a/crates/loopal-meta-hub/tests/suite/shadow_lifecycle_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/shadow_lifecycle_test.rs
@@ -133,7 +133,7 @@ async fn orphan_cascade_skips_shadows() {
     let _real_client_conn = Arc::new(Connection::new(real_client));
     let real_rx = real_conn.start();
     let _real_client_rx = _real_client_conn.start();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "real-child",
         real_conn,

--- a/crates/loopal-meta-hub/tests/suite/spawn_completion_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/spawn_completion_test.rs
@@ -89,7 +89,7 @@ async fn completion_delivery_to_remote_parent() {
     let child_client_conn = Arc::new(Connection::new(child_client));
     let child_server_rx = child_server_conn.start();
     let _child_client_rx = child_client_conn.start();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub_b.clone(),
         "child-worker",
         child_server_conn,

--- a/crates/loopal-meta-hub/tests/suite/spawn_edge_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/spawn_edge_test.rs
@@ -86,7 +86,7 @@ async fn local_parent_completion_unaffected_by_uplink() {
     let child_client_conn = Arc::new(Connection::new(child_client));
     let child_server_rx = child_server_conn.start();
     let _child_client_rx = child_client_conn.start();
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         "child",
         child_server_conn,

--- a/crates/loopal-meta-hub/tests/suite/test_helpers.rs
+++ b/crates/loopal-meta-hub/tests/suite/test_helpers.rs
@@ -71,7 +71,7 @@ pub async fn register_mock_agent(
     let server_rx = server_conn.start();
     let client_rx = client_conn.start();
 
-    register_agent_connection(
+    let _ = register_agent_connection(
         hub.clone(),
         name,
         server_conn,

--- a/crates/loopal-prompt-system/prompts/tools/agent-guidelines.md
+++ b/crates/loopal-prompt-system/prompts/tools/agent-guidelines.md
@@ -35,13 +35,17 @@ Scale concurrency to task complexity:
 
 ## Delegation Depth
 
-Your current depth in the agent tree is **{{ agent_depth }}** (0 = root, 1 = first-level sub-agent, etc.). Every sub-agent you spawn can itself spawn further sub-agents. This makes cascading delegation a real risk — if every agent subdivides its work, agent count grows exponentially and each individual agent ends up doing very little useful work.
+Your current depth in the agent tree is **{{ agent_depth }}** (0 = root, 1 = first-level sub-agent, etc.).
 
-**The deeper you are, the more you should prefer doing the work yourself:**
-- At depth 0 (root): spawning sub-agents for broad tasks is natural.
-- At depth 1+: you were created to handle a specific scope. Consider whether your tools (Glob, Grep, Read, Edit, Bash) are sufficient before spawning children.
-- Only delegate further if your assigned scope genuinely contains multiple independent sub-problems that would each benefit from a separate context.
-- Give children **narrowly scoped, concrete tasks** — not vague directives that they would need to subdivide again.
+{% if agent_depth == 0 %}
+Before spawning any sub-agents, **you must first use Glob/Grep/Read to understand the project structure**. Then spawn focused agents with concrete, narrow tasks. Prefer fewer well-scoped agents over many vague ones.
+
+**Anti-pattern to avoid:** Spawning 5+ agents immediately after receiving a task without reading any files first. This leads to exponential agent growth because each blind agent subdivides its blind sub-task further.
+{% elif agent_depth >= 2 %}
+**Your spawn capability has been removed at this depth.** Execute your task directly with your tools (Glob, Grep, Read, Edit, Bash). You have your parent's context — use it.
+{% else %}
+**You are a sub-agent (depth {{ agent_depth }}).** You were spawned to handle a specific task and already have your parent's context. Strongly prefer doing the work yourself with Glob/Grep/Read/Edit/Bash. Only delegate further if your scope genuinely contains 3+ independent sub-problems each requiring separate exploration of different codebase areas. If in doubt, do it yourself.
+{% endif %}
 
 ## Agent Types
 

--- a/crates/loopal-runtime/src/agent_loop/fork_snapshot.rs
+++ b/crates/loopal-runtime/src/agent_loop/fork_snapshot.rs
@@ -8,10 +8,7 @@ impl AgentLoopRunner {
     /// Called before each tool execution batch so the Agent tool can
     /// read a consistent snapshot for building fork context.
     /// Only clones if this batch contains an Agent tool call.
-    pub(super) fn update_fork_snapshot(
-        &self,
-        tool_uses: &[(String, String, serde_json::Value)],
-    ) {
+    pub(super) fn update_fork_snapshot(&self, tool_uses: &[(String, String, serde_json::Value)]) {
         let has_agent_call = tool_uses.iter().any(|(_, name, _)| name == "Agent");
         if !has_agent_call {
             return;

--- a/crates/loopal-runtime/src/agent_loop/fork_snapshot.rs
+++ b/crates/loopal-runtime/src/agent_loop/fork_snapshot.rs
@@ -1,0 +1,29 @@
+//! Fork snapshot — update shared message snapshot before tool execution.
+
+use super::runner::AgentLoopRunner;
+
+impl AgentLoopRunner {
+    /// Copy current conversation messages into the shared snapshot.
+    ///
+    /// Called before each tool execution batch so the Agent tool can
+    /// read a consistent snapshot for building fork context.
+    /// Only clones if this batch contains an Agent tool call.
+    pub(super) fn update_fork_snapshot(
+        &self,
+        tool_uses: &[(String, String, serde_json::Value)],
+    ) {
+        let has_agent_call = tool_uses.iter().any(|(_, name, _)| name == "Agent");
+        if !has_agent_call {
+            return;
+        }
+        if let Some(ref snapshot) = self.params.message_snapshot {
+            match snapshot.write() {
+                Ok(mut guard) => *guard = self.params.store.messages().to_vec(),
+                Err(e) => {
+                    tracing::warn!("fork snapshot write lock poisoned, recovering: {e}");
+                    *e.into_inner() = self.params.store.messages().to_vec();
+                }
+            }
+        }
+    }
+}

--- a/crates/loopal-runtime/src/agent_loop/mod.rs
+++ b/crates/loopal-runtime/src/agent_loop/mod.rs
@@ -40,6 +40,7 @@ pub(crate) mod turn_metrics;
 pub mod turn_observer;
 mod turn_observer_dispatch;
 mod turn_telemetry;
+mod fork_snapshot;
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -61,8 +62,6 @@ use crate::session::SessionManager;
 use finished_guard::FinishedGuard;
 
 pub use runner::AgentLoopRunner;
-
-// ── Sub-structs ────────────────────────────────────────────────────
 
 /// Agent lifecycle mode — determines idle behavior after turn completion.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -150,8 +149,6 @@ impl Default for InterruptHandle {
     }
 }
 
-// ── AgentLoopParams ────────────────────────────────────────────────
-
 pub struct AgentLoopParams {
     pub config: AgentConfig,
     pub deps: AgentDeps,
@@ -173,6 +170,8 @@ pub struct AgentLoopParams {
     pub harness: HarnessConfig,
     /// Receive end for async hook rewake messages (exit code 2 from background hooks).
     pub rewake_rx: Option<tokio::sync::mpsc::Receiver<loopal_protocol::Envelope>>,
+    /// Shared conversation snapshot for fork context — updated before tool execution.
+    pub message_snapshot: Option<Arc<std::sync::RwLock<Vec<loopal_message::Message>>>>,
 }
 
 /// Public wrapper — constructs default observers and runs the loop.

--- a/crates/loopal-runtime/src/agent_loop/mod.rs
+++ b/crates/loopal-runtime/src/agent_loop/mod.rs
@@ -4,6 +4,7 @@ mod context_prep;
 pub mod diff_tracker;
 pub mod env_context;
 mod finished_guard;
+mod fork_snapshot;
 mod input;
 mod input_control;
 mod llm;
@@ -40,7 +41,6 @@ pub(crate) mod turn_metrics;
 pub mod turn_observer;
 mod turn_observer_dispatch;
 mod turn_telemetry;
-mod fork_snapshot;
 
 use std::collections::HashSet;
 use std::sync::Arc;

--- a/crates/loopal-runtime/src/agent_loop/turn_exec.rs
+++ b/crates/loopal-runtime/src/agent_loop/turn_exec.rs
@@ -1,5 +1,3 @@
-//! Inner turn execution loop.
-
 use loopal_error::Result;
 use loopal_protocol::AgentEventPayload;
 use loopal_provider_api::StopReason;
@@ -138,6 +136,8 @@ impl AgentLoopRunner {
             if self.run_before_tools(turn_ctx, &result.tool_uses).await? {
                 return Ok(TurnOutput { output: last_text });
             }
+
+            self.update_fork_snapshot(&result.tool_uses); // fork context
 
             // Start ReadOnly tools early (parallel with permission checks).
             let kernel = std::sync::Arc::clone(&self.params.deps.kernel);

--- a/crates/loopal-runtime/tests/agent_loop/auto_mode_degradation_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/auto_mode_degradation_test.rs
@@ -117,6 +117,7 @@ async fn no_provider_denies_gracefully() {
         auto_classifier: Some(classifier),
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     };
     let mut runner = AgentLoopRunner::new(params);
 

--- a/crates/loopal-runtime/tests/agent_loop/auto_mode_helpers.rs
+++ b/crates/loopal-runtime/tests/agent_loop/auto_mode_helpers.rs
@@ -132,6 +132,7 @@ pub fn make_auto_runner_with_setup(
         auto_classifier: Some(classifier),
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     };
     (AgentLoopRunner::new(params), event_rx)
 }

--- a/crates/loopal-runtime/tests/agent_loop/drain_pending_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/drain_pending_test.rs
@@ -140,6 +140,7 @@ async fn test_subagent_drains_pending_before_exit() {
         auto_classifier: None,
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     };
 
     // Drain events in background so channels don't block

--- a/crates/loopal-runtime/tests/agent_loop/input_edge_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/input_edge_test.rs
@@ -58,6 +58,7 @@ fn test_model_info_defaults_for_unknown_model() {
         auto_classifier: None,
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     };
 
     let runner = AgentLoopRunner::new(params);

--- a/crates/loopal-runtime/tests/agent_loop/integration_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/integration_test.rs
@@ -63,6 +63,7 @@ async fn test_agent_loop_immediate_channel_close() {
         auto_classifier: None,
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     };
 
     // Drop senders to close channels

--- a/crates/loopal-runtime/tests/agent_loop/mock_provider.rs
+++ b/crates/loopal-runtime/tests/agent_loop/mock_provider.rs
@@ -64,6 +64,7 @@ fn build_params_with_config(
         auto_classifier: None,
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     }
 }
 

--- a/crates/loopal-runtime/tests/agent_loop/mod.rs
+++ b/crates/loopal-runtime/tests/agent_loop/mod.rs
@@ -102,6 +102,7 @@ pub fn make_runner() -> (AgentLoopRunner, mpsc::Receiver<AgentEvent>) {
         auto_classifier: None,
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     };
     (AgentLoopRunner::new(params), event_rx)
 }
@@ -148,6 +149,7 @@ pub fn make_runner_with_channels() -> (
         auto_classifier: None,
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     };
     (
         AgentLoopRunner::new(params),

--- a/crates/loopal-runtime/tests/agent_loop/model_routing_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/model_routing_test.rs
@@ -56,6 +56,7 @@ fn make_runner_with_routing(
         auto_classifier: None,
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     };
     (AgentLoopRunner::new(params), event_rx)
 }
@@ -142,6 +143,7 @@ fn test_model_routing_default_override_via_config_model() {
         auto_classifier: None,
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     };
     let (runner, _rx) = (AgentLoopRunner::new(params), event_rx);
 

--- a/crates/loopal-runtime/tests/agent_loop/permission_test_ext.rs
+++ b/crates/loopal-runtime/tests/agent_loop/permission_test_ext.rs
@@ -135,6 +135,7 @@ async fn test_check_permission_channel_closed_denies() {
         auto_classifier: None,
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     };
 
     let runner = AgentLoopRunner::new(params);

--- a/crates/loopal-runtime/tests/agent_loop/turn_completion_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/turn_completion_test.rs
@@ -104,6 +104,7 @@ pub(crate) fn make_multi_runner(
         auto_classifier: None,
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     };
     (AgentLoopRunner::new(params), event_rx)
 }

--- a/crates/loopal-test-support/src/agent_ctx.rs
+++ b/crates/loopal-test-support/src/agent_ctx.rs
@@ -71,6 +71,7 @@ fn agent_tool_context_inner(
         parent_event_tx: None,
         cancel_token: None,
         scheduler_handle,
+        message_snapshot: Arc::new(std::sync::RwLock::new(Vec::new())),
     });
 
     let shared_any: Arc<dyn std::any::Any + Send + Sync> = Arc::new(shared.clone());

--- a/crates/loopal-test-support/src/wiring.rs
+++ b/crates/loopal-test-support/src/wiring.rs
@@ -101,6 +101,7 @@ pub(crate) async fn wire(builder: HarnessBuilder) -> (SpawnedHarness, AgentLoopR
         parent_event_tx: Some(event_tx),
         cancel_token: None,
         scheduler_handle,
+        message_snapshot: Arc::new(std::sync::RwLock::new(Vec::new())),
     });
     let shared_any: Arc<dyn std::any::Any + Send + Sync> = Arc::new(shared);
 
@@ -159,6 +160,7 @@ pub(crate) async fn wire(builder: HarnessBuilder) -> (SpawnedHarness, AgentLoopR
         auto_classifier: None,
         harness: loopal_config::HarnessConfig::default(),
         rewake_rx: None,
+        message_snapshot: None,
     };
 
     let harness = SpawnedHarness {

--- a/src/bootstrap/hub_bootstrap.rs
+++ b/src/bootstrap/hub_bootstrap.rs
@@ -31,6 +31,7 @@ pub async fn bootstrap_hub_and_agent(
 ) -> anyhow::Result<BootstrapContext> {
     let (event_tx, event_rx) = mpsc::channel(256);
     let hub = Arc::new(Mutex::new(Hub::new(event_tx)));
+    hub.lock().await.max_total_agents = config.settings.harness.agent_max_total;
 
     let (listener, port, hub_token) = hub_server::start_hub_listener(hub.clone()).await?;
     hub.lock().await.listener_port = Some(port);


### PR DESCRIPTION
## Summary
- **Depth degradation**: agents at `depth >= agent_max_depth` (default 2) physically lose Agent/SendMessage/ListHubs tools — LLM cannot spawn further
- **Hub spawn budget**: total sub-agents capped at `agent_max_total` (default 16) with atomic check-and-register under lock, pre-spawn early rejection to prevent process orphans
- **Fork context**: child agents inherit compressed parent conversation (stripped thinking/image, truncated tool results, 50K token cap), eliminating redundant exploration; boilerplate instructs forked workers to execute directly

## Changes
- **New files (7)**: `spawn_policy.rs`, `fork.rs`, `fork_snapshot.rs`, `agent_fork.rs`, `memory_consolidation.rs`, `status_handler.rs`, `fork_test.rs`
- **Config**: `HarnessConfig` gains `agent_max_depth` and `agent_max_total` with backward-compatible defaults
- **IPC chain**: `fork_context` threaded through SpawnParams → Hub dispatch → spawn_manager → AgentClient → session_start → agent_setup (6-layer passthrough)
- **Prompt**: `agent-guidelines.md` depth-conditional template (root: explore first; depth 1: prefer self; depth 2+: spawn removed)

## Test plan
- [x] `bazel build //...` passes
- [x] `bazel build //... --config=clippy` zero warnings
- [x] `bazel test //...` — 52/52 tests pass
- [x] Fork context JSON round-trip test added
- [x] UTF-8 truncation safety test added
- [ ] CI passes