### PR TITLE
feat(mcp): .mcp.json config support and disconnect action in /mcp page

### DIFF
--- a/crates/loopal-config/src/lib.rs
+++ b/crates/loopal-config/src/lib.rs
@@ -5,6 +5,7 @@ pub mod housekeeping;
 pub mod layer;
 pub mod loader;
 pub mod locations;
+pub mod mcp_json;
 pub mod pipeline;
 pub mod plugin;
 pub mod resolved;

--- a/crates/loopal-config/src/loader.rs
+++ b/crates/loopal-config/src/loader.rs
@@ -124,6 +124,7 @@ pub(crate) fn read_optional_text(path: &Path) -> Option<String> {
 /// ```text
 /// <dir>/
 /// ├── settings.json     # settings + mcp_servers + hooks
+/// ├── .mcp.json         # MCP servers (industry-standard format, overrides settings.json)
 /// ├── skills/           # skill markdown files
 /// └── LOOPAL.md         # instruction text
 /// ```
@@ -147,6 +148,12 @@ pub fn load_layer_from_dir(
         layer.mcp_servers = mcp;
         layer.hooks = hooks;
         layer.settings = settings_value;
+    }
+
+    // .mcp.json — industry-standard format, overrides settings.json by name
+    let mcp_json = crate::mcp_json::load_mcp_json(&dir.join(".mcp.json"));
+    for (name, config) in mcp_json {
+        layer.mcp_servers.insert(name, config);
     }
 
     // skills/ directory

--- a/crates/loopal-config/src/mcp_json.rs
+++ b/crates/loopal-config/src/mcp_json.rs
@@ -1,0 +1,108 @@
+//! Parse industry-standard `.mcp.json` files into `McpServerConfig` entries.
+//!
+//! Format: `{ "mcpServers": { "<name>": { "command": "...", ... } } }`
+//! - Servers without a `type` field default to `stdio`.
+//! - Loopal extensions (`enabled`, `timeout_ms`) are optional.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+use crate::settings::McpServerConfig;
+
+#[derive(Deserialize)]
+struct McpJsonFile {
+    #[serde(default, rename = "mcpServers")]
+    servers: IndexMap<String, McpJsonEntry>,
+}
+
+#[derive(Deserialize)]
+struct McpJsonEntry {
+    #[serde(rename = "type")]
+    server_type: Option<String>,
+    // stdio
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: HashMap<String, String>,
+    // streamable-http
+    url: Option<String>,
+    #[serde(default)]
+    headers: HashMap<String, String>,
+    // Loopal extensions
+    enabled: Option<bool>,
+    timeout_ms: Option<u64>,
+}
+
+const DEFAULT_MCP_TIMEOUT: u64 = 30_000;
+
+/// Load `.mcp.json` from `path`, returning parsed servers.
+///
+/// Missing file or parse errors are handled gracefully (logged, not fatal).
+pub fn load_mcp_json(path: &Path) -> IndexMap<String, McpServerConfig> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return IndexMap::new(),
+        Err(e) => {
+            tracing::warn!(path = %path.display(), "failed to read .mcp.json: {e}");
+            return IndexMap::new();
+        }
+    };
+
+    let file: McpJsonFile = match serde_json::from_str(&contents) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!(path = %path.display(), "invalid .mcp.json: {e}");
+            return IndexMap::new();
+        }
+    };
+
+    let mut result = IndexMap::new();
+    for (name, entry) in file.servers {
+        if let Some(config) = convert_entry(&name, entry) {
+            result.insert(name, config);
+        }
+    }
+    result
+}
+
+fn convert_entry(name: &str, entry: McpJsonEntry) -> Option<McpServerConfig> {
+    let enabled = entry.enabled.unwrap_or(true);
+    let timeout_ms = entry.timeout_ms.unwrap_or(DEFAULT_MCP_TIMEOUT);
+    let server_type = entry.server_type.as_deref().unwrap_or("stdio");
+
+    match server_type {
+        "stdio" => {
+            let Some(command) = entry.command else {
+                tracing::warn!(server = %name, "stdio server missing 'command', skipping");
+                return None;
+            };
+            Some(McpServerConfig::Stdio {
+                command,
+                args: entry.args,
+                env: entry.env,
+                enabled,
+                timeout_ms,
+            })
+        }
+        "streamable-http" => {
+            let Some(url) = entry.url else {
+                tracing::warn!(server = %name, "streamable-http server missing 'url', skipping");
+                return None;
+            };
+            Some(McpServerConfig::StreamableHttp {
+                url,
+                headers: entry.headers,
+                enabled,
+                timeout_ms,
+            })
+        }
+        other => {
+            tracing::warn!(server = %name, r#type = %other, "unknown server type, skipping");
+            None
+        }
+    }
+}

--- a/crates/loopal-config/tests/suite.rs
+++ b/crates/loopal-config/tests/suite.rs
@@ -13,6 +13,8 @@ mod loader_settings_test;
 mod loader_unit_test;
 #[path = "suite/locations_test.rs"]
 mod locations_test;
+#[path = "suite/mcp_json_test.rs"]
+mod mcp_json_test;
 #[path = "suite/plugin_test.rs"]
 mod plugin_test;
 #[path = "suite/resolver_edge_test.rs"]

--- a/crates/loopal-config/tests/suite/mcp_json_test.rs
+++ b/crates/loopal-config/tests/suite/mcp_json_test.rs
@@ -1,0 +1,188 @@
+use std::io::Write;
+
+use loopal_config::McpServerConfig;
+use loopal_config::mcp_json::load_mcp_json;
+use tempfile::NamedTempFile;
+
+fn write_temp(content: &str) -> NamedTempFile {
+    let mut f = NamedTempFile::new().unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+    f
+}
+
+#[test]
+fn stdio_implicit_type() {
+    let f =
+        write_temp(r#"{ "mcpServers": { "gh": { "command": "npx", "args": ["-y", "server"] } } }"#);
+    let result = load_mcp_json(f.path());
+    assert_eq!(result.len(), 1);
+    match &result["gh"] {
+        McpServerConfig::Stdio {
+            command,
+            args,
+            enabled,
+            ..
+        } => {
+            assert_eq!(command, "npx");
+            assert_eq!(args, &["-y", "server"]);
+            assert!(*enabled);
+        }
+        _ => panic!("expected Stdio variant"),
+    }
+}
+
+#[test]
+fn streamable_http_explicit_type() {
+    let f = write_temp(
+        r#"{ "mcpServers": { "remote": { "type": "streamable-http", "url": "https://mcp.example.com", "headers": { "Authorization": "Bearer tok" } } } }"#,
+    );
+    let result = load_mcp_json(f.path());
+    assert_eq!(result.len(), 1);
+    match &result["remote"] {
+        McpServerConfig::StreamableHttp {
+            url,
+            headers,
+            enabled,
+            timeout_ms,
+            ..
+        } => {
+            assert_eq!(url, "https://mcp.example.com");
+            assert_eq!(headers.get("Authorization").unwrap(), "Bearer tok");
+            assert!(*enabled);
+            assert_eq!(*timeout_ms, 30_000);
+        }
+        _ => panic!("expected StreamableHttp variant"),
+    }
+}
+
+#[test]
+fn custom_enabled_and_timeout() {
+    let f = write_temp(
+        r#"{ "mcpServers": { "slow": { "command": "slow-server", "enabled": false, "timeout_ms": 60000 } } }"#,
+    );
+    let result = load_mcp_json(f.path());
+    match &result["slow"] {
+        McpServerConfig::Stdio {
+            enabled,
+            timeout_ms,
+            ..
+        } => {
+            assert!(!*enabled);
+            assert_eq!(*timeout_ms, 60_000);
+        }
+        _ => panic!("expected Stdio variant"),
+    }
+}
+
+#[test]
+fn missing_command_skipped() {
+    let f = write_temp(r#"{ "mcpServers": { "bad": { "args": ["--help"] } } }"#);
+    let result = load_mcp_json(f.path());
+    assert!(result.is_empty());
+}
+
+#[test]
+fn missing_url_skipped() {
+    let f = write_temp(r#"{ "mcpServers": { "bad": { "type": "streamable-http" } } }"#);
+    let result = load_mcp_json(f.path());
+    assert!(result.is_empty());
+}
+
+#[test]
+fn unknown_type_skipped() {
+    let f = write_temp(r#"{ "mcpServers": { "x": { "type": "grpc", "command": "cmd" } } }"#);
+    let result = load_mcp_json(f.path());
+    assert!(result.is_empty());
+}
+
+#[test]
+fn missing_file_returns_empty() {
+    let result = load_mcp_json(std::path::Path::new("/nonexistent/.mcp.json"));
+    assert!(result.is_empty());
+}
+
+#[test]
+fn invalid_json_returns_empty() {
+    let f = write_temp("not json");
+    let result = load_mcp_json(f.path());
+    assert!(result.is_empty());
+}
+
+#[test]
+fn empty_servers_returns_empty() {
+    let f = write_temp(r#"{ "mcpServers": {} }"#);
+    let result = load_mcp_json(f.path());
+    assert!(result.is_empty());
+}
+
+#[test]
+fn multiple_servers_parsed() {
+    let f = write_temp(
+        r#"{
+        "mcpServers": {
+            "a": { "command": "cmd-a" },
+            "b": { "type": "streamable-http", "url": "https://b.com" }
+        }
+    }"#,
+    );
+    let result = load_mcp_json(f.path());
+    assert_eq!(result.len(), 2);
+    assert!(matches!(result["a"], McpServerConfig::Stdio { .. }));
+    assert!(matches!(
+        result["b"],
+        McpServerConfig::StreamableHttp { .. }
+    ));
+}
+
+#[test]
+fn env_field_parsed() {
+    let f =
+        write_temp(r#"{ "mcpServers": { "s": { "command": "srv", "env": { "TOKEN": "abc" } } } }"#);
+    let result = load_mcp_json(f.path());
+    match &result["s"] {
+        McpServerConfig::Stdio { env, .. } => {
+            assert_eq!(env.get("TOKEN").unwrap(), "abc");
+        }
+        _ => panic!("expected Stdio"),
+    }
+}
+
+// --- Integration: .mcp.json overrides settings.json within a single layer ---
+
+#[test]
+fn layer_mcp_json_overrides_and_adds() {
+    use loopal_config::layer::LayerSource;
+    use loopal_config::loader::load_layer_from_dir;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    std::fs::write(
+        dir.join("settings.json"),
+        r#"{ "mcp_servers": {
+            "shared": { "type": "stdio", "command": "old-cmd" },
+            "only_settings": { "type": "stdio", "command": "s" }
+        } }"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        dir.join(".mcp.json"),
+        r#"{ "mcpServers": {
+            "shared": { "command": "new-cmd" },
+            "only_mcp_json": { "command": "m" }
+        } }"#,
+    )
+    .unwrap();
+
+    let layer = load_layer_from_dir(dir, LayerSource::Project, None).unwrap();
+    assert_eq!(layer.mcp_servers.len(), 3);
+    // .mcp.json overrides same-name server from settings.json
+    match &layer.mcp_servers["shared"] {
+        McpServerConfig::Stdio { command, .. } => assert_eq!(command, "new-cmd"),
+        _ => panic!("expected Stdio"),
+    }
+    // Both unique servers are present
+    assert!(layer.mcp_servers.contains_key("only_settings"));
+    assert!(layer.mcp_servers.contains_key("only_mcp_json"));
+}

--- a/crates/loopal-kernel/src/kernel/mcp.rs
+++ b/crates/loopal-kernel/src/kernel/mcp.rs
@@ -48,4 +48,12 @@ impl Kernel {
             self.tool_registry.register(Box::new(adapter));
         }
     }
+
+    /// Remove tools by name from the ToolRegistry.
+    pub fn unregister_tools(&self, names: &[String]) {
+        for name in names {
+            info!(tool = %name, "unregistering MCP tool");
+            self.tool_registry.unregister(name);
+        }
+    }
 }

