### PR TITLE
feat(tui): show session resume info on /exit

### DIFF
--- a/crates/loopal-session/src/controller.rs
+++ b/crates/loopal-session/src/controller.rs
@@ -181,6 +181,10 @@ impl SessionController {
         self.lock().root_session_id = Some(session_id.to_string());
     }
 
+    pub fn root_session_id(&self) -> Option<String> {
+        self.lock().root_session_id.clone()
+    }
+
     /// Drain pending sub-agent refs that need to be persisted.
     /// Returns `(root_session_id, refs)`. The caller is responsible for
     /// writing them to disk via `SessionManager::add_sub_agent`.

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -73,11 +73,15 @@ pub async fn run() -> anyhow::Result<()> {
     // Clean up worktree: remove if no changes, keep otherwise.
     // Note: If the process is killed by SIGKILL or panics, this cleanup won't run.
     // Stale worktrees are caught by `cleanup_stale_worktrees()` on the next startup.
-    if let Some(wt) = worktree {
-        cleanup_session_worktree(&wt);
+    let worktree_kept = match worktree.as_ref() {
+        Some(wt) if !cleanup_session_worktree(wt) => Some(wt),
+        _ => None,
+    };
+    if let Ok(ref session_id) = result {
+        print_resume_info(session_id, worktree_kept);
     }
 
-    result
+    result.map(|_| ())
 }
 
 /// Holds worktree info for cleanup on exit.
@@ -96,14 +100,29 @@ fn create_session_worktree(cwd: &std::path::Path) -> anyhow::Result<SessionWorkt
     Ok(SessionWorktree { info, repo_root })
 }
 
-fn cleanup_session_worktree(wt: &SessionWorktree) {
-    if loopal_git::cleanup_if_clean(&wt.repo_root, &wt.info) {
+fn cleanup_session_worktree(wt: &SessionWorktree) -> bool {
+    let removed = loopal_git::cleanup_if_clean(&wt.repo_root, &wt.info);
+    if removed {
         tracing::info!("session worktree removed (no changes)");
     } else {
         tracing::info!(
             worktree = %wt.info.path.display(),
             "worktree has changes, keeping for manual review"
         );
+    }
+    removed
+}
+
+/// Print session resume instructions to stderr after TUI exits.
+fn print_resume_info(session_id: &str, worktree: Option<&SessionWorktree>) {
+    eprintln!();
+    eprintln!("To resume this session:");
+    eprintln!("  loopal --resume {session_id}");
+    if let Some(wt) = worktree {
+        let display = abbreviate_home(&wt.info.path);
+        eprintln!();
+        eprintln!("Session worktree: {display}");
+        eprintln!("  cd {display} && loopal --resume {session_id}");
     }
 }
 

--- a/src/bootstrap/multiprocess.rs
+++ b/src/bootstrap/multiprocess.rs
@@ -15,7 +15,7 @@ pub async fn run(
     cwd: &std::path::Path,
     config: &loopal_config::ResolvedConfig,
     resume: Option<&str>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<String> {
     info!("starting in Hub mode");
 
     // 1-3. Create Hub + spawn root agent
@@ -72,6 +72,8 @@ pub async fn run(
     }
 
     // 10. Run TUI (bg_store is TUI-local; future: sync from agent via IPC)
+    // Clone before move into run_tui — used after TUI exits to read final session ID.
+    let session_ref = session_ctrl.clone();
     let result = loopal_tui::run_tui(
         session_ctrl,
         cwd.to_path_buf(),
@@ -84,7 +86,14 @@ pub async fn run(
     info!("shutting down agent process");
     let _ = ctx.agent_proc.shutdown().await;
 
-    result
+    // Read the final session ID — may differ from `root_session_id` if the user
+    // switched sessions via `/resume` during the TUI session. The fallback to
+    // `root_session_id` is defensive only; `set_root_session_id` on line 44
+    // guarantees the Option is always Some.
+    let final_session_id = session_ref
+        .root_session_id()
+        .unwrap_or(root_session_id);
+    result.map(|()| final_session_id)
 }
 
 /// Bridge broadcast::Receiver → mpsc::Receiver for TUI compatibility.

--- a/src/bootstrap/multiprocess.rs
+++ b/src/bootstrap/multiprocess.rs
@@ -90,9 +90,7 @@ pub async fn run(
     // switched sessions via `/resume` during the TUI session. The fallback to
     // `root_session_id` is defensive only; `set_root_session_id` on line 44
     // guarantees the Option is always Some.
-    let final_session_id = session_ref
-        .root_session_id()
-        .unwrap_or(root_session_id);
+    let final_session_id = session_ref.root_session_id().unwrap_or(root_session_id);
     result.map(|()| final_session_id)
 }
 


### PR DESCRIPTION
## Summary
- Print session ID and `loopal --resume <id>` command to stderr after TUI exits
- For worktree sessions with uncommitted changes, also display the worktree path and `cd` command
- Reads final session ID from `SessionController` (not startup snapshot) to handle mid-session `/resume` switches correctly

## Changes
- `src/bootstrap/multiprocess.rs` — return `Result<String>` carrying session ID; clone `SessionController` before TUI move to read final state
- `src/bootstrap/mod.rs` — add `print_resume_info()`; preserve worktree cleanup on error path; `cleanup_session_worktree()` returns `bool`
- `crates/loopal-session/src/controller.rs` — add `root_session_id()` getter

## Test plan
- [ ] CI passes
- [ ] `loopal` → `/exit` → stderr shows resume command
- [ ] `loopal --worktree` → make changes → `/exit` → stderr shows worktree path + resume command
- [ ] `loopal --worktree` → no changes → `/exit` → worktree cleaned, no worktree info in output