### PR TITLE
feat(tui): convert /skills to sub-page overlay

### DIFF
--- a/crates/loopal-tui/src/app/mod.rs
+++ b/crates/loopal-tui/src/app/mod.rs
@@ -1,8 +1,10 @@
 mod mcp_page;
+mod skills_page;
 mod status_page;
 mod types;
 
 pub use mcp_page::*;
+pub use skills_page::*;
 pub use status_page::*;
 pub use types::*;
 

--- a/crates/loopal-tui/src/app/skills_page.rs
+++ b/crates/loopal-tui/src/app/skills_page.rs
@@ -1,0 +1,30 @@
+//! State for the `/skills` sub-page — skill list with source info.
+
+/// A single skill entry for display.
+pub struct SkillItem {
+    pub name: String,
+    pub source: String,
+    pub description: String,
+    pub has_arg: bool,
+}
+
+/// Full state for the skills sub-page.
+pub struct SkillsPageState {
+    pub skills: Vec<SkillItem>,
+    pub selected: usize,
+    pub scroll_offset: usize,
+}
+
+impl SkillsPageState {
+    pub fn new(skills: Vec<SkillItem>) -> Self {
+        Self {
+            skills,
+            selected: 0,
+            scroll_offset: 0,
+        }
+    }
+
+    pub fn selected_skill(&self) -> Option<&SkillItem> {
+        self.skills.get(self.selected)
+    }
+}

--- a/crates/loopal-tui/src/app/types.rs
+++ b/crates/loopal-tui/src/app/types.rs
@@ -82,6 +82,7 @@ impl PickerState {
 use super::StatusPageState;
 
 use crate::app::McpPageState;
+use crate::app::SkillsPageState;
 
 /// Active sub-page overlay that replaces the main chat area.
 pub enum SubPage {
@@ -95,6 +96,8 @@ pub enum SubPage {
     StatusPage(StatusPageState),
     /// MCP server status page — list of MCP servers with connection state.
     McpPage(McpPageState),
+    /// Skills page — list of loaded skills with source info.
+    SkillsPage(SkillsPageState),
     /// Background task log viewer — full output of a single bg task.
     BgTaskLog(BgTaskLogState),
 }

--- a/crates/loopal-tui/src/command/skills_cmd.rs
+++ b/crates/loopal-tui/src/command/skills_cmd.rs
@@ -1,11 +1,9 @@
-//! `/skills` command — lists loaded skills and their sources.
-
-use std::collections::BTreeSet;
+//! `/skills` command — opens the skills sub-page.
 
 use async_trait::async_trait;
 
 use super::{CommandEffect, CommandHandler};
-use crate::app::App;
+use crate::app::{App, SkillItem, SkillsPageState, SubPage};
 
 pub struct SkillsCmd;
 
@@ -18,47 +16,28 @@ impl CommandHandler for SkillsCmd {
         "List loaded skills and sources"
     }
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
-        let content = build_skills_list(app);
-        app.session.push_system_message(content);
+        let state = build_skills_page_state(app);
+        app.sub_page = Some(SubPage::SkillsPage(state));
         CommandEffect::Done
     }
 }
 