--- a/crates/loopal-mcp/src/manager_query.rs
+++ b/crates/loopal-mcp/src/manager_query.rs
@@ -103,6 +103,23 @@ impl McpManager {
         Ok(())
     }
 
+    /// Disconnect a specific connection by name. Returns removed tool names.
+    pub async fn disconnect_connection(&mut self, name: &str) -> Result<Vec<String>, McpError> {
+        let conn = self
+            .connections
+            .get_mut(name)
+            .ok_or_else(|| McpError::ServerNotFound(name.to_string()))?;
+        let removed: Vec<String> = self
+            .tool_map
+            .iter()
+            .filter(|(_, srv)| srv.as_str() == name)
+            .map(|(tool, _)| tool.clone())
+            .collect();
+        self.tool_map.retain(|_, srv| srv != name);
+        conn.disconnect().await;
+        Ok(removed)
+    }
+
     /// Restart a specific connection by name (manual restart, no backoff).
     ///
     /// Skips if the connection is already connected (guards against concurrent

--- a/crates/loopal-protocol/src/control.rs
+++ b/crates/loopal-protocol/src/control.rs
@@ -31,4 +31,6 @@ pub enum ControlCommand {
     QueryMcpStatus,
     /// Reconnect a specific MCP server by name.
     McpReconnect { server: String },
+    /// Disconnect a specific MCP server by name.
+    McpDisconnect { server: String },
 }

