### PR TITLE
feat(tui): add /skills slash command

### DIFF
--- a/crates/loopal-tui/src/command/builtin.rs
+++ b/crates/loopal-tui/src/command/builtin.rs
@@ -109,4 +109,5 @@ pub fn register_all(registry: &mut CommandRegistry) {
     registry.register(Arc::new(ExitCmd));
     registry.register(Arc::new(super::agent_cmd::AgentsCmd));
     registry.register(Arc::new(super::topology_cmd::TopologyCmd));
+    registry.register(Arc::new(super::skills_cmd::SkillsCmd));
 }

--- a/crates/loopal-tui/src/command/mod.rs
+++ b/crates/loopal-tui/src/command/mod.rs
@@ -9,6 +9,7 @@ pub mod registry;
 mod resume_cmd;
 mod rewind_cmd;
 mod skill;
+mod skills_cmd;
 mod status_cmd;
 mod status_config;
 mod topology_cmd;

--- a/crates/loopal-tui/src/command/skills_cmd.rs
+++ b/crates/loopal-tui/src/command/skills_cmd.rs
@@ -1,0 +1,64 @@
+//! `/skills` command — lists loaded skills and their sources.
+
+use std::collections::BTreeSet;
+
+use async_trait::async_trait;
+
+use super::{CommandEffect, CommandHandler};
+use crate::app::App;
+
+pub struct SkillsCmd;
+
+#[async_trait]
+impl CommandHandler for SkillsCmd {
+    fn name(&self) -> &str {
+        "/skills"
+    }
+    fn description(&self) -> &str {
+        "List loaded skills and sources"
+    }
+    async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
+        let content = build_skills_list(app);
+        app.session.push_system_message(content);
+        CommandEffect::Done
+    }
+}
+
+fn build_skills_list(app: &App) -> String {
+    let config = match loopal_config::load_config(&app.cwd) {
+        Ok(c) => c,
+        Err(_) => return "Failed to load config.".to_string(),
+    };
+
+    if config.skills.is_empty() {
+        return "No skills loaded.".to_string();
+    }
+
+    let name_width = config
+        .skills
+        .values()
+        .map(|e| e.skill.name.len())
+        .max()
+        .unwrap_or(8);
+
+    let mut lines = Vec::with_capacity(config.skills.len() + 3);
+    lines.push(format!("Loaded skills ({}):", config.skills.len()));
+
+    let mut sources = BTreeSet::new();
+    for entry in config.skills.values() {
+        let s = &entry.skill;
+        sources.insert(entry.source.to_string());
+        lines.push(format!(
+            "  {:<width$}  [{}]  {}",
+            s.name,
+            entry.source,
+            s.description,
+            width = name_width,
+        ));
+    }
+
+    lines.push(String::new());
+    let legend: Vec<_> = sources.into_iter().collect();
+    lines.push(format!("Sources: {}", legend.join(", ")));
+    lines.join("\n")
+}

--- a/crates/loopal-tui/tests/suite.rs
+++ b/crates/loopal-tui/tests/suite.rs
@@ -66,6 +66,8 @@ mod scroll_compensation_test;
 mod scroll_test;
 #[path = "suite/skill_render_test.rs"]
 mod skill_render_test;
+#[path = "suite/skills_cmd_test.rs"]
+mod skills_cmd_test;
 #[path = "suite/styled_wrap_test.rs"]
 mod styled_wrap_test;
 #[path = "suite/view_switch_panel_lifecycle_test.rs"]