-fn build_skills_list(app: &App) -> String {
+fn build_skills_page_state(app: &App) -> SkillsPageState {
     let config = match loopal_config::load_config(&app.cwd) {
         Ok(c) => c,
-        Err(_) => return "Failed to load config.".to_string(),
+        Err(_) => return SkillsPageState::new(Vec::new()),
     };
 
-    if config.skills.is_empty() {
-        return "No skills loaded.".to_string();
-    }
-
-    let name_width = config
+    let mut items: Vec<SkillItem> = config
         .skills
         .values()
-        .map(|e| e.skill.name.len())
-        .max()
-        .unwrap_or(8);
-
-    let mut lines = Vec::with_capacity(config.skills.len() + 3);
-    lines.push(format!("Loaded skills ({}):", config.skills.len()));
-
-    let mut sources = BTreeSet::new();
-    for entry in config.skills.values() {
-        let s = &entry.skill;
-        sources.insert(entry.source.to_string());
-        lines.push(format!(
-            "  {:<width$}  [{}]  {}",
-            s.name,
-            entry.source,
-            s.description,
-            width = name_width,
-        ));
-    }
-
-    lines.push(String::new());
-    let legend: Vec<_> = sources.into_iter().collect();
-    lines.push(format!("Sources: {}", legend.join(", ")));
-    lines.join("\n")
+        .map(|entry| SkillItem {
+            name: entry.skill.name.clone(),
+            source: entry.source.to_string(),
+            description: entry.skill.description.clone(),
+            has_arg: entry.skill.has_arg,
+        })
+        .collect();
+    items.sort_by(|a, b| a.name.cmp(&b.name));
+    SkillsPageState::new(items)
 }

--- a/crates/loopal-tui/src/input/mod.rs
+++ b/crates/loopal-tui/src/input/mod.rs
@@ -8,6 +8,7 @@ mod modal;
 pub(crate) mod multiline;
 mod navigation;
 pub(crate) mod paste;
+mod skills_page_keys;
 mod status_page_keys;
 mod sub_page;
 mod sub_page_rewind;

--- a/crates/loopal-tui/src/input/skills_page_keys.rs
+++ b/crates/loopal-tui/src/input/skills_page_keys.rs
@@ -1,0 +1,32 @@
+//! Key handler for the skills sub-page.
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::InputAction;
+use crate::app::{App, SubPage};
+
+pub(super) fn handle_skills_page_key(app: &mut App, key: &KeyEvent) -> InputAction {
+    let state = match app.sub_page.as_mut() {
+        Some(SubPage::SkillsPage(s)) => s,
+        _ => return InputAction::None,
+    };
+
+    match key.code {
+        KeyCode::Esc => {
+            app.sub_page = None;
+            app.last_esc_time = None;
+            InputAction::None
+        }
+        KeyCode::Up => {
+            state.selected = state.selected.saturating_sub(1);
+            InputAction::None
+        }
+        KeyCode::Down => {
+            if !state.skills.is_empty() && state.selected + 1 < state.skills.len() {
+                state.selected += 1;
+            }
+            InputAction::None
+        }
+        _ => InputAction::None,
+    }
+}

--- a/crates/loopal-tui/src/input/sub_page.rs
+++ b/crates/loopal-tui/src/input/sub_page.rs
@@ -4,6 +4,7 @@ use crate::app::{App, PickerState, SubPage};
 
 use super::bg_task_log_keys::handle_bg_task_log_key;
 use super::mcp_page_keys::handle_mcp_page_key;
+use super::skills_page_keys::handle_skills_page_key;
 use super::status_page_keys::handle_status_page_key;
 use super::sub_page_rewind::handle_rewind_picker_key;
 use super::{InputAction, SubPageResult};
@@ -30,6 +31,7 @@ pub(super) fn handle_sub_page_key(app: &mut App, key: &KeyEvent) -> InputAction 
         SubPage::SessionPicker(_) => handle_session_picker_key(app, key),
         SubPage::StatusPage(_) => handle_status_page_key(app, key),
         SubPage::McpPage(_) => handle_mcp_page_key(app, key),
+        SubPage::SkillsPage(_) => handle_skills_page_key(app, key),
         SubPage::BgTaskLog(_) => handle_bg_task_log_key(app, key),
     }
 }

--- a/crates/loopal-tui/src/render.rs
+++ b/crates/loopal-tui/src/render.rs
@@ -49,6 +49,9 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             SubPage::McpPage(s) => {
                 views::mcp_page::render_mcp_page(f, s, layout.picker);
             }
+            SubPage::SkillsPage(s) => {
+                views::skills_page::render_skills_page(f, s, layout.picker);
+            }
             SubPage::BgTaskLog(s) => {
                 views::bg_task_log::render_bg_task_log(f, s, &app.bg_task_details, layout.picker);
             }