--- a/crates/loopal-protocol/tests/suite/control_test.rs
+++ b/crates/loopal-protocol/tests/suite/control_test.rs
@@ -77,3 +77,17 @@ fn test_control_command_resume_session_serde_roundtrip() {
         panic!("expected ResumeSession after roundtrip");
     }
 }
+
+#[test]
+fn test_control_command_mcp_disconnect_serde_roundtrip() {
+    let cmd = ControlCommand::McpDisconnect {
+        server: "my-mcp".to_string(),
+    };
+    let json = serde_json::to_string(&cmd).unwrap();
+    let deserialized: ControlCommand = serde_json::from_str(&json).unwrap();
+    if let ControlCommand::McpDisconnect { server } = deserialized {
+        assert_eq!(server, "my-mcp");
+    } else {
+        panic!("expected McpDisconnect after roundtrip");
+    }
+}

--- a/crates/loopal-runtime/src/agent_loop/input_control.rs
+++ b/crates/loopal-runtime/src/agent_loop/input_control.rs
@@ -76,6 +76,9 @@ impl AgentLoopRunner {
             ControlCommand::McpReconnect { server } => {
                 self.handle_mcp_reconnect(server).await?;
             }
+            ControlCommand::McpDisconnect { server } => {
+                self.handle_mcp_disconnect(server).await?;
+            }
         }
         Ok(())
     }

--- a/crates/loopal-runtime/src/agent_loop/input_mcp.rs
+++ b/crates/loopal-runtime/src/agent_loop/input_mcp.rs
@@ -1,4 +1,4 @@
-//! MCP control command handlers — status query and reconnect.
+//! MCP control command handlers — status query, reconnect, and disconnect.
 
 use std::collections::HashMap;
 
