### PR TITLE
feat(provider): add Claude Opus 4.7 and set as default model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ TUI Process ──stdio IPC──→ Agent Server Process ←──TCP──→ 
 <project>/.loopal/settings.local.json  Local overrides (gitignored)
 ```
 
-Environment variable overrides use `LOOPAL_` prefix. Key settings: `model` (default: `claude-sonnet-4-20250514`), `permission_mode`.
+Environment variable overrides use `LOOPAL_` prefix. Key settings: `model` (default: `claude-opus-4-7`), `permission_mode`.
 
 ## Code Conventions
 

--- a/LOOPAL.md
+++ b/LOOPAL.md
@@ -101,7 +101,7 @@ TUI Process ──stdio IPC──→ Agent Server Process ←──TCP──→ 
 <project>/.loopal/settings.local.json  Local overrides (gitignored)
 ```
 
-Environment variable overrides use `LOOPAL_` prefix. Key settings: `model` (default: `claude-sonnet-4-20250514`), `permission_mode`.
+Environment variable overrides use `LOOPAL_` prefix. Key settings: `model` (default: `claude-opus-4-7`), `permission_mode`.
 
 ## Code Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ check: clippy fmt test
 
 # ── Run ──────────────────────────────────────────────────────────────────────
 
-MODEL ?= claude-opus-4-6
+MODEL ?= claude-opus-4-7
 
 run: build
 	./bazel-bin/loopal -m $(MODEL) $(ARGS)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ loopal --server --ephemeral "run all tests and fix failures"
 Works out of the box with **Anthropic**, **OpenAI**, **Google**, and any **OpenAI-compatible** endpoint. Switch models on the fly with `-m`:
 
 ```bash
-loopal -m claude-sonnet-4-20250514
+loopal -m claude-opus-4-7
 loopal -m gpt-4o
 loopal -m gemini-2.5-pro
 ```