--- a/crates/loopal-tui/src/views/mcp_page.rs
+++ b/crates/loopal-tui/src/views/mcp_page.rs
@@ -50,6 +50,11 @@ pub fn render_mcp_page(f: &mut Frame, state: &mut McpPageState, area: Rect) {
 
 fn render_server_list(f: &mut Frame, state: &mut McpPageState, area: Rect) {
     let visible = area.height as usize;
+    if state.selected < state.scroll_offset {
+        state.scroll_offset = state.selected;
+    } else if visible > 0 && state.selected >= state.scroll_offset + visible {
+        state.scroll_offset = state.selected - visible + 1;
+    }
     let max_scroll = state.servers.len().saturating_sub(visible);
     if state.scroll_offset > max_scroll {
         state.scroll_offset = max_scroll;

--- a/crates/loopal-tui/src/views/mod.rs
+++ b/crates/loopal-tui/src/views/mod.rs
@@ -11,6 +11,7 @@ pub mod question_dialog;
 pub mod retry_banner;
 pub mod rewind_picker;
 pub mod separator;
+pub mod skills_page;
 pub mod status_page;
 pub mod tool_confirm;
 pub mod topology_overlay;

--- a/crates/loopal-tui/src/views/skills_page.rs
+++ b/crates/loopal-tui/src/views/skills_page.rs
@@ -1,0 +1,134 @@
+//! Skills sub-page — renders the list of loaded skills and their details.
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+use crate::app::SkillsPageState;
+
+pub fn render_skills_page(f: &mut Frame, state: &mut SkillsPageState, area: Rect) {
+    f.render_widget(Clear, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(Line::from(vec![
+            Span::raw(" "),
+            Span::styled("Skills", Style::default().fg(Color::Cyan).bold()),
+            Span::raw(" "),
+        ]))
+        .title_bottom(build_hint_bar())
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if inner.height < 2 {
+        return;
+    }
+
+    if state.skills.is_empty() {
+        let msg = Paragraph::new("  No skills loaded").style(Style::default().fg(Color::DarkGray));
+        f.render_widget(msg, inner);
+        return;
+    }
+
+    let detail_width = 40.min(inner.width / 2);
+    let list_width = inner.width.saturating_sub(detail_width);
+    let list_area = Rect::new(inner.x, inner.y, list_width, inner.height);
+    let detail_area = Rect::new(inner.x + list_width, inner.y, detail_width, inner.height);
+
+    render_skill_list(f, state, list_area);
+    render_skill_detail(f, state, detail_area);
+}
+
+fn render_skill_list(f: &mut Frame, state: &mut SkillsPageState, area: Rect) {
+    let visible = area.height as usize;
+    if state.selected < state.scroll_offset {
+        state.scroll_offset = state.selected;
+    } else if visible > 0 && state.selected >= state.scroll_offset + visible {
+        state.scroll_offset = state.selected - visible + 1;
+    }
+    let max_scroll = state.skills.len().saturating_sub(visible);
+    if state.scroll_offset > max_scroll {
+        state.scroll_offset = max_scroll;
+    }
+
+    let scroll = state.scroll_offset;
+    for (i, skill) in state.skills.iter().skip(scroll).take(visible).enumerate() {
+        let y = area.y + i as u16;
+        if y >= area.y + area.height {
+            break;
+        }
+        let idx = scroll + i;
+        let is_selected = idx == state.selected;
+        let prefix = if is_selected { "\u{25b8} " } else { "  " };
+        let line = Line::from(vec![
+            Span::styled(prefix, Style::default().fg(Color::Cyan)),
+            Span::styled(
+                &skill.name,
+                if is_selected {
+                    Style::default().fg(Color::White).bold()
+                } else {
+                    Style::default().fg(Color::White)
+                },
+            ),
+            Span::styled(
+                format!("  [{}]", skill.source),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]);
+        f.render_widget(Paragraph::new(line), Rect::new(area.x, y, area.width, 1));
+    }
+}
+
+fn render_skill_detail(f: &mut Frame, state: &SkillsPageState, area: Rect) {
+    let Some(skill) = state.selected_skill() else {
+        return;
+    };
+    if area.height < 4 || area.width < 10 {
+        return;
+    }
+
+    let arg_label = if skill.has_arg { "yes" } else { "no" };
+    let lines: Vec<Line> = vec![
+        detail_row("Name", &skill.name, Color::White),
+        detail_row("Source", &skill.source, Color::White),
+        detail_row("Args", arg_label, Color::Cyan),
+        Line::raw(""),
+        Line::from(Span::styled(
+            " Description:",
+            Style::default().fg(Color::DarkGray).bold(),
+        )),
+        Line::from(Span::styled(
+            format!(" {}", &skill.description),
+            Style::default().fg(Color::White),
+        )),
+    ];
+
+    for (i, line) in lines.iter().take(area.height as usize).enumerate() {
+        let y = area.y + i as u16;
+        f.render_widget(
+            Paragraph::new(line.clone()),
+            Rect::new(area.x, y, area.width, 1),
+        );
+    }
+}
+
+fn detail_row<'a>(label: &'a str, value: &'a str, value_color: Color) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(
+            format!(" {label:<12}"),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(value, Style::default().fg(value_color)),
+    ])
+}
+
+fn build_hint_bar() -> Line<'static> {
+    Line::from(vec![
+        Span::raw(" "),
+        Span::styled("\u{2191}/\u{2193}", Style::default().fg(Color::Cyan)),
+        Span::raw(" navigate  "),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::raw(" close "),
+    ])
+}

--- a/crates/loopal-tui/tests/suite.rs
+++ b/crates/loopal-tui/tests/suite.rs
@@ -74,6 +74,8 @@ mod scroll_test;
 mod skill_render_test;
 #[path = "suite/skills_cmd_test.rs"]
 mod skills_cmd_test;
+#[path = "suite/skills_page_keys_test.rs"]
+mod skills_page_keys_test;
 #[path = "suite/styled_wrap_test.rs"]
 mod styled_wrap_test;
 #[path = "suite/view_switch_panel_lifecycle_test.rs"]

--- a/crates/loopal-tui/tests/suite/skills_cmd_test.rs
+++ b/crates/loopal-tui/tests/suite/skills_cmd_test.rs
@@ -1,9 +1,9 @@
-/// `/skills` command tests: output formatting, source display, edge cases.
+/// `/skills` command tests: opens sub-page, displays correct state.
 use std::path::PathBuf;
 
 use loopal_protocol::{ControlCommand, UserQuestionResponse};
 use loopal_session::SessionController;
-use loopal_tui::app::App;
+use loopal_tui::app::{App, SubPage};
 
 use tokio::sync::mpsc;
 
@@ -23,25 +23,21 @@ fn make_app_with_cwd(cwd: PathBuf) -> App {
     App::new(session, cwd)
 }
 
-fn last_system_message(app: &App) -> String {
-    let state = app.session.lock();
-    state
-        .active_conversation()
-        .messages
-        .last()
-        .expect("expected a system message")
-        .content
-        .clone()
-}
-
 fn write_skill(dir: &std::path::Path, filename: &str, content: &str) {
     let skills_dir = dir.join(".loopal").join("skills");
     std::fs::create_dir_all(&skills_dir).unwrap();
     std::fs::write(skills_dir.join(filename), content).unwrap();
 }
 
+fn extract_skills_page(app: &App) -> &loopal_tui::app::SkillsPageState {
+    match app.sub_page.as_ref().expect("sub_page should be set") {
+        SubPage::SkillsPage(s) => s,
+        _ => panic!("expected SkillsPage variant"),
+    }
+}
+
 // ---------------------------------------------------------------------------
-// No skills
+// No skills — sub-page opens with empty list
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -51,7 +47,8 @@ async fn test_skills_cmd_no_skills() {
     let handler = app.command_registry.find("/skills").unwrap();
     let effect = handler.execute(&mut app, None).await;
     assert!(matches!(effect, loopal_tui::command::CommandEffect::Done));
-    assert_eq!(last_system_message(&app), "No skills loaded.");
+    let state = extract_skills_page(&app);
+    assert!(state.skills.is_empty());
 }
 
 // ---------------------------------------------------------------------------
@@ -70,15 +67,15 @@ async fn test_skills_cmd_single_skill() {
     let handler = app.command_registry.find("/skills").unwrap();
     handler.execute(&mut app, None).await;
 
-    let msg = last_system_message(&app);
-    assert!(msg.contains("Loaded skills (1):"));
-    assert!(msg.contains("/commit"));
-    assert!(msg.contains("[project]"));
-    assert!(msg.contains("Generate git commit"));
+    let state = extract_skills_page(&app);
+    assert_eq!(state.skills.len(), 1);
+    assert_eq!(state.skills[0].name, "/commit");
+    assert_eq!(state.skills[0].source, "project");
+    assert_eq!(state.skills[0].description, "Generate git commit");
 }
 
 // ---------------------------------------------------------------------------
-// Multiple skills — sorted, all listed
+// Multiple skills — sorted alphabetically
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -98,34 +95,10 @@ async fn test_skills_cmd_multiple_sorted() {
     let handler = app.command_registry.find("/skills").unwrap();
     handler.execute(&mut app, None).await;
 
-    let msg = last_system_message(&app);
-    assert!(msg.contains("Loaded skills (2):"));
-    let audit_pos = msg.find("/audit").expect("missing /audit");
-    let deploy_pos = msg.find("/deploy").expect("missing /deploy");
-    assert!(
-        audit_pos < deploy_pos,
-        "skills should be sorted alphabetically"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Source legend
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_skills_cmd_source_legend() {
-    let tmp = tempfile::tempdir().unwrap();
-    write_skill(
-        tmp.path(),
-        "test.md",
-        "---\ndescription: Test\n---\nTest.\n",
-    );
-    let mut app = make_app_with_cwd(tmp.path().to_path_buf());
-    let handler = app.command_registry.find("/skills").unwrap();
-    handler.execute(&mut app, None).await;
-
-    let msg = last_system_message(&app);
-    assert!(msg.contains("Sources: project"));
+    let state = extract_skills_page(&app);
+    assert_eq!(state.skills.len(), 2);
+    assert_eq!(state.skills[0].name, "/audit");
+    assert_eq!(state.skills[1].name, "/deploy");
 }
 
 // ---------------------------------------------------------------------------
@@ -139,4 +112,25 @@ fn test_skills_cmd_is_builtin() {
     let handler = app.command_registry.find("/skills").unwrap();
     assert!(!handler.is_skill());
     assert!(handler.skill_body().is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Selected defaults to 0
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_skills_page_initial_selection() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_skill(
+        tmp.path(),
+        "test.md",
+        "---\ndescription: Test\n---\nTest.\n",
+    );
+    let mut app = make_app_with_cwd(tmp.path().to_path_buf());
+    let handler = app.command_registry.find("/skills").unwrap();
+    handler.execute(&mut app, None).await;
+
+    let state = extract_skills_page(&app);
+    assert_eq!(state.selected, 0);
+    assert_eq!(state.scroll_offset, 0);
 }

--- a/crates/loopal-tui/tests/suite/skills_page_keys_test.rs
+++ b/crates/loopal-tui/tests/suite/skills_page_keys_test.rs
@@ -1,0 +1,109 @@
+/// Skills page key handling tests: Esc close, Up/Down navigation.
+use std::path::PathBuf;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use loopal_protocol::{ControlCommand, UserQuestionResponse};
+use loopal_session::SessionController;
+use loopal_tui::app::{App, SkillItem, SkillsPageState, SubPage};
+use loopal_tui::input::{InputAction, handle_key};
+
+use tokio::sync::mpsc;
+
+fn make_app() -> App {
+    let (control_tx, _) = mpsc::channel::<ControlCommand>(16);
+    let (perm_tx, _) = mpsc::channel::<bool>(16);
+    let (question_tx, _) = mpsc::channel::<UserQuestionResponse>(16);
+    let session = SessionController::new(
+        "test-model".into(),
+        "act".into(),
+        control_tx,
+        perm_tx,
+        question_tx,
+        Default::default(),
+        std::sync::Arc::new(tokio::sync::watch::channel(0u64).0),
+    );
+    App::new(session, PathBuf::from("/tmp"))
+}
+
+fn open_skills_page(app: &mut App, count: usize) {
+    let items: Vec<SkillItem> = (0..count)
+        .map(|i| SkillItem {
+            name: format!("/skill-{i}"),
+            source: "project".into(),
+            description: format!("Skill {i}"),
+            has_arg: false,
+        })
+        .collect();
+    app.sub_page = Some(SubPage::SkillsPage(SkillsPageState::new(items)));
+}
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+fn selected(app: &App) -> usize {
+    match app.sub_page.as_ref().unwrap() {
+        SubPage::SkillsPage(s) => s.selected,
+        _ => panic!("expected SkillsPage"),
+    }
+}
+
+#[test]
+fn test_esc_closes_skills_page() {
+    let mut app = make_app();
+    open_skills_page(&mut app, 3);
+    assert!(app.sub_page.is_some());
+    handle_key(&mut app, key(KeyCode::Esc));
+    assert!(app.sub_page.is_none());
+}
+
+#[test]
+fn test_down_navigates() {
+    let mut app = make_app();
+    open_skills_page(&mut app, 3);
+    assert_eq!(selected(&app), 0);
+    handle_key(&mut app, key(KeyCode::Down));
+    assert_eq!(selected(&app), 1);
+    handle_key(&mut app, key(KeyCode::Down));
+    assert_eq!(selected(&app), 2);
+}
+
+#[test]
+fn test_down_clamps_at_end() {
+    let mut app = make_app();
+    open_skills_page(&mut app, 2);
+    handle_key(&mut app, key(KeyCode::Down));
+    handle_key(&mut app, key(KeyCode::Down));
+    assert_eq!(selected(&app), 1);
+}
+
+#[test]
+fn test_up_navigates() {
+    let mut app = make_app();
+    open_skills_page(&mut app, 3);
+    handle_key(&mut app, key(KeyCode::Down));
+    handle_key(&mut app, key(KeyCode::Down));
+    assert_eq!(selected(&app), 2);
+    handle_key(&mut app, key(KeyCode::Up));
+    assert_eq!(selected(&app), 1);
+}
+
+#[test]
+fn test_up_clamps_at_start() {
+    let mut app = make_app();
+    open_skills_page(&mut app, 3);
+    handle_key(&mut app, key(KeyCode::Up));
+    assert_eq!(selected(&app), 0);
+}
+
+#[test]
+fn test_ctrl_c_closes_skills_page() {
+    let mut app = make_app();
+    open_skills_page(&mut app, 2);
+    let action = handle_key(
+        &mut app,
+        KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+    );
+    assert!(matches!(action, InputAction::None));
+    assert!(app.sub_page.is_none());
+}


### PR DESCRIPTION
## Summary
- Convert `/skills` slash command from inline system message to a full SubPage overlay (left list + right detail pane), matching the `/mcp` page pattern
- Fix scroll tracking bug in both skills and MCP list views — selected item now stays visible when navigating beyond the viewport
- Add `SkillsPageState`, `SkillItem` types, view renderer, key handler, and 11 tests

## Changes
- **New**: `app/skills_page.rs`, `views/skills_page.rs`, `input/skills_page_keys.rs`, `tests/suite/skills_page_keys_test.rs`
- **Modified**: `skills_cmd.rs` (core logic), `types.rs` (SubPage enum), `render.rs`, `sub_page.rs`, `mcp_page.rs` (scroll fix), `mod.rs` files, `suite.rs`, `skills_cmd_test.rs`

## Test plan
- [x] `bazel test //crates/loopal-tui:loopal-tui_test` — all pass
- [x] `bazel build //crates/loopal-tui --config=clippy` — zero warnings
- [x] `bazel build //crates/loopal-tui --config=rustfmt` — pass
- [ ] CI passes