### PR TITLE
fix(ipc): retry initialize() on transient failures

### DIFF
--- a/crates/loopal-agent-client/src/client.rs
+++ b/crates/loopal-agent-client/src/client.rs
@@ -46,17 +46,47 @@ impl AgentClient {
     }
 
     /// Send `initialize` and wait for response.
+    /// Retries on transient failures (e.g. agent process still starting up).
     pub async fn initialize(&self) -> anyhow::Result<Value> {
-        let result = self
-            .connection
-            .send_request(
-                methods::INITIALIZE.name,
-                serde_json::json!({"protocol_version": 1}),
+        use std::time::Duration;
+        const MAX_ATTEMPTS: u32 = 5;
+        const TIMEOUT: Duration = Duration::from_secs(2);
+
+        for attempt in 1..=MAX_ATTEMPTS {
+            match tokio::time::timeout(
+                TIMEOUT,
+                self.connection.send_request(
+                    methods::INITIALIZE.name,
+                    serde_json::json!({"protocol_version": 1}),
+                ),
             )
             .await
-            .map_err(|e| anyhow::anyhow!("initialize failed: {e}"))?;
-        info!("IPC initialized: {result}");
-        Ok(result)
+            {
+                Ok(Ok(result)) => {
+                    info!("IPC initialized: {result}");
+                    return Ok(result);
+                }
+                Ok(Err(e)) if attempt < MAX_ATTEMPTS => {
+                    tracing::warn!(attempt, error = %e, "initialize failed, retrying");
+                    tokio::time::sleep(Duration::from_millis(100 * attempt as u64)).await;
+                }
+                Ok(Err(e)) => {
+                    return Err(anyhow::anyhow!(
+                        "initialize failed after {MAX_ATTEMPTS} attempts: {e}"
+                    ));
+                }
+                Err(_) if attempt < MAX_ATTEMPTS => {
+                    tracing::warn!(attempt, "initialize timed out, retrying");
+                    tokio::time::sleep(Duration::from_millis(100 * attempt as u64)).await;
+                }
+                Err(_) => {
+                    return Err(anyhow::anyhow!(
+                        "initialize timed out after {MAX_ATTEMPTS} attempts"
+                    ));
+                }
+            }
+        }
+        unreachable!()
     }
 
     /// Send `agent/start` to begin the agent loop.


### PR DESCRIPTION
## Summary
- `AgentClient::initialize()` now retries up to 5 times with 2s timeout per attempt and exponential backoff (100ms, 200ms, 300ms, 400ms)
- Fixes flaky `cluster_boots_two_hubs_with_agents` and `cluster_cross_hub_message_delivery` e2e tests that fail on Ubuntu CI

## Root cause
`AgentProcess::spawn_with_env()` returns immediately after creating the OS process, but the agent server may not be ready to handle JSON-RPC requests yet. On resource-constrained CI runners, `initialize()` sends the request before the server loop starts, causing the response oneshot channel to be dropped when the reader loop exits.

## Changes
- `crates/loopal-agent-client/src/client.rs` — `initialize()` method: add timeout + retry loop with exponential backoff. All callers benefit automatically.

## Test plan
- [ ] CI passes (specifically `loopal-meta-hub_e2e` on Ubuntu)