### PR TITLE
fix(tui): prevent Shift+Enter inserting 'j' instead of newline

### DIFF
--- a/crates/loopal-tui/src/input/mod.rs
+++ b/crates/loopal-tui/src/input/mod.rs
@@ -54,6 +54,12 @@ fn handle_global_keys(app: &mut App, key: &KeyEvent) -> Option<InputAction> {
             KeyCode::Char('n') if matches!(app.focus_mode, FocusMode::Panel(_)) => {
                 return Some(InputAction::PanelDown);
             }
+            // 0x0A (LF) arrives as Ctrl+J — many terminals send this for Shift+Enter
+            KeyCode::Char('j') => {
+                app.input.insert(app.input_cursor, '\n');
+                app.input_cursor += 1;
+                return Some(InputAction::None);
+            }
             KeyCode::Char('p') => return Some(handle_up(app)),
             KeyCode::Char('n') => return Some(handle_down(app)),
             _ => {}
@@ -92,8 +98,12 @@ fn handle_panel_key(app: &mut App, key: &KeyEvent) -> InputAction {
         KeyCode::Delete if kind == PanelKind::Agents => InputAction::TerminateFocusedAgent,
         KeyCode::Tab => InputAction::PanelTab,
         KeyCode::Esc => InputAction::ExitPanel,
-        KeyCode::Char(c) => {
-            // Auto-switch to Input mode and insert the character
+        // Only insert plain or Shift-modified characters; ignore Ctrl/Alt combos
+        KeyCode::Char(c)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+        {
             app.focus_mode = FocusMode::Input;
             app.input.insert(app.input_cursor, c);
             app.input_cursor += c.len_utf8();
@@ -129,7 +139,12 @@ fn handle_input_mode_key(app: &mut App, key: &KeyEvent) -> InputAction {
             InputAction::None
         }
         KeyCode::Enter => handle_enter(app),
-        KeyCode::Char(c) => {
+        // Only insert plain or Shift-modified characters; ignore Ctrl/Alt combos
+        KeyCode::Char(c)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+        {
             app.input.insert(app.input_cursor, c);
             app.input_cursor += c.len_utf8();
             InputAction::None

--- a/crates/loopal-tui/src/input/status_page_keys.rs
+++ b/crates/loopal-tui/src/input/status_page_keys.rs
@@ -1,6 +1,6 @@
 //! Key handler for the status page sub-page.
 
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::InputAction;
 use crate::app::{App, StatusTab, SubPage};
@@ -39,7 +39,12 @@ pub(super) fn handle_status_page_key(app: &mut App, key: &KeyEvent) -> InputActi
             }
             InputAction::None
         }
-        KeyCode::Char(c) if state.active_tab == StatusTab::Config => {
+        KeyCode::Char(c)
+            if state.active_tab == StatusTab::Config
+                && !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+        {
             state.filter.insert(state.filter_cursor, c);
             state.filter_cursor += c.len_utf8();
             state.scroll_offsets[StatusTab::Config.index()] = 0;

--- a/crates/loopal-tui/src/input/sub_page.rs
+++ b/crates/loopal-tui/src/input/sub_page.rs
@@ -57,7 +57,11 @@ fn handle_generic_picker_key(picker: &mut PickerState, key: &KeyEvent) -> Picker
             }
             PickerKeyResult::Handled
         }
-        KeyCode::Char(c) => {
+        KeyCode::Char(c)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+        {
             picker.filter.insert(picker.filter_cursor, c);
             picker.filter_cursor += c.len_utf8();
             picker.selected = 0;

--- a/crates/loopal-tui/src/terminal.rs
+++ b/crates/loopal-tui/src/terminal.rs
@@ -1,18 +1,27 @@
 use std::io;
 
 use crossterm::{
-    event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
+    event::{
+        DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    },
     execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    terminal::{
+        EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+        supports_keyboard_enhancement,
+    },
 };
 
 /// RAII guard that ensures raw mode and alternate screen are cleaned up on drop,
 /// even if the TUI panics or returns early via `?`.
-pub struct TerminalGuard;
+pub struct TerminalGuard {
+    keyboard_enhanced: bool,
+}
 
 impl TerminalGuard {
     pub fn new() -> io::Result<Self> {
         enable_raw_mode()?;
+        let keyboard_enhanced = supports_keyboard_enhancement().unwrap_or(false);
         let mut stdout = io::stdout();
         execute!(
             stdout,
@@ -20,12 +29,23 @@ impl TerminalGuard {
             EnableMouseCapture,
             EnableBracketedPaste
         )?;
-        Ok(Self)
+        if keyboard_enhanced {
+            let _ = execute!(
+                stdout,
+                PushKeyboardEnhancementFlags(
+                    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                )
+            );
+        }
+        Ok(Self { keyboard_enhanced })
     }
 }
 
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
+        if self.keyboard_enhanced {
+            let _ = execute!(io::stdout(), PopKeyboardEnhancementFlags);
+        }
         let _ = disable_raw_mode();
         let _ = execute!(
             io::stdout(),
@@ -45,6 +65,7 @@ pub fn install_panic_hook() {
         let _ = disable_raw_mode();
         let _ = execute!(
             io::stdout(),
+            PopKeyboardEnhancementFlags,
             DisableBracketedPaste,
             DisableMouseCapture,
             LeaveAlternateScreen,

--- a/crates/loopal-tui/src/terminal.rs
+++ b/crates/loopal-tui/src/terminal.rs
@@ -32,9 +32,7 @@ impl TerminalGuard {
         if keyboard_enhanced {
             let _ = execute!(
                 stdout,
-                PushKeyboardEnhancementFlags(
-                    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                )
+                PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
             );
         }
         Ok(Self { keyboard_enhanced })


### PR DESCRIPTION
## Summary
- Shift+Enter in the input box typed 'j' instead of inserting a newline, because terminals send 0x0A (LF) which crossterm reports as `Ctrl+J` / `KeyCode::Char('j')`
- Added Kitty keyboard enhancement protocol so supporting terminals report Shift+Enter correctly
- Guarded all `Char(c)` insertion points against CONTROL/ALT modifiers to prevent the entire class of misinterpreted modifier+key bugs

## Changes
- `crates/loopal-tui/src/terminal.rs` — enable `DISAMBIGUATE_ESCAPE_CODES` via Kitty protocol, clean up on drop/panic
- `crates/loopal-tui/src/input/mod.rs` — Ctrl+J → newline in global keys; modifier guard on `Char(c)` in panel/input modes
- `crates/loopal-tui/src/input/sub_page.rs` — modifier guard on picker filter `Char(c)`
- `crates/loopal-tui/src/input/status_page_keys.rs` — modifier guard on config filter `Char(c)`

## Test plan
- [ ] CI passes
- [ ] `bazel test //crates/loopal-tui:loopal-tui_test` passes (verified locally)