### PR TITLE
fix(sandbox): unrestrict signal, process-info and add mach-register

### DIFF
--- a/crates/loopal-sandbox/src/platform/seatbelt_base.sbpl
+++ b/crates/loopal-sandbox/src/platform/seatbelt_base.sbpl
@@ -23,8 +23,17 @@
 ; --- Process ---
 (allow process-exec)
 (allow process-fork)
-(allow signal (target same-sandbox))
-(allow process-info* (target same-sandbox))
+; signal / process-info are unrestricted: restricting them to same-sandbox
+; provides no security when process-exec/process-fork are already open —
+; a child can trivially escape by spawning a helper outside the sandbox.
+(allow signal)
+(allow process-info*)
+
+; --- Mach service registration ---
+; GUI apps (Chrome, browsers, etc.) need to register Mach ports via
+; bootstrap_check_in. Blocking mach-register while allowing process-exec
+; breaks app launches without adding security.
+(allow mach-register)
 
 ; --- System info (read-only, no security impact) ---
 (allow sysctl-read)

--- a/crates/loopal-sandbox/tests/suite/platform_macos_test.rs
+++ b/crates/loopal-sandbox/tests/suite/platform_macos_test.rs
@@ -76,11 +76,12 @@ mod macos_tests {
     fn system_access_rules_are_permissive() {
         let profile = generate_seatbelt_profile(&workspace_policy());
 
-        // Process rules
+        // Process rules — unrestricted (same rationale as process-exec)
         assert!(profile.contains("(allow process-exec)"));
         assert!(profile.contains("(allow process-fork)"));
-        assert!(profile.contains("(allow signal (target same-sandbox))"));
-        assert!(profile.contains("(allow process-info* (target same-sandbox))"));
+        assert!(profile.contains("(allow signal)"));
+        assert!(profile.contains("(allow process-info*)"));
+        assert!(profile.contains("(allow mach-register)"));
 
         // Blanket allows (no whitelists)
         assert!(profile.contains("(allow sysctl-read)"));


### PR DESCRIPTION
## Summary
- Unrestrict `signal` and `process-info*` in Seatbelt profile (were limited to `same-sandbox`, blocking `killall` and process enumeration for external processes)
- Add `(allow mach-register)` to fix `bootstrap_check_in` Permission Denied for GUI apps (Chrome, browsers)
- These restrictions had no security value since `process-exec`/`process-fork` are already unrestricted

## Changes
- `crates/loopal-sandbox/src/platform/seatbelt_base.sbpl` — relaxed 3 Seatbelt rules
- `crates/loopal-sandbox/tests/suite/platform_macos_test.rs` — updated assertions

## Test plan
- [x] `bazel test //crates/loopal-sandbox:loopal-sandbox_test` passes
- [ ] CI passes