@@ -305,7 +305,7 @@ Key settings:
 
 ```json
 {
-  "model": "claude-sonnet-4-20250514",
+  "model": "claude-opus-4-7",
   "permission_mode": "supervised",
   "thinking": { "type": "auto" },
   "providers": {

--- a/crates/loopal-config/src/settings.rs
+++ b/crates/loopal-config/src/settings.rs
@@ -71,7 +71,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            model: "claude-sonnet-4-20250514".to_string(),
+            model: "claude-opus-4-7".to_string(),
             model_routing: HashMap::new(),
             models: HashMap::new(),
             permission_mode: PermissionMode::Bypass,

--- a/crates/loopal-config/tests/suite/config_test.rs
+++ b/crates/loopal-config/tests/suite/config_test.rs
@@ -5,7 +5,7 @@ use loopal_tool_api::PermissionMode;
 #[test]
 fn test_settings_default_model() {
     let settings = Settings::default();
-    assert_eq!(settings.model, "claude-sonnet-4-20250514");
+    assert_eq!(settings.model, "claude-opus-4-7");
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn test_settings_serde_roundtrip() {
 fn test_settings_serde_from_empty_json() {
     let json = "{}";
     let settings: Settings = serde_json::from_str(json).unwrap();
-    assert_eq!(settings.model, "claude-sonnet-4-20250514");
+    assert_eq!(settings.model, "claude-opus-4-7");
 }
 
 #[test]

--- a/crates/loopal-config/tests/suite/loader_settings_test.rs
+++ b/crates/loopal-config/tests/suite/loader_settings_test.rs
@@ -14,7 +14,7 @@ fn test_load_settings_all_env_var_scenarios() {
     {
         let tmp = TempDir::new().unwrap();
         let settings = load_config(tmp.path()).unwrap().settings;
-        assert_eq!(settings.model, "claude-sonnet-4-20250514");
+        assert_eq!(settings.model, "claude-opus-4-7");
         assert!(!settings.model.is_empty());
     }
 

--- a/crates/loopal-config/tests/suite/resolver_edge_test.rs
+++ b/crates/loopal-config/tests/suite/resolver_edge_test.rs
@@ -77,7 +77,7 @@ fn test_resolve_null_settings_layer_skipped() {
     // Default ConfigLayer has settings = Value::Null
     resolver.add_layer(ConfigLayer::default());
     let config = resolver.resolve().unwrap();
-    assert_eq!(config.settings.model, "claude-sonnet-4-20250514");
+    assert_eq!(config.settings.model, "claude-opus-4-7");
 }
 
 #[test]

--- a/crates/loopal-config/tests/suite/resolver_test.rs
+++ b/crates/loopal-config/tests/suite/resolver_test.rs
@@ -19,7 +19,7 @@ fn mcp_config(command: &str) -> McpServerConfig {
 fn test_resolve_empty_produces_defaults() {
     let resolver = ConfigResolver::new();
     let config = resolver.resolve().unwrap();
-    assert_eq!(config.settings.model, "claude-sonnet-4-20250514");
+    assert_eq!(config.settings.model, "claude-opus-4-7");
     assert!(config.mcp_servers.is_empty());
     assert!(config.skills.is_empty());
     assert!(config.hooks.is_empty());

--- a/crates/loopal-config/tests/suite/telemetry_test.rs
+++ b/crates/loopal-config/tests/suite/telemetry_test.rs
@@ -129,7 +129,7 @@ fn settings_with_telemetry_merge() {
     assert!(settings.telemetry.enabled);
     assert!((settings.telemetry.sample_rate.unwrap() - 0.5).abs() < f64::EPSILON);
     // Other settings remain default
-    assert_eq!(settings.model, "claude-sonnet-4-20250514");
+    assert_eq!(settings.model, "claude-opus-4-7");
 }
 
 #[test]

--- a/crates/loopal-kernel/tests/suite/kernel_init_test.rs
+++ b/crates/loopal-kernel/tests/suite/kernel_init_test.rs
@@ -36,7 +36,7 @@ fn test_get_hooks_empty_by_default() {
 fn test_settings_accessor() {
     let kernel = make_kernel();
     let settings = kernel.settings();
-    assert_eq!(settings.model, "claude-sonnet-4-20250514");
+    assert_eq!(settings.model, "claude-opus-4-7");
 }
 
 #[test]

--- a/crates/loopal-provider/src/model_info/catalog.rs
+++ b/crates/loopal-provider/src/model_info/catalog.rs
@@ -107,6 +107,19 @@ pub(crate) static KNOWN_MODELS: &[ModelEntry] = &[
         true
     ),
     model!(
+        "claude-opus-4-7",
+        "anthropic",
+        "Claude Opus 4.7",
+        1_000_000,
+        128_000,
+        Adaptive,
+        Slow,
+        High,
+        Premium,
+        true,
+        true
+    ),
+    model!(
         "claude-haiku-3-5-20241022",
         "anthropic",
         "Claude 3.5 Haiku",

--- a/crates/loopal-provider/tests/suite/model_info_test.rs
+++ b/crates/loopal-provider/tests/suite/model_info_test.rs
@@ -54,6 +54,21 @@ fn test_get_sonnet_4_6_model() {
 }
 
 #[test]
+fn test_get_opus_4_7_model() {
+    let info = get_model_info("claude-opus-4-7").unwrap();
+    assert_eq!(info.provider, "anthropic");
+    assert_eq!(info.display_name, "Claude Opus 4.7");
+    assert_eq!(info.context_window, 1_000_000);
+    assert_eq!(info.max_output_tokens, 128_000);
+    assert_eq!(info.thinking, ThinkingCapability::Adaptive);
+}
+
+#[test]
+fn test_opus_4_7_resolves_to_anthropic() {
+    assert_eq!(resolve_provider("claude-opus-4-7"), "anthropic");
+}
+
+#[test]
 fn test_resolve_provider_anthropic() {
     assert_eq!(resolve_provider("claude-sonnet-4"), "anthropic");
 }


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-7` (1M context, 128K output, Adaptive thinking) to the Anthropic provider catalog
- Switch `Settings::default().model` from `claude-sonnet-4-20250514` to `claude-opus-4-7` so new users get the latest flagship by default
- Sync documentation (CLAUDE.md, LOOPAL.md, README.md) and the `Makefile` run-target default

## Changes
**Core**
- `crates/loopal-provider/src/model_info/catalog.rs` — new Opus 4.7 ModelEntry (mirrors Opus 4.6 tier metadata)
- `crates/loopal-config/src/settings.rs` — default `model` updated

**Tests**
- `crates/loopal-provider/tests/suite/model_info_test.rs` — new `test_get_opus_4_7_model` + provider-resolution case
- `crates/loopal-config/tests/suite/{config,loader_settings,resolver,resolver_edge,telemetry}_test.rs` — default-value assertions updated
- `crates/loopal-kernel/tests/suite/kernel_init_test.rs` — settings-accessor assertion updated
- Fixture defaults in `loopal-test-support` and `loopal-runtime` routing tests **intentionally left on** `claude-sonnet-4-20250514` to keep test harness stable and decoupled from production defaults

**Docs & DevEx**
- `CLAUDE.md`, `LOOPAL.md`, `README.md` — default-model references updated
- `Makefile` — `MODEL ?= claude-opus-4-7` for `make run` / `make debug`

## Test plan
- [x] `bazel test //...` — 52/52 passing locally
- [x] `bazel build //... --config=clippy` — zero warnings
- [x] `bazel build //... --config=rustfmt` — clean
- [x] Installed binary strings-verified to contain `claude-opus-4-7` (catalog + default)
- [ ] CI passes