### PR TITLE
fix(runtime): emit error event on silent SSE stream truncation

### DIFF
--- a/crates/loopal-runtime/src/agent_loop/llm.rs
+++ b/crates/loopal-runtime/src/agent_loop/llm.rs
@@ -77,6 +77,11 @@ impl AgentLoopRunner {
         // which would look like truncation but is intentional.
         if !received_done && !result.stream_error && !cancel.is_cancelled() {
             warn!("SSE stream ended without message_stop — treating as stream truncation");
+            self.emit(AgentEventPayload::Error {
+                message: "Response stream ended unexpectedly — possible network interruption"
+                    .to_string(),
+            })
+            .await?;
             result.stream_error = true;
         }
 


### PR DESCRIPTION
## Summary
- SSE stream silent truncation (connection lost after HTTP 200) only logged a warning, never emitted an error event to the TUI
- User saw no response and immediate idle state after typing "continue"
- Now emits `AgentEventPayload::Error` so the conversation shows a clear "connection lost" message

## Changes
- `crates/loopal-runtime/src/agent_loop/llm.rs`: added `emit(Error)` call in the silent truncation detection path (line 78-86)

## Test plan
- [x] `bazel build //crates/loopal-runtime` passes
- [x] `bazel test //crates/loopal-runtime:loopal-runtime_test` passes
- [x] `bazel build //crates/loopal-runtime --config=clippy` passes (zero warnings)
- [ ] CI passes