@@ -38,6 +38,23 @@ impl AgentLoopRunner {
             .kernel
             .register_mcp_tools_for_server(&server)
             .await;
+        let snapshots = self.collect_mcp_snapshots().await;
+        self.emit(AgentEventPayload::McpStatusReport { servers: snapshots })
+            .await
+    }
+
+    pub(super) async fn handle_mcp_disconnect(&mut self, server: String) -> Result<()> {
+        info!(server = %server, "disconnecting MCP server");
+        let mgr = self.params.deps.kernel.mcp_manager();
+        let result = mgr.write().await.disconnect_connection(&server).await;
+        match result {
+            Ok(removed_tools) => {
+                self.params.deps.kernel.unregister_tools(&removed_tools);
+            }
+            Err(e) => {
+                error!(server = %server, error = %e, "MCP disconnect failed");
+            }
+        }
         let snapshots = self.collect_mcp_snapshots().await;
         self.emit(AgentEventPayload::McpStatusReport { servers: snapshots })
             .await

--- a/crates/loopal-tui/src/app/mcp_page.rs
+++ b/crates/loopal-tui/src/app/mcp_page.rs
@@ -1,4 +1,4 @@
-//! State for the `/mcp` sub-page — MCP server status list.
+//! State for the `/mcp` sub-page — MCP server status list with action menu.
 
 use loopal_protocol::McpServerSnapshot;
 
@@ -9,6 +9,31 @@ pub struct McpPageState {
     pub scroll_offset: usize,
     /// `false` until the first McpStatusReport event has been received.
     pub loaded: bool,
+    /// When set, an action menu is open for the selected server.
+    pub action_menu: Option<ActionMenu>,
+}
+
+/// Inline action menu for an MCP server.
+pub struct ActionMenu {
+    pub server_name: String,
+    pub options: Vec<McpAction>,
+    pub cursor: usize,
+}
+
+/// Actions available in the MCP server action menu.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpAction {
+    Reconnect,
+    Disconnect,
+}
+
+impl McpAction {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Reconnect => "Reconnect",
+            Self::Disconnect => "Disconnect",
+        }
+    }
 }
 
 impl McpPageState {
@@ -19,10 +44,44 @@ impl McpPageState {
             selected: 0,
             scroll_offset: 0,
             loaded,
+            action_menu: None,
         }
     }
 
     pub fn selected_server(&self) -> Option<&McpServerSnapshot> {
         self.servers.get(self.selected)
+    }
+
+    pub fn open_action_menu(&mut self) {
+        let Some(server) = self.selected_server() else {
+            return;
+        };
+        let name = server.name.clone();
+        let is_connected = server.status == "connected";
+        let mut options = vec![McpAction::Reconnect];
+        if is_connected {
+            options.insert(0, McpAction::Disconnect);
+        }
+        self.action_menu = Some(ActionMenu {
+            server_name: name,
+            options,
+            cursor: 0,
+        });
+    }
+}
+
+impl ActionMenu {
+    pub fn cursor_up(&mut self) {
+        self.cursor = self.cursor.saturating_sub(1);
+    }
+
+    pub fn cursor_down(&mut self) {
+        if self.cursor + 1 < self.options.len() {
+            self.cursor += 1;
+        }
+    }
+
+    pub fn selected_action(&self) -> Option<McpAction> {
+        self.options.get(self.cursor).copied()
     }
 }

--- a/crates/loopal-tui/src/input/actions.rs
+++ b/crates/loopal-tui/src/input/actions.rs
@@ -68,4 +68,6 @@ pub enum InputAction {
     PasteRequested,
     /// Reconnect an MCP server by name
     McpReconnect(String),
+    /// Disconnect an MCP server by name
+    McpDisconnect(String),
 }

--- a/crates/loopal-tui/src/input/mcp_page_keys.rs
+++ b/crates/loopal-tui/src/input/mcp_page_keys.rs
@@ -3,6 +3,7 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
 use super::InputAction;
+use crate::app::McpAction;
 use crate::app::{App, SubPage};
 
 pub(super) fn handle_mcp_page_key(app: &mut App, key: &KeyEvent) -> InputAction {
@@ -10,6 +11,10 @@ pub(super) fn handle_mcp_page_key(app: &mut App, key: &KeyEvent) -> InputAction 
         Some(SubPage::McpPage(s)) => s,
         _ => return InputAction::None,
     };