--- a/crates/loopal-tui/tests/suite/command_test.rs
+++ b/crates/loopal-tui/tests/suite/command_test.rs
@@ -13,7 +13,7 @@ fn test_registry_new_has_all_builtins() {
     let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
     for expected in &[
         "/plan", "/act", "/clear", "/compact", "/model", "/rewind", "/status", "/resume", "/init",
-        "/help", "/exit",
+        "/help", "/exit", "/agents", "/topology", "/skills",
     ] {
         assert!(names.contains(expected), "missing builtin: {expected}");
     }

--- a/crates/loopal-tui/tests/suite/command_test.rs
+++ b/crates/loopal-tui/tests/suite/command_test.rs
@@ -12,8 +12,20 @@ fn test_registry_new_has_all_builtins() {
     let entries = registry.entries();
     let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
     for expected in &[
-        "/plan", "/act", "/clear", "/compact", "/model", "/rewind", "/status", "/resume", "/init",
-        "/help", "/exit", "/agents", "/topology", "/skills",
+        "/plan",
+        "/act",
+        "/clear",
+        "/compact",
+        "/model",
+        "/rewind",
+        "/status",
+        "/resume",
+        "/init",
+        "/help",
+        "/exit",
+        "/agents",
+        "/topology",
+        "/skills",
     ] {
         assert!(names.contains(expected), "missing builtin: {expected}");
     }

--- a/crates/loopal-tui/tests/suite/skills_cmd_test.rs
+++ b/crates/loopal-tui/tests/suite/skills_cmd_test.rs
@@ -84,8 +84,16 @@ async fn test_skills_cmd_single_skill() {
 #[tokio::test]
 async fn test_skills_cmd_multiple_sorted() {
     let tmp = tempfile::tempdir().unwrap();
-    write_skill(tmp.path(), "deploy.md", "---\ndescription: Deploy app\n---\nDeploy.\n");
-    write_skill(tmp.path(), "audit.md", "---\ndescription: Run audit\n---\nAudit.\n");
+    write_skill(
+        tmp.path(),
+        "deploy.md",
+        "---\ndescription: Deploy app\n---\nDeploy.\n",
+    );
+    write_skill(
+        tmp.path(),
+        "audit.md",
+        "---\ndescription: Run audit\n---\nAudit.\n",
+    );
     let mut app = make_app_with_cwd(tmp.path().to_path_buf());
     let handler = app.command_registry.find("/skills").unwrap();
     handler.execute(&mut app, None).await;
@@ -94,7 +102,10 @@ async fn test_skills_cmd_multiple_sorted() {
     assert!(msg.contains("Loaded skills (2):"));
     let audit_pos = msg.find("/audit").expect("missing /audit");
     let deploy_pos = msg.find("/deploy").expect("missing /deploy");
-    assert!(audit_pos < deploy_pos, "skills should be sorted alphabetically");
+    assert!(
+        audit_pos < deploy_pos,
+        "skills should be sorted alphabetically"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -104,7 +115,11 @@ async fn test_skills_cmd_multiple_sorted() {
 #[tokio::test]
 async fn test_skills_cmd_source_legend() {
     let tmp = tempfile::tempdir().unwrap();
-    write_skill(tmp.path(), "test.md", "---\ndescription: Test\n---\nTest.\n");
+    write_skill(
+        tmp.path(),
+        "test.md",
+        "---\ndescription: Test\n---\nTest.\n",
+    );
     let mut app = make_app_with_cwd(tmp.path().to_path_buf());
     let handler = app.command_registry.find("/skills").unwrap();
     handler.execute(&mut app, None).await;

--- a/crates/loopal-tui/tests/suite/skills_cmd_test.rs
+++ b/crates/loopal-tui/tests/suite/skills_cmd_test.rs
@@ -1,0 +1,127 @@
+/// `/skills` command tests: output formatting, source display, edge cases.
+use std::path::PathBuf;
+
+use loopal_protocol::{ControlCommand, UserQuestionResponse};
+use loopal_session::SessionController;
+use loopal_tui::app::App;
+
+use tokio::sync::mpsc;
+
+fn make_app_with_cwd(cwd: PathBuf) -> App {
+    let (control_tx, _) = mpsc::channel::<ControlCommand>(16);
+    let (perm_tx, _) = mpsc::channel::<bool>(16);
+    let (question_tx, _) = mpsc::channel::<UserQuestionResponse>(16);
+    let session = SessionController::new(
+        "test-model".into(),
+        "act".into(),
+        control_tx,
+        perm_tx,
+        question_tx,
+        Default::default(),
+        std::sync::Arc::new(tokio::sync::watch::channel(0u64).0),
+    );
+    App::new(session, cwd)
+}
+
+fn last_system_message(app: &App) -> String {
+    let state = app.session.lock();
+    state
+        .active_conversation()
+        .messages
+        .last()
+        .expect("expected a system message")
+        .content
+        .clone()
+}
+
+fn write_skill(dir: &std::path::Path, filename: &str, content: &str) {
+    let skills_dir = dir.join(".loopal").join("skills");
+    std::fs::create_dir_all(&skills_dir).unwrap();
+    std::fs::write(skills_dir.join(filename), content).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// No skills
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_skills_cmd_no_skills() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = make_app_with_cwd(tmp.path().to_path_buf());
+    let handler = app.command_registry.find("/skills").unwrap();
+    let effect = handler.execute(&mut app, None).await;
+    assert!(matches!(effect, loopal_tui::command::CommandEffect::Done));
+    assert_eq!(last_system_message(&app), "No skills loaded.");
+}
+
+// ---------------------------------------------------------------------------
+// Single skill from project layer
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_skills_cmd_single_skill() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_skill(
+        tmp.path(),
+        "commit.md",
+        "---\ndescription: Generate git commit\n---\nReview changes.\n",
+    );
+    let mut app = make_app_with_cwd(tmp.path().to_path_buf());
+    let handler = app.command_registry.find("/skills").unwrap();
+    handler.execute(&mut app, None).await;
+
+    let msg = last_system_message(&app);
+    assert!(msg.contains("Loaded skills (1):"));
+    assert!(msg.contains("/commit"));
+    assert!(msg.contains("[project]"));
+    assert!(msg.contains("Generate git commit"));
+}
+
+// ---------------------------------------------------------------------------
+// Multiple skills — sorted, all listed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_skills_cmd_multiple_sorted() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_skill(tmp.path(), "deploy.md", "---\ndescription: Deploy app\n---\nDeploy.\n");
+    write_skill(tmp.path(), "audit.md", "---\ndescription: Run audit\n---\nAudit.\n");
+    let mut app = make_app_with_cwd(tmp.path().to_path_buf());
+    let handler = app.command_registry.find("/skills").unwrap();
+    handler.execute(&mut app, None).await;
+
+    let msg = last_system_message(&app);
+    assert!(msg.contains("Loaded skills (2):"));
+    let audit_pos = msg.find("/audit").expect("missing /audit");
+    let deploy_pos = msg.find("/deploy").expect("missing /deploy");
+    assert!(audit_pos < deploy_pos, "skills should be sorted alphabetically");
+}
+
+// ---------------------------------------------------------------------------
+// Source legend
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_skills_cmd_source_legend() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_skill(tmp.path(), "test.md", "---\ndescription: Test\n---\nTest.\n");
+    let mut app = make_app_with_cwd(tmp.path().to_path_buf());
+    let handler = app.command_registry.find("/skills").unwrap();
+    handler.execute(&mut app, None).await;
+
+    let msg = last_system_message(&app);
+    assert!(msg.contains("Sources: project"));
+}
+
+// ---------------------------------------------------------------------------
+// /skills is builtin, not a skill
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_skills_cmd_is_builtin() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = make_app_with_cwd(tmp.path().to_path_buf());
+    let handler = app.command_registry.find("/skills").unwrap();
+    assert!(!handler.is_skill());
+    assert!(handler.skill_body().is_none());
+}


### PR DESCRIPTION
## Summary
- Add `/skills` builtin command that lists all loaded skills with their source layers
- Shows skill name, origin (global/project/plugin), and description in a formatted table
- Includes source legend summary at the bottom

## Changes
- `crates/loopal-tui/src/command/skills_cmd.rs` — new command handler
- `crates/loopal-tui/src/command/mod.rs` — module registration
- `crates/loopal-tui/src/command/builtin.rs` — builtin registration
- `crates/loopal-tui/tests/suite/skills_cmd_test.rs` — 5 test cases
- `crates/loopal-tui/tests/suite/command_test.rs` — builtin assertion updated
- `crates/loopal-tui/tests/suite.rs` — test module registration

## Test plan
- [x] `bazel test //crates/loopal-tui:loopal-tui_test` passes
- [x] `bazel build --config=clippy` zero warnings
- [x] `bazel build --config=rustfmt` passes
- [ ] CI passes