### PR TITLE
fix(status-bar): emit explicit Running event on turn start

### DIFF
--- a/crates/loopal-acp/src/translate/mod.rs
+++ b/crates/loopal-acp/src/translate/mod.rs
@@ -98,6 +98,7 @@ pub fn translate_event(payload: &AgentEventPayload, session_id: &str) -> Option<
         AgentEventPayload::AwaitingInput
         | AgentEventPayload::AutoContinuation { .. }
         | AgentEventPayload::Started
+        | AgentEventPayload::Running
         | AgentEventPayload::Finished
         | AgentEventPayload::MessageRouted { .. }
         | AgentEventPayload::ToolPermissionRequest { .. }
@@ -162,6 +163,7 @@ mod tests {
             AgentEventPayload::AwaitingInput,
             AgentEventPayload::MaxTurnsReached { turns: 50 },
             AgentEventPayload::Started,
+            AgentEventPayload::Running,
             AgentEventPayload::Finished,
             AgentEventPayload::Interrupted,
             AgentEventPayload::RetryCleared,

--- a/crates/loopal-protocol/src/event_payload.rs
+++ b/crates/loopal-protocol/src/event_payload.rs
@@ -81,6 +81,10 @@ pub enum AgentEventPayload {
     ModeChanged { mode: String },
     /// Agent loop started
     Started,
+    /// Agent transitioned into active processing (turn begins).
+    /// Authoritative "started working" signal: emitted as soon as the runner
+    /// moves from `WaitingForInput` to `Running`, before any LLM call or tool.
+    Running,
     /// Agent loop finished
     Finished,
     /// Inter-agent message routed through MessageRouter (Observation Plane).

--- a/crates/loopal-runtime/src/agent_loop/runner.rs
+++ b/crates/loopal-runtime/src/agent_loop/runner.rs
@@ -140,7 +140,7 @@ impl AgentLoopRunner {
         self.status = new_status;
         let result = match new_status {
             AgentStatus::Starting => Ok(()),
-            AgentStatus::Running => Ok(()), // Running is signaled implicitly by Stream/ToolCall events.
+            AgentStatus::Running => self.emit(AgentEventPayload::Running).await,
             AgentStatus::WaitingForInput => self.emit(AgentEventPayload::AwaitingInput).await,
             AgentStatus::Finished => self.emit(AgentEventPayload::Finished).await,
             AgentStatus::Error => Ok(()), // Error event carries a message; use transition_error().

--- a/crates/loopal-runtime/tests/agent_loop/run_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/run_test.rs
@@ -133,3 +133,43 @@ async fn test_prompt_driven_error_exits_cleanly() {
         output.terminate_reason
     );
 }
+
+/// Authoritative `Running` event is emitted before any `Stream`, so the
+/// TUI status bar can flip before the first LLM byte arrives.
+#[tokio::test]
+async fn test_running_emitted_before_stream() {
+    let calls = vec![vec![
+        Ok(StreamChunk::Text {
+            text: "hello".into(),
+        }),
+        Ok(StreamChunk::Done {
+            stop_reason: StopReason::EndTurn,
+        }),
+    ]];
+    let (mut runner, mut event_rx) = make_multi_runner(calls);
+
+    let events = tokio::spawn(async move {
+        let mut payloads = vec![];
+        while let Some(e) = event_rx.recv().await {
+            payloads.push(e.payload);
+        }
+        payloads
+    });
+
+    runner.run().await.unwrap();
+    drop(runner);
+    let payloads = events.await.unwrap();
+
+    let running_pos = payloads
+        .iter()
+        .position(|p| matches!(p, AgentEventPayload::Running));
+    let stream_pos = payloads
+        .iter()
+        .position(|p| matches!(p, AgentEventPayload::Stream { .. }));
+    assert!(running_pos.is_some(), "Running event must be emitted");
+    assert!(stream_pos.is_some(), "Stream event must be emitted");
+    assert!(
+        running_pos.unwrap() < stream_pos.unwrap(),
+        "Running must precede first Stream",
+    );
+}

--- a/crates/loopal-session/src/agent_handler.rs
+++ b/crates/loopal-session/src/agent_handler.rs
@@ -102,6 +102,10 @@ pub(crate) fn apply_agent_event(state: &mut SessionState, name: &str, payload: A
         }
         payload @ AgentEventPayload::Compacted { .. } => apply_compaction_event(conv, payload),
         AgentEventPayload::Started => obs.status = AgentStatus::Running,
+        AgentEventPayload::Running => {
+            conv.begin_turn();
+            obs.status = AgentStatus::Running;
+        }
         AgentEventPayload::ServerToolUse {
             id,
             name: tn,

--- a/crates/loopal-session/tests/suite.rs
+++ b/crates/loopal-session/tests/suite.rs
@@ -33,6 +33,8 @@ mod resume_test;
 mod retry_banner_test;
 #[path = "suite/rewind_test.rs"]
 mod rewind_test;
+#[path = "suite/running_event_test.rs"]
+mod running_event_test;
 #[path = "suite/task_state_test.rs"]
 mod task_state_test;
 #[path = "suite/topology_test.rs"]

--- a/crates/loopal-session/tests/suite/running_event_test.rs
+++ b/crates/loopal-session/tests/suite/running_event_test.rs
@@ -1,0 +1,57 @@
+//! Tests for `AgentEventPayload::Running` — turn-begin authoritative signal.
+
+use std::time::Duration;
+
+use loopal_protocol::{AgentEvent, AgentEventPayload, AgentStatus};
+use loopal_session::event_handler::apply_event;
+use loopal_session::state::{ROOT_AGENT, SessionState};
+
+fn make_state() -> SessionState {
+    SessionState::new("test-model".into(), "act".into())
+}
+
+#[test]
+fn running_flips_status_to_running() {
+    let mut state = make_state();
+    apply_event(
+        &mut state,
+        AgentEvent::root(AgentEventPayload::AwaitingInput),
+    );
+    assert_eq!(
+        state.agents[ROOT_AGENT].observable.status,
+        AgentStatus::WaitingForInput,
+    );
+
+    apply_event(&mut state, AgentEvent::root(AgentEventPayload::Running));
+    assert_eq!(
+        state.agents[ROOT_AGENT].observable.status,
+        AgentStatus::Running,
+    );
+}
+
+#[test]
+fn running_starts_turn_timer() {
+    let mut state = make_state();
+    apply_event(&mut state, AgentEvent::root(AgentEventPayload::Running));
+    // After Running, turn_elapsed starts accumulating (> 0 after a short sleep).
+    std::thread::sleep(Duration::from_millis(5));
+    let elapsed = state.active_conversation().turn_elapsed();
+    assert!(
+        elapsed >= Duration::from_millis(1),
+        "expected turn timer running, got {elapsed:?}",
+    );
+}
+
+#[test]
+fn running_on_sub_agent_creates_view() {
+    let mut state = make_state();
+    apply_event(
+        &mut state,
+        AgentEvent::named("worker", AgentEventPayload::Running),
+    );
+    assert!(state.agents.contains_key("worker"));
+    assert_eq!(
+        state.agents["worker"].observable.status,
+        AgentStatus::Running,
+    );
+}


### PR DESCRIPTION
## Summary

The TUI status bar stays on "Idle" after the user presses Enter until the LLM's first streamed chunk arrives (1-5s TTFB). Root cause: `runner.transition(AgentStatus::Running)` was a no-op — session-layer `observable.status` only flipped when `Stream`/`ToolCall`/etc. events arrived, so the UI had no signal between "input accepted" and "first token back."

Fix by making the agent the authoritative source of status transitions:

- Add `AgentEventPayload::Running` — emitted the moment the runner enters active processing, before any LLM call.
- Hub broadcasts it to all observers (TUI, ACP, MetaHub shadows).
- Session layer handles it by calling `begin_turn()` and setting `observable.status = Running`.
- TUI reads the projection as before — no client-side optimistic state.

Also fixes a secondary issue: the turn-elapsed timer now starts when the turn begins, not on the first `Stream`/`ToolCall` event.

### Architecture rationale

Status is data-plane state; the agent owns it. Any observer (TUI, IDE via ACP, external Hub clients) gets the same authoritative view via event broadcast. No lossy shortcut (TUI-side optimistic updates) that would desync from the server model.

## Test plan

- New runtime test asserts `Running` is emitted before the first `Stream`
- New session tests cover status flip, turn timer start, sub-agent creation
- `bazel test //...` — all 52 test targets pass
- `bazel build //... --config=clippy` — zero warnings
