### PR TITLE
feat(tui): panel section headers + fix focus arrow residue

### DIFF
--- a/crates/loopal-tui/src/lib.rs
+++ b/crates/loopal-tui/src/lib.rs
@@ -11,6 +11,7 @@ pub mod panel_state;
 pub mod providers;
 pub mod render;
 mod render_layout;
+pub mod render_panel;
 mod session_cleanup;
 pub mod terminal;
 pub(crate) mod text_util;

--- a/crates/loopal-tui/src/panel_ops.rs
+++ b/crates/loopal-tui/src/panel_ops.rs
@@ -41,8 +41,11 @@ pub fn cycle_panel_focus(app: &mut App, forward: bool) {
     let Some(provider) = app.panel_registry.by_kind(kind) else {
         return;
     };
-    let ids = provider.item_ids(app);
     let max = provider.max_visible();
+    let ids = {
+        let state = app.session.lock();
+        provider.item_ids(app, &state)
+    };
     if ids.is_empty() {
         let section = app.section_mut(kind);
         section.focused = None;
@@ -56,9 +59,11 @@ pub fn cycle_panel_focus(app: &mut App, forward: bool) {
 }
 
 pub(crate) fn has_live_agents(app: &App) -> bool {
-    app.panel_registry
-        .by_kind(PanelKind::Agents)
-        .is_some_and(|p| !p.item_ids(app).is_empty())
+    let Some(provider) = app.panel_registry.by_kind(PanelKind::Agents) else {
+        return false;
+    };
+    let state = app.session.lock();
+    !provider.item_ids(app, &state).is_empty()
 }
 
 // --- Generic helpers ---
@@ -67,8 +72,11 @@ fn ensure_focus(app: &mut App, kind: PanelKind) {
     let Some(provider) = app.panel_registry.by_kind(kind) else {
         return;
     };
-    let ids = provider.item_ids(app);
     let max = provider.max_visible();
+    let ids = {
+        let state = app.session.lock();
+        provider.item_ids(app, &state)
+    };
     let section = app.section_mut(kind);
     if section.focused.as_ref().is_none_or(|f| !ids.contains(f)) {
         section.focused = ids.first().cloned();
@@ -87,10 +95,11 @@ fn fallback(app: &mut App) {
 }
 
 fn non_empty_kinds(app: &App) -> Vec<PanelKind> {
+    let state = app.session.lock();
     app.panel_registry
         .providers()
         .iter()
-        .filter(|p| !p.item_ids(app).is_empty())
+        .filter(|p| !p.item_ids(app, &state).is_empty())
         .map(|p| p.kind())
         .collect()
 }

--- a/crates/loopal-tui/src/panel_provider.rs
+++ b/crates/loopal-tui/src/panel_provider.rs
@@ -13,8 +13,25 @@ use crate::app::{App, PanelKind};
 
 pub trait PanelProvider: Send + Sync {
     fn kind(&self) -> PanelKind;
+    /// Short label shown in the section header when multiple panels are visible.
+    fn title(&self) -> &'static str;
     fn max_visible(&self) -> usize;
-    fn item_ids(&self, app: &App) -> Vec<String>;
+    /// List of item identifiers in the panel, read from the passed-in
+    /// `state`.
+    ///
+    /// Taking `state` as a parameter (rather than calling
+    /// `app.session.lock()` internally) avoids lock-reentrancy deadlocks
+    /// when render-time callers already hold the session guard.
+    fn item_ids(&self, app: &App, state: &SessionState) -> Vec<String>;
+    /// Number of items in the panel.
+    ///
+    /// Default delegates to `item_ids(...).len()`. Providers should
+    /// override with an allocation-free count (`iter().filter().count()`)
+    /// when `item_ids` would otherwise build a throwaway `Vec<String>`
+    /// — the section header only needs the integer.
+    fn count(&self, app: &App, state: &SessionState) -> usize {
+        self.item_ids(app, state).len()
+    }
     fn height(&self, app: &App, state: &SessionState) -> u16;
     fn render(
         &self,

--- a/crates/loopal-tui/src/providers/agent_provider.rs
+++ b/crates/loopal-tui/src/providers/agent_provider.rs
@@ -16,12 +16,17 @@ impl PanelProvider for AgentPanelProvider {
     fn kind(&self) -> PanelKind {
         PanelKind::Agents
     }
+    fn title(&self) -> &'static str {
+        "Agents"
+    }
     fn max_visible(&self) -> usize {
         agent_panel::MAX_VISIBLE
     }
-    fn item_ids(&self, app: &App) -> Vec<String> {
-        let state = app.session.lock();
-        live_agent_ids(&state)
+    fn item_ids(&self, _app: &App, state: &SessionState) -> Vec<String> {
+        live_agent_ids(state)
+    }
+    fn count(&self, _app: &App, state: &SessionState) -> usize {
+        live_agents(state).count()
     }
     fn height(&self, app: &App, state: &SessionState) -> u16 {
         let offset = app.section(PanelKind::Agents).scroll_offset;
@@ -49,12 +54,20 @@ impl PanelProvider for AgentPanelProvider {
 }
 
 pub(crate) fn live_agent_ids(state: &SessionState) -> Vec<String> {
+    live_agents(state).map(|(k, _)| k.clone()).collect()
+}
+
+/// Iterator over live sub-agents, excluding the currently active view.
+///
+/// Shared by `item_ids` (clones into a `Vec`) and `count` (just counts),
+/// so the filter predicate lives in one place.
+pub(crate) fn live_agents(
+    state: &SessionState,
+) -> impl Iterator<Item = (&String, &loopal_session::state::AgentViewState)> + '_ {
     state
         .agents
         .iter()
         .filter(|(k, a)| k.as_str() != state.active_view && is_live(&a.observable.status))
-        .map(|(k, _)| k.clone())
-        .collect()
 }
 
 fn is_live(status: &AgentStatus) -> bool {

--- a/crates/loopal-tui/src/providers/bg_tasks_provider.rs
+++ b/crates/loopal-tui/src/providers/bg_tasks_provider.rs
@@ -15,11 +15,17 @@ impl PanelProvider for BgTasksPanelProvider {
     fn kind(&self) -> PanelKind {
         PanelKind::BgTasks
     }
+    fn title(&self) -> &'static str {
+        "Background"
+    }
     fn max_visible(&self) -> usize {
         bg_tasks_panel::MAX_BG_VISIBLE
     }
-    fn item_ids(&self, app: &App) -> Vec<String> {
+    fn item_ids(&self, app: &App, _state: &SessionState) -> Vec<String> {
         bg_tasks_panel::task_ids(&app.bg_snapshots)
+    }
+    fn count(&self, app: &App, _state: &SessionState) -> usize {
+        bg_tasks_panel::running_count(&app.bg_snapshots)
     }
     fn height(&self, app: &App, _state: &SessionState) -> u16 {
         bg_tasks_panel::bg_panel_height(&app.bg_snapshots)

--- a/crates/loopal-tui/src/providers/crons_provider.rs
+++ b/crates/loopal-tui/src/providers/crons_provider.rs
@@ -15,11 +15,17 @@ impl PanelProvider for CronsPanelProvider {
     fn kind(&self) -> PanelKind {
         PanelKind::Crons
     }
+    fn title(&self) -> &'static str {
+        "Scheduled"
+    }
     fn max_visible(&self) -> usize {
         crons_panel::MAX_CRON_VISIBLE
     }
-    fn item_ids(&self, app: &App) -> Vec<String> {
+    fn item_ids(&self, app: &App, _state: &SessionState) -> Vec<String> {
         crons_panel::cron_ids(&app.cron_snapshots)
+    }
+    fn count(&self, app: &App, _state: &SessionState) -> usize {
+        app.cron_snapshots.len()
     }
     fn height(&self, app: &App, _state: &SessionState) -> u16 {
         crons_panel::crons_panel_height(&app.cron_snapshots)

--- a/crates/loopal-tui/src/providers/tasks_provider.rs
+++ b/crates/loopal-tui/src/providers/tasks_provider.rs
@@ -15,11 +15,17 @@ impl PanelProvider for TasksPanelProvider {
     fn kind(&self) -> PanelKind {
         PanelKind::Tasks
     }
+    fn title(&self) -> &'static str {
+        "Tasks"
+    }
     fn max_visible(&self) -> usize {
         tasks_panel::MAX_TASK_VISIBLE
     }
-    fn item_ids(&self, app: &App) -> Vec<String> {
+    fn item_ids(&self, app: &App, _state: &SessionState) -> Vec<String> {
         tasks_panel::task_ids(&app.task_snapshots)
+    }
+    fn count(&self, app: &App, _state: &SessionState) -> usize {
+        tasks_panel::active_count(&app.task_snapshots)
     }
     fn height(&self, app: &App, _state: &SessionState) -> u16 {
         tasks_panel::tasks_panel_height(&app.task_snapshots)

--- a/crates/loopal-tui/src/render.rs
+++ b/crates/loopal-tui/src/render.rs
@@ -19,12 +19,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     let breadcrumb_h = u16::from(state.active_view != loopal_session::ROOT_AGENT);
     let elapsed = conv.turn_elapsed();
 
-    let panel_zone_h: u16 = app
-        .panel_registry
-        .providers()
-        .iter()
-        .map(|p| p.height(app, &state))
-        .sum();
+    let panel_zone_h = crate::render_panel::panel_zone_height(app, &state);
     let layout = FrameLayout::compute(size, breadcrumb_h, panel_zone_h, banner_h, input_h);
 
     if let Some(ref mut sub_page) = app.sub_page {
@@ -37,7 +32,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         views::breadcrumb::render_breadcrumb(f, &state.active_view, layout.breadcrumb);
     }
     app.content_scroll.render(f, &state, layout.content);
-    render_panel_zone(f, app, &state, elapsed, layout.agents);
+    crate::render_panel::render_panel_zone(f, app, &state, elapsed, layout.agents);
     views::separator::render_separator(f, layout.separator);
     if let Some(ref msg) = conv.retry_banner {
         views::retry_banner::render_retry_banner(f, msg, layout.retry_banner);
@@ -91,41 +86,6 @@ fn render_sub_page(
         SubPage::McpPage(s) => views::mcp_page::render_mcp_page(f, s, area),
         SubPage::SkillsPage(s) => views::skills_page::render_skills_page(f, s, area),
         SubPage::BgTaskLog(s) => views::bg_task_log::render_bg_task_log(f, s, bg_details, area),
-    }
-}
-
-/// Render the panel zone using registered providers.
-fn render_panel_zone(
-    f: &mut Frame,
-    app: &App,
-    state: &loopal_session::state::SessionState,
-    elapsed: std::time::Duration,
-    area: Rect,
-) {
-    if area.height == 0 {
-        return;
-    }
-    let heights: Vec<_> = app
-        .panel_registry
-        .providers()
-        .iter()
-        .map(|p| (p.as_ref(), p.height(app, state)))
-        .filter(|(_, h)| *h > 0)
-        .collect();
-    if heights.is_empty() {
-        return;
-    }
-    let constraints: Vec<Constraint> = heights
-        .iter()
-        .map(|(_, h)| Constraint::Length(*h))
-        .collect();
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints(constraints)
-        .split(area);
-    for ((provider, _), &chunk) in heights.iter().zip(chunks.iter()) {
-        let focused = app.section(provider.kind()).focused.as_deref();
-        provider.render(f, app, state, focused, elapsed, chunk);
     }
 }
 

--- a/crates/loopal-tui/src/render_panel.rs
+++ b/crates/loopal-tui/src/render_panel.rs
@@ -1,0 +1,137 @@
+//! Panel zone rendering — section headers + active-only focus highlight.
+//!
+//! Renders the stack of registered panel providers. When ≥2 panels have
+//! content, a single-line section header (`━━ Title (count) ━━…`) is
+//! drawn above each panel, acting as both label and separator. Only the
+//! currently active panel (per `FocusMode::Panel(kind)`) receives its
+//! `section.focused` id — other panels are rendered with `None`, which
+//! hides their ` ▸ ` indicator. The underlying state is preserved so
+//! Tab-ing back restores the prior selection.
+
+use std::time::Duration;
+
+use ratatui::prelude::*;
+
+use crate::app::{App, FocusMode, PanelKind};
+use crate::panel_provider::PanelProvider;
+use crate::views::panel_header;
+
+/// Minimum number of visible panels required to show section headers.
+/// A lone panel is self-evident and doesn't need a label.
+const HEADER_MIN_PANELS: usize = 2;
+
+/// Total vertical height the panel zone needs for this frame.
+///
+/// Accounts for the optional per-panel header row when ≥2 panels are
+/// visible. Mirrors the layout done in `render_panel_zone` to ensure
+/// `FrameLayout` allocates the right amount of space.
+pub fn panel_zone_height(app: &App, state: &loopal_session::state::SessionState) -> u16 {
+    let visible = visible_providers(app, state);
+    let content: u16 = visible.iter().map(|(_, h)| *h).sum();
+    let headers = if show_headers(visible.len()) {
+        visible.len() as u16
+    } else {
+        0
+    };
+    content + headers
+}
+
+/// Render the panel zone into `area`.
+pub fn render_panel_zone(
+    f: &mut Frame,
+    app: &App,
+    state: &loopal_session::state::SessionState,
+    elapsed: Duration,
+    area: Rect,
+) {
+    if area.height == 0 {
+        return;
+    }
+    let visible = visible_providers(app, state);
+    if visible.is_empty() {
+        return;
+    }
+    let with_header = show_headers(visible.len());
+    let header_h: u16 = u16::from(with_header);
+    let active_kind = match app.focus_mode {
+        FocusMode::Panel(k) => Some(k),
+        _ => None,
+    };
+
+    let constraints: Vec<Constraint> = visible
+        .iter()
+        .map(|(_, h)| Constraint::Length(*h + header_h))
+        .collect();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(area);
+
+    for ((provider, content_h), &chunk) in visible.iter().zip(chunks.iter()) {
+        let content_area = if with_header {
+            draw_header(f, app, state, *provider, active_kind, chunk);
+            Rect {
+                x: chunk.x,
+                y: chunk.y + 1,
+                width: chunk.width,
+                height: *content_h,
+            }
+        } else {
+            chunk
+        };
+        let focused = active_focused_id(app, provider.kind(), active_kind);
+        provider.render(f, app, state, focused, elapsed, content_area);
+    }
+}
+
+/// Whether section headers should be drawn for `visible_len` panels.
+///
+/// Centralized so `panel_zone_height` and `render_panel_zone` cannot drift.
+fn show_headers(visible_len: usize) -> bool {
+    visible_len >= HEADER_MIN_PANELS
+}
+
+/// Collect `(provider, content_height)` for panels with non-zero height,
+/// preserving registry order.
+fn visible_providers<'a>(
+    app: &'a App,
+    state: &loopal_session::state::SessionState,
+) -> Vec<(&'a dyn PanelProvider, u16)> {
+    app.panel_registry
+        .providers()
+        .iter()
+        .map(|p| (p.as_ref(), p.height(app, state)))
+        .filter(|(_, h)| *h > 0)
+        .collect()
+}
+
+/// Render the 1-row section header above `chunk`.
+fn draw_header(
+    f: &mut Frame,
+    app: &App,
+    state: &loopal_session::state::SessionState,
+    provider: &dyn PanelProvider,
+    active_kind: Option<PanelKind>,
+    chunk: Rect,
+) {
+    let header_area = Rect {
+        x: chunk.x,
+        y: chunk.y,
+        width: chunk.width,
+        height: 1,
+    };
+    let is_active = active_kind == Some(provider.kind());
+    let count = provider.count(app, state);
+    panel_header::render_section_header(f, provider.title(), count, is_active, header_area);
+}
+
+/// Return the focused id only for the panel that owns input focus.
+/// Inactive panels get `None` so their ` ▸ ` indicator is hidden even
+/// though `section.focused` may still hold a remembered selection.
+fn active_focused_id(app: &App, kind: PanelKind, active_kind: Option<PanelKind>) -> Option<&str> {
+    if active_kind == Some(kind) {
+        app.section(kind).focused.as_deref()
+    } else {
+        None
+    }
+}

--- a/crates/loopal-tui/src/tui_loop.rs
+++ b/crates/loopal-tui/src/tui_loop.rs
@@ -137,12 +137,14 @@ fn sync_panel_caches(app: &mut App) {
 
 /// Ensure scroll offsets don't exceed item counts after data changes.
 fn clamp_scroll_offsets(app: &mut App) {
-    let clamps: Vec<_> = app
-        .panel_registry
-        .providers()
-        .iter()
-        .map(|p| (p.kind(), p.item_ids(app).len(), p.max_visible()))
-        .collect();
+    let clamps: Vec<_> = {
+        let state = app.session.lock();
+        app.panel_registry
+            .providers()
+            .iter()
+            .map(|p| (p.kind(), p.item_ids(app, &state).len(), p.max_visible()))
+            .collect()
+    };
     for (kind, count, max) in clamps {
         let section = app.section_mut(kind);
         section.scroll_offset = section.scroll_offset.min(count.saturating_sub(max));

--- a/crates/loopal-tui/src/views/bg_tasks_panel.rs
+++ b/crates/loopal-tui/src/views/bg_tasks_panel.rs
@@ -98,7 +98,9 @@ fn render_task_line(
     ])
 }
 
-fn running_count(snapshots: &[BgTaskSnapshot]) -> usize {
+/// Running background task count — allocation-free alternative to
+/// `task_ids(...).len()`.
+pub fn running_count(snapshots: &[BgTaskSnapshot]) -> usize {
     snapshots
         .iter()
         .filter(|s| s.status == BgTaskStatus::Running)

--- a/crates/loopal-tui/src/views/mod.rs
+++ b/crates/loopal-tui/src/views/mod.rs
@@ -8,6 +8,7 @@ pub mod crons_panel;
 pub mod input_view;
 pub mod mcp_action_menu;
 pub mod mcp_page;
+pub mod panel_header;
 pub mod picker;
 pub mod progress;
 pub mod question_dialog;
@@ -21,3 +22,6 @@ pub mod text_width;
 pub mod tool_confirm;
 pub mod topology_overlay;
 pub mod unified_status;
+
+/// Shared dim-grey color used for separators and inactive panel decoration.
+pub const DIM_SEPARATOR: ratatui::style::Color = ratatui::style::Color::Rgb(60, 60, 60);

--- a/crates/loopal-tui/src/views/panel_header.rs
+++ b/crates/loopal-tui/src/views/panel_header.rs
@@ -1,0 +1,52 @@
+//! Section header for the panel zone — `━━ Title (count) ━━━━…`.
+//!
+//! Rendered only when ≥2 panels are visible, acting as both label and
+//! separator. The active panel's header is highlighted (Cyan + bold);
+//! inactive headers use dim colors so focus is visually unambiguous.
+
+use ratatui::prelude::*;
+use ratatui::widgets::Paragraph;
+
+use super::DIM_SEPARATOR;
+use super::text_width::display_width;
+
+const HEADER_PREFIX: &str = "━━";
+
+/// Render a single-line section header at `area`.
+///
+/// - `title`: short label (e.g. "Tasks", "Background").
+/// - `count`: item count shown in parentheses; omitted when 0.
+/// - `focused`: true when this panel is the active focus target.
+pub fn render_section_header(f: &mut Frame, title: &str, count: usize, focused: bool, area: Rect) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let (title_fg, decor_fg) = if focused {
+        (Color::Cyan, Color::Cyan)
+    } else {
+        (Color::Gray, DIM_SEPARATOR)
+    };
+    let title_style = if focused {
+        Style::default().fg(title_fg).bold()
+    } else {
+        Style::default().fg(title_fg)
+    };
+
+    let label = if count > 0 {
+        format!(" {title} ({count}) ")
+    } else {
+        format!(" {title} ")
+    };
+    let total = area.width as usize;
+    let left_w = display_width(HEADER_PREFIX);
+    let label_w = display_width(&label);
+    let right_w = total.saturating_sub(left_w + label_w);
+    let right: String = "━".repeat(right_w);
+
+    let line = Line::from(vec![
+        Span::styled(HEADER_PREFIX.to_string(), Style::default().fg(decor_fg)),
+        Span::styled(label, title_style),
+        Span::styled(right, Style::default().fg(decor_fg)),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
+}

--- a/crates/loopal-tui/src/views/separator.rs
+++ b/crates/loopal-tui/src/views/separator.rs
@@ -2,6 +2,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
+use super::DIM_SEPARATOR;
+
 /// Render a dim horizontal dashed line across the full width.
 ///
 /// Pattern `─ ─ ─` repeats to fill the area. Ratatui's Paragraph
@@ -14,9 +16,6 @@ pub fn render_separator(f: &mut Frame, area: Rect) {
     // Each "─ " is 2 display columns. Generate enough repeats.
     let repeats = area.width as usize / 2 + 1;
     let pattern: String = "─ ".repeat(repeats);
-    let line = Line::from(Span::styled(
-        pattern,
-        Style::default().fg(Color::Rgb(60, 60, 60)),
-    ));
+    let line = Line::from(Span::styled(pattern, Style::default().fg(DIM_SEPARATOR)));
     f.render_widget(Paragraph::new(line), area);
 }

--- a/crates/loopal-tui/src/views/tasks_panel.rs
+++ b/crates/loopal-tui/src/views/tasks_panel.rs
@@ -135,7 +135,10 @@ fn task_suffix(task: &TaskSnapshot) -> String {
     String::new()
 }
 
-fn active_count(snapshots: &[TaskSnapshot]) -> usize {
+/// Non-completed task count — used by the panel height calc, section
+/// headers, and focus tracking. Allocation-free alternative to
+/// `task_ids(...).len()`.
+pub fn active_count(snapshots: &[TaskSnapshot]) -> usize {
     snapshots
         .iter()
         .filter(|t| !matches!(t.status, TaskSnapshotStatus::Completed))

--- a/crates/loopal-tui/tests/suite.rs
+++ b/crates/loopal-tui/tests/suite.rs
@@ -70,6 +70,12 @@ mod mcp_refresh_test;
 mod message_lines_edge_test;
 #[path = "suite/message_lines_test.rs"]
 mod message_lines_test;
+#[path = "suite/panel_focus_visibility_test.rs"]
+mod panel_focus_visibility_test;
+#[path = "suite/panel_header_render_test.rs"]
+mod panel_header_render_test;
+#[path = "suite/panel_provider_count_test.rs"]
+mod panel_provider_count_test;
 #[path = "suite/panel_tab_crons_test.rs"]
 mod panel_tab_crons_test;
 #[path = "suite/panel_tab_test.rs"]

--- a/crates/loopal-tui/tests/suite/crons_provider_test.rs
+++ b/crates/loopal-tui/tests/suite/crons_provider_test.rs
@@ -60,8 +60,9 @@ fn provider_max_visible_matches_panel_constant() {
 #[test]
 fn provider_item_ids_empty_when_no_snapshots() {
     let app = make_app();
+    let state = app.session.lock();
     let provider = app.panel_registry.by_kind(PanelKind::Crons).unwrap();
-    assert!(provider.item_ids(&app).is_empty());
+    assert!(provider.item_ids(&app, &state).is_empty());
 }
 
 #[test]
@@ -72,8 +73,12 @@ fn provider_item_ids_lists_all_snapshots_in_order() {
         snap("second", "p2", false),
         snap("third", "p3", true),
     ];
+    let state = app.session.lock();
     let provider = app.panel_registry.by_kind(PanelKind::Crons).unwrap();
-    assert_eq!(provider.item_ids(&app), vec!["first", "second", "third"]);
+    assert_eq!(
+        provider.item_ids(&app, &state),
+        vec!["first", "second", "third"]
+    );
 }
 
 #[test]

--- a/crates/loopal-tui/tests/suite/panel_focus_visibility_test.rs
+++ b/crates/loopal-tui/tests/suite/panel_focus_visibility_test.rs
@@ -1,0 +1,182 @@
+//! Verifies that Tab-switching between sub-panels hides the ` ▸ `
+//! indicator on non-active panels, preventing the "arrows on multiple
+//! panels simultaneously" visual bug.
+//!
+//! Strategy: populate both Tasks and BgTasks, set both `section.focused`,
+//! render the panel zone, and count the ` ▸ ` occurrences — it must
+//! equal exactly one (the active panel) or zero (in Input mode).
+
+use loopal_protocol::{BgTaskDetail, BgTaskStatus, ControlCommand, UserQuestionResponse};
+use loopal_protocol::{TaskSnapshot, TaskSnapshotStatus};
+use loopal_session::SessionController;
+use loopal_tui::app::{App, FocusMode, PanelKind};
+use loopal_tui::render_panel::render_panel_zone;
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::prelude::*;
+
+use tokio::sync::mpsc;
+
+fn make_app() -> App {
+    let (control_tx, _) = mpsc::channel::<ControlCommand>(16);
+    let (perm_tx, _) = mpsc::channel::<bool>(16);
+    let (question_tx, _) = mpsc::channel::<UserQuestionResponse>(16);
+    let session = SessionController::new(
+        "m".into(),
+        "act".into(),
+        control_tx,
+        perm_tx,
+        question_tx,
+        Default::default(),
+        std::sync::Arc::new(tokio::sync::watch::channel(0u64).0),
+    );
+    App::new(session, std::env::temp_dir())
+}
+
+fn setup_two_panels() -> App {
+    let mut app = make_app();
+    app.task_snapshots = vec![TaskSnapshot {
+        id: "1".into(),
+        subject: "Task 1".into(),
+        active_form: None,
+        status: TaskSnapshotStatus::InProgress,
+        blocked_by: Vec::new(),
+    }];
+    app.session.lock().bg_tasks.insert(
+        "bg_1".into(),
+        BgTaskDetail {
+            id: "bg_1".into(),
+            description: "bg".into(),
+            status: BgTaskStatus::Running,
+            exit_code: None,
+            output: String::new(),
+        },
+    );
+    app.bg_snapshots = app
+        .session
+        .lock()
+        .bg_tasks
+        .values()
+        .map(|t| t.to_snapshot())
+        .collect();
+    // Both panels have a remembered selection in state.
+    app.section_mut(PanelKind::Tasks).focused = Some("1".into());
+    app.section_mut(PanelKind::BgTasks).focused = Some("bg_1".into());
+    app
+}
+
+fn render_and_dump(app: &App, width: u16, height: u16) -> String {
+    let state = app.session.lock();
+    let backend = TestBackend::new(width, height);
+    let mut t = Terminal::new(backend).unwrap();
+    t.draw(|f| {
+        render_panel_zone(
+            f,
+            app,
+            &state,
+            std::time::Duration::ZERO,
+            Rect::new(0, 0, width, height),
+        )
+    })
+    .unwrap();
+    let buf = t.backend().buffer();
+    let mut out = String::new();
+    for y in 0..buf.area.height {
+        for x in 0..buf.area.width {
+            out.push_str(buf[(x, y)].symbol());
+        }
+        out.push('\n');
+    }
+    out
+}
+
+fn count_arrows(text: &str) -> usize {
+    text.matches('▸').count()
+}
+
+#[test]
+fn only_active_panel_shows_arrow_when_tasks_focused() {
+    let mut app = setup_two_panels();
+    app.focus_mode = FocusMode::Panel(PanelKind::Tasks);
+    let text = render_and_dump(&app, 80, 4);
+    assert_eq!(
+        count_arrows(&text),
+        1,
+        "exactly one ▸ expected, got:\n{text}"
+    );
+}
+
+#[test]
+fn only_active_panel_shows_arrow_when_bg_focused() {
+    let mut app = setup_two_panels();
+    app.focus_mode = FocusMode::Panel(PanelKind::BgTasks);
+    let text = render_and_dump(&app, 80, 4);
+    assert_eq!(
+        count_arrows(&text),
+        1,
+        "exactly one ▸ expected, got:\n{text}"
+    );
+}
+
+#[test]
+fn no_arrows_in_input_mode() {
+    let app = setup_two_panels();
+    // focus_mode defaults to Input; both sections still have `focused` set.
+    let text = render_and_dump(&app, 80, 4);
+    assert_eq!(count_arrows(&text), 0, "no ▸ expected, got:\n{text}");
+}
+
+#[test]
+fn state_preserved_across_render() {
+    // Rendering must not mutate `section.focused` — selection is restored
+    // when the user Tabs back to that panel.
+    let mut app = setup_two_panels();
+    app.focus_mode = FocusMode::Panel(PanelKind::Tasks);
+    let _ = render_and_dump(&app, 80, 4);
+    assert_eq!(
+        app.section(PanelKind::BgTasks).focused.as_deref(),
+        Some("bg_1")
+    );
+    assert_eq!(app.section(PanelKind::Tasks).focused.as_deref(), Some("1"));
+}
+
+#[test]
+fn arrow_follows_tab_switch() {
+    let mut app = setup_two_panels();
+    app.focus_mode = FocusMode::Panel(PanelKind::Tasks);
+    let before = render_and_dump(&app, 80, 4);
+    app.focus_mode = FocusMode::Panel(PanelKind::BgTasks);
+    let after = render_and_dump(&app, 80, 4);
+    // Arrow on each render is 1, but located in different rows.
+    assert_eq!(count_arrows(&before), 1);
+    assert_eq!(count_arrows(&after), 1);
+    // Arrow row should differ — Tasks panel is above BgTasks panel.
+    let row_of = |t: &str| {
+        t.lines()
+            .enumerate()
+            .find_map(|(i, l)| if l.contains('▸') { Some(i) } else { None })
+    };
+    assert_ne!(row_of(&before), row_of(&after));
+}
+
+#[test]
+fn single_panel_has_no_header() {
+    // Only Tasks has content → no "━━ Tasks ━━" header should appear.
+    let mut app = make_app();
+    app.task_snapshots = vec![TaskSnapshot {
+        id: "1".into(),
+        subject: "Only task".into(),
+        active_form: None,
+        status: TaskSnapshotStatus::InProgress,
+        blocked_by: Vec::new(),
+    }];
+    let text = render_and_dump(&app, 40, 2);
+    assert!(
+        !text.contains("━"),
+        "single panel should not show header decor: {text}"
+    );
+    assert!(
+        !text.contains("Tasks"),
+        "single panel should not show title label: {text}"
+    );
+}

--- a/crates/loopal-tui/tests/suite/panel_header_render_test.rs
+++ b/crates/loopal-tui/tests/suite/panel_header_render_test.rs
@@ -1,0 +1,199 @@
+//! Tests for section header rendering + `panel_zone_height`.
+
+use loopal_protocol::{
+    BgTaskDetail, BgTaskStatus, ControlCommand, TaskSnapshot, TaskSnapshotStatus,
+    UserQuestionResponse,
+};
+use loopal_session::SessionController;
+use loopal_tui::app::{App, FocusMode, PanelKind};
+use loopal_tui::render_panel::{panel_zone_height, render_panel_zone};
+use loopal_tui::views::panel_header::render_section_header;
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::prelude::*;
+
+use tokio::sync::mpsc;
+
+fn make_app() -> App {
+    let (control_tx, _) = mpsc::channel::<ControlCommand>(16);
+    let (perm_tx, _) = mpsc::channel::<bool>(16);
+    let (question_tx, _) = mpsc::channel::<UserQuestionResponse>(16);
+    let session = SessionController::new(
+        "m".into(),
+        "act".into(),
+        control_tx,
+        perm_tx,
+        question_tx,
+        Default::default(),
+        std::sync::Arc::new(tokio::sync::watch::channel(0u64).0),
+    );
+    App::new(session, std::env::temp_dir())
+}
+
+fn task(id: &str, status: TaskSnapshotStatus) -> TaskSnapshot {
+    TaskSnapshot {
+        id: id.into(),
+        subject: format!("Task {id}"),
+        active_form: None,
+        status,
+        blocked_by: Vec::new(),
+    }
+}
+
+fn bg(id: &str) -> BgTaskDetail {
+    BgTaskDetail {
+        id: id.into(),
+        description: format!("desc {id}"),
+        status: BgTaskStatus::Running,
+        exit_code: None,
+        output: String::new(),
+    }
+}
+
+fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+    let buf = terminal.backend().buffer();
+    let mut out = String::new();
+    for y in 0..buf.area.height {
+        for x in 0..buf.area.width {
+            out.push_str(buf[(x, y)].symbol());
+        }
+        out.push('\n');
+    }
+    out
+}
+
+// ── render_section_header ────────────────────────────────────────────
+
+#[test]
+fn section_header_includes_title_and_count() {
+    let backend = TestBackend::new(40, 1);
+    let mut t = Terminal::new(backend).unwrap();
+    t.draw(|f| render_section_header(f, "Tasks", 3, false, Rect::new(0, 0, 40, 1)))
+        .unwrap();
+    let text = buffer_text(&t);
+    assert!(text.contains("Tasks"), "{text}");
+    assert!(text.contains("(3)"), "{text}");
+}
+
+#[test]
+fn section_header_omits_count_when_zero() {
+    let backend = TestBackend::new(40, 1);
+    let mut t = Terminal::new(backend).unwrap();
+    t.draw(|f| render_section_header(f, "Agents", 0, false, Rect::new(0, 0, 40, 1)))
+        .unwrap();
+    assert!(!buffer_text(&t).contains("(0)"));
+}
+
+#[test]
+fn section_header_focused_uses_cyan_title() {
+    let backend = TestBackend::new(40, 1);
+    let mut t = Terminal::new(backend).unwrap();
+    t.draw(|f| render_section_header(f, "Tasks", 1, true, Rect::new(0, 0, 40, 1)))
+        .unwrap();
+    let buf = t.backend().buffer();
+    // Find cell containing 'T' from "Tasks" — it should be Cyan.
+    let found = (0..buf.area.width)
+        .find(|&x| buf[(x, 0)].symbol() == "T")
+        .map(|x| buf[(x, 0)].fg);
+    assert_eq!(found, Some(Color::Cyan));
+}
+
+#[test]
+fn section_header_unfocused_not_cyan_title() {
+    let backend = TestBackend::new(40, 1);
+    let mut t = Terminal::new(backend).unwrap();
+    t.draw(|f| render_section_header(f, "Tasks", 1, false, Rect::new(0, 0, 40, 1)))
+        .unwrap();
+    let buf = t.backend().buffer();
+    let found = (0..buf.area.width)
+        .find(|&x| buf[(x, 0)].symbol() == "T")
+        .map(|x| buf[(x, 0)].fg);
+    assert_ne!(found, Some(Color::Cyan));
+}
+
+#[test]
+fn section_header_empty_area_is_noop() {
+    let backend = TestBackend::new(40, 1);
+    let mut t = Terminal::new(backend).unwrap();
+    t.draw(|f| render_section_header(f, "Tasks", 1, true, Rect::new(0, 0, 0, 1)))
+        .unwrap();
+    // No panic; buffer remains the default spaces.
+    assert!(!buffer_text(&t).contains("Tasks"));
+}
+
+// ── panel_zone_height ────────────────────────────────────────────────
+
+#[test]
+fn zone_height_zero_when_all_empty() {
+    let app = make_app();
+    let state = app.session.lock();
+    assert_eq!(panel_zone_height(&app, &state), 0);
+}
+
+#[test]
+fn zone_height_single_panel_no_header_added() {
+    let mut app = make_app();
+    app.task_snapshots = vec![task("1", TaskSnapshotStatus::InProgress)];
+    let state = app.session.lock();
+    assert_eq!(panel_zone_height(&app, &state), 1);
+}
+
+#[test]
+fn zone_height_two_panels_adds_two_header_rows() {
+    let mut app = make_app();
+    app.task_snapshots = vec![task("1", TaskSnapshotStatus::InProgress)];
+    app.session
+        .lock()
+        .bg_tasks
+        .insert("bg_1".into(), bg("bg_1"));
+    app.bg_snapshots = app
+        .session
+        .lock()
+        .bg_tasks
+        .values()
+        .map(|t| t.to_snapshot())
+        .collect();
+    let state = app.session.lock();
+    // 1 tasks + 1 bg + 2 headers = 4
+    assert_eq!(panel_zone_height(&app, &state), 4);
+}
+
+// ── end-to-end: render_panel_zone with headers ───────────────────────
+
+#[test]
+fn render_two_panels_produces_two_header_lines() {
+    let mut app = make_app();
+    app.task_snapshots = vec![task("1", TaskSnapshotStatus::InProgress)];
+    app.session
+        .lock()
+        .bg_tasks
+        .insert("bg_1".into(), bg("bg_1"));
+    app.bg_snapshots = app
+        .session
+        .lock()
+        .bg_tasks
+        .values()
+        .map(|t| t.to_snapshot())
+        .collect();
+    app.focus_mode = FocusMode::Panel(PanelKind::Tasks);
+
+    let backend = TestBackend::new(50, 4);
+    let mut t = Terminal::new(backend).unwrap();
+    {
+        let state = app.session.lock();
+        t.draw(|f| {
+            render_panel_zone(
+                f,
+                &app,
+                &state,
+                std::time::Duration::ZERO,
+                Rect::new(0, 0, 50, 4),
+            )
+        })
+        .unwrap();
+    }
+    let text = buffer_text(&t);
+    assert!(text.contains("Tasks"), "tasks header missing: {text}");
+    assert!(text.contains("Background"), "bg header missing: {text}");
+    assert!(text.contains("━"), "decor lines missing: {text}");
+}

--- a/crates/loopal-tui/tests/suite/panel_provider_count_test.rs
+++ b/crates/loopal-tui/tests/suite/panel_provider_count_test.rs
@@ -1,0 +1,180 @@
+//! Tests for `PanelProvider::count` across all 4 providers.
+//!
+//! Each provider overrides `count` with an allocation-free `.filter().count()`
+//! variant (the section header only needs the integer). These tests
+//! verify the override matches the length of `item_ids` — so if someone
+//! changes the filter predicate in one place and forgets the other, the
+//! test fails.
+
+use loopal_protocol::{
+    AgentEvent, AgentEventPayload, BgTaskDetail, BgTaskStatus, ControlCommand, CronJobSnapshot,
+    TaskSnapshot, TaskSnapshotStatus, UserQuestionResponse,
+};
+use loopal_session::SessionController;
+use loopal_tui::app::{App, PanelKind};
+use tokio::sync::mpsc;
+
+fn make_app() -> App {
+    let (control_tx, _) = mpsc::channel::<ControlCommand>(16);
+    let (perm_tx, _) = mpsc::channel::<bool>(16);
+    let (question_tx, _) = mpsc::channel::<UserQuestionResponse>(16);
+    let session = SessionController::new(
+        "m".into(),
+        "act".into(),
+        control_tx,
+        perm_tx,
+        question_tx,
+        Default::default(),
+        std::sync::Arc::new(tokio::sync::watch::channel(0u64).0),
+    );
+    App::new(session, std::env::temp_dir())
+}
+
+fn spawn_agent(app: &App, name: &str) {
+    app.session.handle_event(AgentEvent::named(
+        name,
+        AgentEventPayload::SubAgentSpawned {
+            name: name.to_string(),
+            agent_id: format!("id-{name}"),
+            parent: Some("main".into()),
+            model: Some("m".into()),
+            session_id: None,
+        },
+    ));
+    app.session
+        .handle_event(AgentEvent::named(name, AgentEventPayload::Started));
+}
+
+fn assert_count_matches_item_ids(
+    app: &App,
+    state: &loopal_session::state::SessionState,
+    kind: PanelKind,
+) {
+    let provider = app.panel_registry.by_kind(kind).unwrap();
+    let expected = provider.item_ids(app, state).len();
+    assert_eq!(
+        provider.count(app, state),
+        expected,
+        "count / item_ids.len drift for {kind:?}"
+    );
+}
+
+// ── Agent provider ──────────────────────────────────────────────────
+
+#[test]
+fn agent_count_matches_live_agents() {
+    let app = make_app();
+    spawn_agent(&app, "w1");
+    spawn_agent(&app, "w2");
+    spawn_agent(&app, "w3");
+    let state = app.session.lock();
+    let provider = app.panel_registry.by_kind(PanelKind::Agents).unwrap();
+    assert_eq!(provider.count(&app, &state), 3);
+    assert_count_matches_item_ids(&app, &state, PanelKind::Agents);
+}
+
+#[test]
+fn agent_count_zero_when_no_live_agents() {
+    let app = make_app();
+    let state = app.session.lock();
+    let provider = app.panel_registry.by_kind(PanelKind::Agents).unwrap();
+    assert_eq!(provider.count(&app, &state), 0);
+}
+
+#[test]
+fn agent_count_does_not_require_extra_lock() {
+    // The caller holds the guard; `count` must read from the passed-in
+    // `state` without re-acquiring. Success = no deadlock.
+    let app = make_app();
+    spawn_agent(&app, "w1");
+    let state = app.session.lock();
+    let provider = app.panel_registry.by_kind(PanelKind::Agents).unwrap();
+    let _ = provider.count(&app, &state);
+}
+
+// ── Tasks provider ──────────────────────────────────────────────────
+
+#[test]
+fn tasks_count_matches_snapshots() {
+    let mut app = make_app();
+    app.task_snapshots = vec![
+        TaskSnapshot {
+            id: "1".into(),
+            subject: "a".into(),
+            active_form: None,
+            status: TaskSnapshotStatus::Pending,
+            blocked_by: Vec::new(),
+        },
+        TaskSnapshot {
+            id: "2".into(),
+            subject: "b".into(),
+            active_form: None,
+            status: TaskSnapshotStatus::InProgress,
+            blocked_by: Vec::new(),
+        },
+        TaskSnapshot {
+            id: "3".into(),
+            subject: "c".into(),
+            active_form: None,
+            status: TaskSnapshotStatus::Completed,
+            blocked_by: Vec::new(),
+        },
+    ];
+    let state = app.session.lock();
+    let provider = app.panel_registry.by_kind(PanelKind::Tasks).unwrap();
+    // Completed excluded by tasks_panel::task_ids.
+    assert_eq!(provider.count(&app, &state), 2);
+    assert_count_matches_item_ids(&app, &state, PanelKind::Tasks);
+}
+
+// ── BgTasks provider ────────────────────────────────────────────────
+
+#[test]
+fn bg_tasks_count_matches_running_snapshots() {
+    let mut app = make_app();
+    app.bg_snapshots = vec![
+        BgTaskDetail {
+            id: "bg_1".into(),
+            description: "a".into(),
+            status: BgTaskStatus::Running,
+            exit_code: None,
+            output: String::new(),
+        }
+        .to_snapshot(),
+        BgTaskDetail {
+            id: "bg_2".into(),
+            description: "b".into(),
+            status: BgTaskStatus::Completed,
+            exit_code: Some(0),
+            output: String::new(),
+        }
+        .to_snapshot(),
+    ];
+    let state = app.session.lock();
+    let provider = app.panel_registry.by_kind(PanelKind::BgTasks).unwrap();
+    // Completed excluded by bg_tasks_panel::task_ids.
+    assert_eq!(provider.count(&app, &state), 1);
+    assert_count_matches_item_ids(&app, &state, PanelKind::BgTasks);
+}
+
+// ── Crons provider ──────────────────────────────────────────────────
+
+#[test]
+fn crons_count_matches_snapshots() {
+    let mut app = make_app();
+    app.cron_snapshots = (0..3)
+        .map(|i| CronJobSnapshot {
+            id: format!("c{i}"),
+            cron_expr: "*/5 * * * *".into(),
+            prompt: "p".into(),
+            recurring: true,
+            created_at_unix_ms: 0,
+            next_fire_unix_ms: None,
+            durable: false,
+        })
+        .collect();
+    let state = app.session.lock();
+    let provider = app.panel_registry.by_kind(PanelKind::Crons).unwrap();
+    assert_eq!(provider.count(&app, &state), 3);
+    assert_count_matches_item_ids(&app, &state, PanelKind::Crons);
+}


### PR DESCRIPTION
## Summary

- Multi-panel display now shows `━━ Title (count) ━━━━` section headers when ≥2 sub-panels are visible (Agents / Tasks / Background / Scheduled), with the active one highlighted cyan.
- Fixes a latent bug: Tab-switching between panels left stale `▸` arrows on the previously-focused panels. Only the active panel now renders `▸`; other panels preserve `section.focused` state so Tab-back restores selection.
- Refactors `PanelProvider::item_ids` to take `state: &SessionState` by parameter, eliminating a lock-reentrancy deadlock risk in the render path. Adds `count(app, state)` with zero-alloc overrides on all 4 providers for header integer display.

## Changes

**Production**
- `src/panel_provider.rs` — trait: `item_ids(app, state)` + `count(app, state)` default
- `src/render_panel.rs` (new, 137 lines) — `panel_zone_height` + `render_panel_zone` with section headers + active-only focus scoping
- `src/views/panel_header.rs` (new, 52 lines) — `render_section_header` with cyan/dim variants
- `src/views/mod.rs` — `DIM_SEPARATOR` shared color constant; adopted by `separator.rs` and `panel_header.rs`
- `src/providers/{agent,tasks,bg_tasks,crons}_provider.rs` — `title()`, `item_ids(app, state)`, zero-alloc `count` overrides
- `src/panel_ops.rs` / `src/tui_loop.rs` / `src/render.rs` — call sites updated; lock once, pass `&state` in

**Tests** (3 new files, 20 tests)
- `panel_header_render_test.rs` — header decoration / cyan-when-focused / single-panel-no-header / title+count rendering
- `panel_focus_visibility_test.rs` — Tab-switch arrow exclusivity, Input-mode no arrows, state-preserved-across-render, single-panel-has-no-header
- `panel_provider_count_test.rs` — per-provider count correctness + `count() == item_ids().len()` drift guard

## Test plan

- [x] `bazel build //... --config=clippy` (zero warnings)
- [x] `bazel build //... --config=rustfmt`
- [x] `bazel test //crates/loopal-tui:loopal-tui_test` (passes, 1.1s)
- [x] `bazel test //...` (52/52 pass)
- [x] All `.rs` files ≤200 lines
- [ ] CI passes