+
+    if state.action_menu.is_some() {
+        return handle_menu_key(app, key);
+    }
 
     match key.code {
         KeyCode::Esc => {
@@ -28,11 +33,45 @@ pub(super) fn handle_mcp_page_key(app: &mut App, key: &KeyEvent) -> InputAction 
             InputAction::None
         }
         KeyCode::Enter => {
-            if let Some(server) = state.selected_server() {
-                let name = server.name.clone();
-                return InputAction::McpReconnect(name);
-            }
+            state.open_action_menu();
             InputAction::None
+        }
+        _ => InputAction::None,
+    }
+}
+
+fn handle_menu_key(app: &mut App, key: &KeyEvent) -> InputAction {
+    let state = match app.sub_page.as_mut() {
+        Some(SubPage::McpPage(s)) => s,
+        _ => return InputAction::None,
+    };
+    let menu = match state.action_menu.as_mut() {
+        Some(m) => m,
+        None => return InputAction::None,
+    };
+
+    match key.code {
+        KeyCode::Esc => {
+            state.action_menu = None;
+            InputAction::None
+        }
+        KeyCode::Up => {
+            menu.cursor_up();
+            InputAction::None
+        }
+        KeyCode::Down => {
+            menu.cursor_down();
+            InputAction::None
+        }
+        KeyCode::Enter => {
+            let action = menu.selected_action();
+            let name = menu.server_name.clone();
+            state.action_menu = None;
+            match action {
+                Some(McpAction::Reconnect) => InputAction::McpReconnect(name),
+                Some(McpAction::Disconnect) => InputAction::McpDisconnect(name),
+                None => InputAction::None,
+            }
         }
         _ => InputAction::None,
     }

--- a/crates/loopal-tui/src/key_dispatch.rs
+++ b/crates/loopal-tui/src/key_dispatch.rs
@@ -32,27 +32,11 @@ pub(crate) async fn handle_key_action(
             false
         }
         InputAction::ToolApprove => {
-            let has = app
-                .session
-                .lock()
-                .active_conversation()
-                .pending_permission
-                .is_some();
-            if has {
-                app.session.approve_permission().await;
-            }
+            crate::key_dispatch_ops::tool_approve(app).await;
             false
         }
         InputAction::ToolDeny => {
-            let has = app
-                .session
-                .lock()
-                .active_conversation()
-                .pending_permission
-                .is_some();
-            if has {
-                app.session.deny_permission().await;
-            }
+            crate::key_dispatch_ops::tool_deny(app).await;
             false
         }
         InputAction::Interrupt => {
@@ -197,6 +181,10 @@ pub(crate) async fn handle_key_action(
         }
         InputAction::McpReconnect(server) => {
             crate::key_dispatch_ops::mcp_reconnect(app, server).await;
+            false
+        }
+        InputAction::McpDisconnect(server) => {
+            crate::key_dispatch_ops::mcp_disconnect(app, server).await;
             false
         }
         InputAction::None => false,

--- a/crates/loopal-tui/src/key_dispatch_ops.rs
+++ b/crates/loopal-tui/src/key_dispatch_ops.rs
@@ -11,6 +11,30 @@ use crate::views::bg_tasks_panel;
 // Re-export panel operations used by key_dispatch and lib.rs dispatch_ops.
 pub use crate::panel_ops::{cycle_panel_focus, enter_panel, panel_tab};
 
+pub(crate) async fn tool_approve(app: &mut App) {
+    let has = app
+        .session
+        .lock()
+        .active_conversation()
+        .pending_permission
+        .is_some();
+    if has {
+        app.session.approve_permission().await;
+    }
+}
+
+pub(crate) async fn tool_deny(app: &mut App) {
+    let has = app
+        .session
+        .lock()
+        .active_conversation()
+        .pending_permission
+        .is_some();
+    if has {
+        app.session.deny_permission().await;
+    }
+}
+
 pub(crate) async fn push_to_inbox(app: &mut App, content: UserContent) {
     // For skill invocations, record the slash command (not the expanded body)
     let history_text = match &content.skill_info {
@@ -74,6 +98,14 @@ pub(crate) async fn mcp_reconnect(app: &mut App, server: String) {
     let target = app.session.lock().active_view.clone();
     app.session
         .send_control(target, ControlCommand::McpReconnect { server })
+        .await;
+}
+
+/// Request disconnect of an MCP server.
+pub(crate) async fn mcp_disconnect(app: &mut App, server: String) {
+    let target = app.session.lock().active_view.clone();
+    app.session
+        .send_control(target, ControlCommand::McpDisconnect { server })
         .await;
 }
 

--- a/crates/loopal-tui/src/tui_loop.rs
+++ b/crates/loopal-tui/src/tui_loop.rs
@@ -113,6 +113,7 @@ fn refresh_mcp_page(app: &mut App) {
         state.scroll_offset = state.scroll_offset.min(servers.len().saturating_sub(1));
         state.servers = servers;
         state.loaded = true;
+        state.action_menu = None;
     }
 }
 

--- a/crates/loopal-tui/src/views/mcp_action_menu.rs
+++ b/crates/loopal-tui/src/views/mcp_action_menu.rs
@@ -1,0 +1,62 @@
+//! Action menu overlay for MCP server operations (disconnect / reconnect).
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+use crate::app::McpPageState;
+
+pub fn render(f: &mut Frame, state: &McpPageState, area: Rect) {
+    let Some(menu) = &state.action_menu else {
+        return;
+    };
+    let menu_h = menu.options.len() as u16 + 2;
+    let menu_w: u16 = 22;
+    let x = area.x + (area.width.saturating_sub(menu_w)) / 2;
+    let y = area.y + (area.height.saturating_sub(menu_h)) / 2;
+    let menu_area = Rect::new(x, y, menu_w.min(area.width), menu_h.min(area.height));
+
+    f.render_widget(Clear, menu_area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(Line::from(Span::styled(
+            " Action ",
+            Style::default().fg(Color::Cyan).bold(),
+        )))
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(menu_area);
+    f.render_widget(block, menu_area);
+
+    for (i, action) in menu.options.iter().enumerate() {
+        let row_y = inner.y + i as u16;
+        if row_y >= inner.y + inner.height {
+            break;
+        }
+        let is_sel = i == menu.cursor;
+        let prefix = if is_sel { "\u{25b8} " } else { "  " };
+        let style = if is_sel {
+            Style::default().fg(Color::White).bold()
+        } else {
+            Style::default().fg(Color::Gray)
+        };
+        let line = Line::from(vec![
+            Span::styled(prefix, Style::default().fg(Color::Cyan)),
+            Span::styled(action.label(), style),
+        ]);
+        f.render_widget(
+            Paragraph::new(line),
+            Rect::new(inner.x, row_y, inner.width, 1),
+        );
+    }
+}
+
+pub fn hint_bar() -> Line<'static> {
+    Line::from(vec![
+        Span::raw(" "),
+        Span::styled("\u{2191}/\u{2193}", Style::default().fg(Color::Cyan)),
+        Span::raw(" select  "),
+        Span::styled("Enter", Style::default().fg(Color::Green)),
+        Span::raw(" confirm  "),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::raw(" cancel "),
+    ])
+}

--- a/crates/loopal-tui/src/views/mcp_page.rs
+++ b/crates/loopal-tui/src/views/mcp_page.rs
@@ -5,9 +5,12 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
 use crate::app::McpPageState;
 
+use super::mcp_action_menu;
+
 pub fn render_mcp_page(f: &mut Frame, state: &mut McpPageState, area: Rect) {
     f.render_widget(Clear, area);
 
+    let has_menu = state.action_menu.is_some();
     let block = Block::default()
         .borders(Borders::ALL)
         .title(Line::from(vec![
@@ -15,7 +18,11 @@ pub fn render_mcp_page(f: &mut Frame, state: &mut McpPageState, area: Rect) {
             Span::styled("MCP Servers", Style::default().fg(Color::Cyan).bold()),
             Span::raw(" "),
         ]))
-        .title_bottom(build_hint_bar())
+        .title_bottom(if has_menu {
+            mcp_action_menu::hint_bar()
+        } else {
+            build_hint_bar()
+        })
         .border_style(Style::default().fg(Color::DarkGray));
 
     let inner = block.inner(area);
@@ -46,6 +53,10 @@ pub fn render_mcp_page(f: &mut Frame, state: &mut McpPageState, area: Rect) {
 
     render_server_list(f, state, list_area);
     render_server_detail(f, state, detail_area);
+
+    if state.action_menu.is_some() {
+        mcp_action_menu::render(f, state, inner);
+    }
 }
 
 fn render_server_list(f: &mut Frame, state: &mut McpPageState, area: Rect) {
@@ -72,7 +83,10 @@ fn render_server_list(f: &mut Frame, state: &mut McpPageState, area: Rect) {
         let prefix = if is_selected { "\u{25b8} " } else { "  " };
         let line = Line::from(vec![
             Span::styled(prefix, Style::default().fg(Color::Cyan)),
-            Span::styled(status_icon, status_style(&server.status)),
+            Span::styled(
+                status_icon,
+                Style::default().fg(status_color(&server.status)),
+            ),
             Span::raw(" "),
             Span::styled(
                 &server.name,
@@ -157,28 +171,19 @@ fn detail_row<'a>(label: &'a str, value: &'a str, value_color: Color) -> Line<'a
 }
 
 fn status_indicator(status: &str) -> &'static str {
-    if status == "connected" {
-        "\u{25cf}" // ● filled = connected
-    } else if status.starts_with("failed") {
-        "\u{2717}" // ✗ cross = failed
-    } else {
-        "\u{25cb}" // ○ hollow = disconnected/connecting
+    match () {
+        _ if status == "connected" => "\u{25cf}",
+        _ if status.starts_with("failed") => "\u{2717}",
+        _ => "\u{25cb}",
     }
 }
 
-fn status_style(status: &str) -> Style {
-    Style::default().fg(status_color(status))
-}
-
 fn status_color(status: &str) -> Color {
-    if status == "connected" {
-        Color::Green
-    } else if status.starts_with("failed") {
-        Color::Red
-    } else if status == "connecting" {
-        Color::Yellow
-    } else {
-        Color::DarkGray
+    match () {
+        _ if status == "connected" => Color::Green,
+        _ if status.starts_with("failed") => Color::Red,
+        _ if status == "connecting" => Color::Yellow,
+        _ => Color::DarkGray,
     }
 }
 
@@ -188,7 +193,7 @@ fn build_hint_bar() -> Line<'static> {
         Span::styled("\u{2191}/\u{2193}", Style::default().fg(Color::Cyan)),
         Span::raw(" navigate  "),
         Span::styled("Enter", Style::default().fg(Color::Green)),
-        Span::raw(" reconnect  "),
+        Span::raw(" actions  "),
         Span::styled("Esc", Style::default().fg(Color::Yellow)),
         Span::raw(" close "),
     ])

--- a/crates/loopal-tui/src/views/mod.rs
+++ b/crates/loopal-tui/src/views/mod.rs
@@ -4,6 +4,7 @@ pub mod bg_tasks_panel;
 pub mod breadcrumb;
 pub mod command_menu;
 pub mod input_view;
+pub mod mcp_action_menu;
 pub mod mcp_page;
 pub mod picker;
 pub mod progress;

--- a/crates/loopal-tui/tests/suite/mcp_page_keys_test.rs
+++ b/crates/loopal-tui/tests/suite/mcp_page_keys_test.rs
@@ -92,20 +92,31 @@ fn test_down_clamps_at_end() {
 }
 
 #[test]
-fn test_enter_returns_reconnect() {
+fn test_enter_opens_action_menu() {
     let mut app = make_app();
     app.sub_page = Some(SubPage::McpPage(McpPageState::new(Some(servers()))));
     let a = handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-    assert!(matches!(a, InputAction::McpReconnect(n) if n == "a"));
+    assert!(matches!(a, InputAction::None));
+    let s = match app.sub_page.as_ref().unwrap() {
+        SubPage::McpPage(s) => s,
+        _ => panic!("wrong"),
+    };
+    assert!(s.action_menu.is_some());
+    assert_eq!(s.action_menu.as_ref().unwrap().server_name, "a");
 }
 
 #[test]
-fn test_enter_on_second_item() {
+fn test_enter_on_second_item_opens_menu() {
     let mut app = make_app();
     app.sub_page = Some(SubPage::McpPage(McpPageState::new(Some(servers()))));
     handle_key(&mut app, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
     let a = handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-    assert!(matches!(a, InputAction::McpReconnect(n) if n == "b"));
+    assert!(matches!(a, InputAction::None));
+    let s = match app.sub_page.as_ref().unwrap() {
+        SubPage::McpPage(s) => s,
+        _ => panic!("wrong"),
+    };
+    assert_eq!(s.action_menu.as_ref().unwrap().server_name, "b");
 }
 
 #[test]

--- a/crates/loopal-tui/tests/suite/mcp_page_test.rs
+++ b/crates/loopal-tui/tests/suite/mcp_page_test.rs
@@ -2,7 +2,7 @@ use loopal_protocol::{
     AgentEvent, AgentEventPayload, ControlCommand, McpServerSnapshot, UserQuestionResponse,
 };
 use loopal_session::SessionController;
-use loopal_tui::app::{App, McpPageState, SubPage};
+use loopal_tui::app::{App, McpAction, McpPageState, SubPage};
 
 use tokio::sync::mpsc;
 
@@ -93,21 +93,20 @@ fn test_selected_out_of_bounds() {
 // --- Event → SessionState caching ---
 
 #[test]
-fn test_status_cached() {
+fn test_mcp_status_caching() {
     let app = make_app();
+    assert!(app.session.lock().mcp_status.is_none());
     app.session
         .handle_event(AgentEvent::root(AgentEventPayload::McpStatusReport {
             servers: servers(),
         }));
-    let st = app.session.lock();
-    let v = st.mcp_status.as_ref().unwrap();
-    assert_eq!(v.len(), 2);
-    assert_eq!(v[0].name, "a");
-}
-
-#[test]
-fn test_status_initially_none() {
-    assert!(make_app().session.lock().mcp_status.is_none());
+    assert_eq!(app.session.lock().mcp_status.as_ref().unwrap().len(), 2);
+    // Update replaces previous
+    app.session
+        .handle_event(AgentEvent::root(AgentEventPayload::McpStatusReport {
+            servers: vec![servers()[0].clone()],
+        }));
+    assert_eq!(app.session.lock().mcp_status.as_ref().unwrap().len(), 1);
 }
 
 #[test]
@@ -117,22 +116,7 @@ fn test_empty_report_sets_some() {
         .handle_event(AgentEvent::root(AgentEventPayload::McpStatusReport {
             servers: vec![],
         }));
-    let st = app.session.lock();
-    assert!(st.mcp_status.as_ref().unwrap().is_empty());
-}
-
-#[test]
-fn test_update_replaces_previous() {
-    let app = make_app();
-    app.session
-        .handle_event(AgentEvent::root(AgentEventPayload::McpStatusReport {
-            servers: servers(),
-        }));
-    app.session
-        .handle_event(AgentEvent::root(AgentEventPayload::McpStatusReport {
-            servers: vec![servers()[0].clone()],
-        }));
-    assert_eq!(app.session.lock().mcp_status.as_ref().unwrap().len(), 1);
+    assert!(app.session.lock().mcp_status.as_ref().unwrap().is_empty());
 }
 
 // --- Command registry ---
@@ -144,7 +128,7 @@ fn test_mcp_command_registered() {
     assert!(!h.is_skill());
 }
 
-// --- Reconnect dispatch ---
+// --- Control dispatch ---
 
 #[tokio::test]
 async fn test_reconnect_sends_control() {
@@ -155,5 +139,54 @@ async fn test_reconnect_sends_control() {
         .send_control(target, ControlCommand::McpReconnect { server: "s".into() })
         .await;
     let cmd = rx.try_recv().unwrap();
-    assert!(matches!(cmd, ControlCommand::McpReconnect { server } if server == "s"));
+    assert!(matches!(
+        cmd,
+        ControlCommand::McpReconnect { server } if server == "s"
+    ));
+}
+
+#[tokio::test]
+async fn test_disconnect_sends_control() {
+    let (app, mut rx) = make_app_with_rx();
+    let target = app.session.lock().active_view.clone();
+    app.session
+        .send_control(target, ControlCommand::McpDisconnect { server: "x".into() })
+        .await;
+    let cmd = rx.try_recv().unwrap();
+    assert!(matches!(
+        cmd,
+        ControlCommand::McpDisconnect { server } if server == "x"
+    ));
+}
+
+// --- ActionMenu ---
+
+#[test]
+fn test_action_menu_connected_vs_failed() {
+    let mut s = McpPageState::new(Some(servers()));
+    assert!(s.action_menu.is_none());
+
+    // connected server → Disconnect + Reconnect
+    s.selected = 0;
+    s.open_action_menu();
+    let menu = s.action_menu.as_ref().unwrap();
+    assert_eq!(menu.server_name, "a");
+    assert_eq!(
+        menu.options,
+        vec![McpAction::Disconnect, McpAction::Reconnect]
+    );
+
+    // failed server → Reconnect only
+    s.selected = 1;
+    s.open_action_menu();
+    let menu = s.action_menu.as_ref().unwrap();
+    assert_eq!(menu.server_name, "b");
+    assert_eq!(menu.options, vec![McpAction::Reconnect]);
+}
+
+#[test]
+fn test_open_menu_empty_list_noop() {
+    let mut s = McpPageState::new(Some(vec![]));
+    s.open_action_menu();
+    assert!(s.action_menu.is_none());
 }

--- a/crates/tools/registry/src/registry.rs
+++ b/crates/tools/registry/src/registry.rs
@@ -24,6 +24,11 @@ impl ToolRegistry {
         self.tools.write().unwrap().insert(name, Arc::from(tool));
     }
 
+    /// Remove a tool by name. Returns `true` if the tool was present.
+    pub fn unregister(&self, name: &str) -> bool {
+        self.tools.write().unwrap().remove(name).is_some()
+    }
+
     /// Get a tool by name.
     pub fn get(&self, name: &str) -> Option<Arc<dyn Tool>> {
         self.tools.read().unwrap().get(name).cloned()

--- a/crates/tools/registry/tests/registry_test.rs
+++ b/crates/tools/registry/tests/registry_test.rs
@@ -116,6 +116,24 @@ fn test_default_creates_empty_registry() {
     assert!(registry.list().is_empty());
 }
 
+#[test]
+fn test_unregister_removes_tool() {
+    let registry = ToolRegistry::new();
+    registry.register(Box::new(MockTool::new("Keep")));
+    registry.register(Box::new(MockTool::new("Remove")));
+
+    assert!(registry.unregister("Remove"));
+    assert!(registry.get("Remove").is_none());
+    assert!(registry.get("Keep").is_some());
+    assert_eq!(registry.list().len(), 1);
+}
+
+#[test]
+fn test_unregister_nonexistent_returns_false() {
+    let registry = ToolRegistry::new();
+    assert!(!registry.unregister("Ghost"));
+}
+
 /// Contract: runner-direct tools (AskUser, EnterPlanMode, ExitPlanMode) declare
 /// `ToolDispatch::RunnerDirect`; all other builtin tools default to `Pipeline`.
 #[test]


### PR DESCRIPTION
## Summary
- Support industry-standard `.mcp.json` config files in `.loopal/` and plugin directories (camelCase `mcpServers` format, stdio implicit)
- Add disconnect/reconnect action menu in `/mcp` sub-page (Enter opens menu instead of direct reconnect)
- Full disconnect pipeline: protocol → runtime → MCP manager → tool registry cleanup

## Changes

**Config layer** (`loopal-config`):
- New `mcp_json.rs`: parser for standard `.mcp.json` format
- `loader.rs`: `load_layer_from_dir` loads `.mcp.json` after `settings.json`, overrides by name
- 12 unit + integration tests

**Protocol layer** (`loopal-protocol`):
- `ControlCommand::McpDisconnect` variant + serde roundtrip test

**MCP layer** (`loopal-mcp`):
- `disconnect_connection()` on `McpManager` — returns removed tool names for registry cleanup

**Kernel layer** (`loopal-kernel`):
- `unregister_tools()` on `Kernel`
- `ToolRegistry::unregister()` method

**Runtime layer** (`loopal-runtime`):
- `handle_mcp_disconnect()` handler: disconnect → unregister tools → emit status

**TUI layer** (`loopal-tui`):
- `ActionMenu` state model with dynamic options (Disconnect shown only when connected)
- Two-mode key handler (list navigation vs menu selection)
- `mcp_action_menu.rs`: centered overlay rendering
- Status update clears stale action menu
- `tool_approve`/`tool_deny` extracted to `key_dispatch_ops.rs` (line limit fix)
- Updated existing tests + 6 new tests

## Test plan
- [ ] CI passes
- [ ] `bazel build //... --config=clippy` zero warnings
- [ ] `bazel build //... --config=rustfmt` zero diffs
- [ ] 5 affected crate test suites pass (config, protocol, mcp, registry, tui)