### PR TITLE
refactor(protocol): NAT-style cross-hub address routing

### DIFF
--- a/crates/loopal-agent-client/tests/suite/bridge_test.rs
+++ b/crates/loopal-agent-client/tests/suite/bridge_test.rs
@@ -110,7 +110,9 @@ async fn bridge_forwards_mailbox_messages_to_ipc() {
     match msg {
         Some(loopal_ipc::connection::Incoming::Request { method, params, .. }) => {
             assert_eq!(method, methods::AGENT_MESSAGE.name);
-            assert_eq!(params["target"], "main");
+            // QualifiedAddress serializes as { "hub": [...], "agent": "name" }
+            assert_eq!(params["target"]["agent"], "main");
+            assert!(params["target"]["hub"].as_array().unwrap().is_empty());
         }
         other => panic!("expected message request, got: {other:?}"),
     }

--- a/crates/loopal-agent-hub/src/agent_io.rs
+++ b/crates/loopal-agent-hub/src/agent_io.rs
@@ -44,7 +44,8 @@ pub async fn agent_io_loop(
                     && let Ok(mut event) = serde_json::from_value::<AgentEvent>(params)
                 {
                     if event.agent_name.is_none() {
-                        event.agent_name = Some(agent_name.clone());
+                        event.agent_name =
+                            Some(loopal_protocol::QualifiedAddress::local(agent_name.clone()));
                     }
                     let h = hub.lock().await;
                     if h.registry.event_sender().try_send(event).is_err() {

--- a/crates/loopal-agent-hub/src/agent_registry/completion.rs
+++ b/crates/loopal-agent-hub/src/agent_registry/completion.rs
@@ -1,7 +1,7 @@
 //! Agent completion tracking, result delivery, and cascade interrupt.
 
 use loopal_ipc::protocol::methods;
-use loopal_protocol::{AgentEvent, AgentEventPayload, Envelope, MessageSource};
+use loopal_protocol::{AgentEvent, AgentEventPayload, Envelope, MessageSource, QualifiedAddress};
 use tokio::sync::{mpsc, watch};
 
 use super::AgentRegistry;
@@ -45,16 +45,22 @@ impl AgentRegistry {
     }
 
     /// Build the delivery envelope and find the parent's completion_tx.
-    /// Returns None if no parent or no completion channel.
+    /// Returns None if no parent, parent is remote, or parent has no
+    /// completion channel registered.
     fn prepare_parent_delivery(
         &self,
         child_name: &str,
         result: &str,
     ) -> Option<(mpsc::Sender<Envelope>, Envelope)> {
-        let parent_name = self.agents.get(child_name)?.info.parent.as_deref()?;
+        let parent = self.agents.get(child_name)?.info.parent.as_ref()?;
+        // Local-only delivery path. Remote parents take the uplink route in
+        // `finish::finish_and_deliver` instead.
+        if parent.is_remote() {
+            return None;
+        }
         let tx = self
             .agents
-            .get(parent_name)?
+            .get(&parent.agent)?
             .completion_tx
             .as_ref()?
             .clone();
@@ -65,9 +71,11 @@ impl AgentRegistry {
             result.to_string()
         };
         let content = format!("<agent-result name=\"{child_name}\">\n{body}\n</agent-result>");
+        // Source carries the child's local view; uplink SNAT stamps the
+        // origin hub when this completion is delivered to a remote parent.
         let envelope = Envelope::new(
-            MessageSource::System("agent-completed".into()),
-            parent_name,
+            MessageSource::Agent(QualifiedAddress::local(child_name)),
+            parent.clone(),
             content,
         );
         Some((tx, envelope))

--- a/crates/loopal-agent-hub/src/agent_registry/mod.rs
+++ b/crates/loopal-agent-hub/src/agent_registry/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, watch};
 
 use loopal_ipc::connection::Connection;
-use loopal_protocol::{AgentEvent, Envelope};
+use loopal_protocol::{AgentEvent, Envelope, QualifiedAddress};
 
 use crate::routing;
 use crate::topology::{AgentInfo, AgentLifecycle};
@@ -59,15 +59,17 @@ impl AgentRegistry {
         &mut self,
         name: &str,
         conn: Arc<Connection>,
-        parent: Option<&str>,
+        parent: Option<QualifiedAddress>,
         model: Option<&str>,
         completion_tx: Option<mpsc::Sender<Envelope>>,
     ) -> Result<(), String> {
         if self.agents.contains_key(name) {
             return Err(format!("agent '{name}' already registered"));
         }
-        if let Some(p) = parent
-            && let Some(pa) = self.agents.get_mut(p)
+        // Local children are tracked on the parent only when the parent is local.
+        if let Some(p) = &parent
+            && p.is_local()
+            && let Some(pa) = self.agents.get_mut(&p.agent)
         {
             pa.info.children.push(name.to_string());
         }
@@ -84,8 +86,9 @@ impl AgentRegistry {
 
     pub fn unregister_connection(&mut self, name: &str) {
         let parent = self.agents.get(name).and_then(|a| a.info.parent.clone());
-        if let Some(ref p) = parent
-            && let Some(pa) = self.agents.get_mut(p.as_str())
+        if let Some(p) = parent
+            && p.is_local()
+            && let Some(pa) = self.agents.get_mut(&p.agent)
         {
             pa.info.children.retain(|c| c != name);
         }
@@ -94,14 +97,11 @@ impl AgentRegistry {
     }
 
     /// Register a shadow entry for a remotely-spawned agent.
-    ///
-    /// The agent runs on another Hub but we need a local entry so that
-    /// `wait_agent` and `emit_agent_finished` work when the completion
-    /// notification arrives via MetaHub.
-    pub fn register_shadow(&mut self, name: &str, parent: &str) {
+    pub fn register_shadow(&mut self, name: &str, parent: QualifiedAddress) {
         use crate::topology::AgentInfo;
         use crate::types::{AgentConnectionState, ManagedAgent};
 
+        let parent_for_children = parent.clone();
         let mut info = AgentInfo::new(name, Some(parent), None);
         info.lifecycle = crate::AgentLifecycle::Running;
         self.agents.insert(
@@ -112,11 +112,14 @@ impl AgentRegistry {
                 completion_tx: None,
             },
         );
-        // Add to parent's children list (parent must be local bare name)
-        if let Some(pa) = self.agents.get_mut(parent) {
+        // Track in parent's children list when parent is local.
+        if parent_for_children.is_local()
+            && let Some(pa) = self.agents.get_mut(&parent_for_children.agent)
+        {
             pa.info.children.push(name.to_string());
         }
-        tracing::info!(agent = %name, parent = %parent, "shadow registered for remote agent");
+        tracing::info!(agent = %name, parent = %parent_for_children,
+            "shadow registered for remote agent");
     }
 
     // ── Queries ──────────────────────────────────────────────────
@@ -162,7 +165,7 @@ impl AgentRegistry {
 
     pub async fn route_message(&self, envelope: &Envelope) -> Result<(), String> {
         let conn = self
-            .get_agent_connection(&envelope.target)
+            .get_agent_connection(&envelope.target.agent)
             .ok_or_else(|| format!("no agent: '{}'", envelope.target))?;
         routing::route_to_agent(&conn, envelope, &self.event_tx).await
     }
@@ -193,7 +196,7 @@ impl AgentRegistry {
             .map(|(name, a)| {
                 serde_json::json!({
                     "name": name,
-                    "parent": a.info.parent,
+                    "parent": a.info.parent.as_ref().map(|p| p.to_string()),
                     "children": a.info.children,
                     "lifecycle": format!("{:?}", a.info.lifecycle),
                     "model": a.info.model,

--- a/crates/loopal-agent-hub/src/dispatch/dispatch_handlers.rs
+++ b/crates/loopal-agent-hub/src/dispatch/dispatch_handlers.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use loopal_ipc::protocol::methods;
-use loopal_protocol::{Envelope, QualifiedAddress};
+use loopal_protocol::Envelope;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 use tracing::info;
@@ -15,10 +15,8 @@ pub async fn handle_route(hub: &Arc<Mutex<Hub>>, params: Value) -> Result<Value,
     let envelope: Envelope =
         serde_json::from_value(params).map_err(|e| format!("invalid envelope: {e}"))?;
 
-    let addr = QualifiedAddress::parse(&envelope.target);
-
-    // Remote address or local miss → try uplink
-    if addr.is_remote() {
+    // Remote address → uplink immediately (target carries the next hop).
+    if envelope.target.is_remote() {
         return route_via_uplink(hub, &envelope).await;
     }
 
@@ -26,7 +24,7 @@ pub async fn handle_route(hub: &Arc<Mutex<Hub>>, params: Value) -> Result<Value,
     let result = {
         let h = hub.lock().await;
         h.registry
-            .get_agent_connection(&addr.agent)
+            .get_agent_connection(&envelope.target.agent)
             .map(|conn| (conn, h.registry.event_sender()))
     };
 
@@ -134,7 +132,12 @@ pub async fn handle_spawn_agent(
             (Some(ul), Some(hn)) => {
                 let mut spawn_params = params.clone();
                 if let Some(obj) = spawn_params.as_object_mut() {
-                    obj.insert("parent".into(), json!(format!("{hn}/{from_agent}")));
+                    // Cross-hub spawn: child's parent is the local agent on
+                    // *this* hub. Encode as a qualified address (`hub/agent`)
+                    // so the receiving hub can route completions back.
+                    let parent_addr =
+                        loopal_protocol::QualifiedAddress::remote([hn.clone()], from_agent);
+                    obj.insert("parent".into(), json!(parent_addr.to_string()));
                 }
                 ul.spawn_agent(spawn_params).await
             }
@@ -146,7 +149,9 @@ pub async fn handle_spawn_agent(
             && let Some(name) = resp["name"].as_str()
         {
             let mut h = hub.lock().await;
-            h.registry.register_shadow(name, from_agent);
+            // Cross-hub child's parent lives on this hub locally.
+            h.registry
+                .register_shadow(name, loopal_protocol::QualifiedAddress::local(from_agent));
         }
         return result;
     }

--- a/crates/loopal-agent-hub/src/dispatch/topology_handlers.rs
+++ b/crates/loopal-agent-hub/src/dispatch/topology_handlers.rs
@@ -17,7 +17,7 @@ pub async fn handle_agent_info(hub: &Arc<Mutex<Hub>>, params: Value) -> Result<V
     if let Some(info) = h.registry.agent_info(name) {
         Ok(json!({
             "name": info.name,
-            "parent": info.parent,
+            "parent": info.parent.as_ref().map(|p| p.to_string()),
             "children": info.children,
             "lifecycle": format!("{:?}", info.lifecycle),
             "model": info.model,

--- a/crates/loopal-agent-hub/src/finish.rs
+++ b/crates/loopal-agent-hub/src/finish.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use loopal_ipc::connection::Connection;
-use loopal_protocol::{Envelope, QualifiedAddress};
+use loopal_protocol::{Envelope, MessageSource, QualifiedAddress};
 
 use crate::hub::Hub;
 
@@ -14,7 +14,7 @@ use crate::hub::Hub;
 ///
 /// Handles both local parents (via completion_tx) and remote parents
 /// (via MetaHub uplink). Called after the agent IO loop exits.
-pub(crate) async fn finish_and_deliver(
+pub async fn finish_and_deliver(
     hub: &Arc<Mutex<Hub>>,
     name: &str,
     output: Option<String>,
@@ -22,7 +22,7 @@ pub(crate) async fn finish_and_deliver(
 ) {
     let output_text = output.as_deref().unwrap_or("(no output)").to_string();
 
-    let (pending, uplink, parent_name) = {
+    let (pending, uplink, parent_addr) = {
         let mut h = hub.lock().await;
         let parent = h
             .registry
@@ -37,21 +37,21 @@ pub(crate) async fn finish_and_deliver(
         if tx.send(envelope).await.is_err() {
             tracing::warn!(agent = %name, "parent completion channel closed");
         }
-    } else if let Some(parent) = parent_name {
-        let addr = QualifiedAddress::parse(&parent);
-        if addr.is_remote()
-            && let Some(ul) = uplink
-        {
-            let content = format!("<agent-result name=\"{name}\">\n{output_text}\n</agent-result>");
-            let envelope = Envelope::new(
-                loopal_protocol::MessageSource::System("agent-completed".into()),
-                &parent,
-                content,
-            );
-            if let Err(e) = ul.route(&envelope).await {
-                tracing::warn!(agent = %name, parent = %parent, error = %e,
-                    "failed to deliver completion to remote parent");
-            }
+    } else if let Some(parent) = parent_addr
+        && parent.is_remote()
+        && let Some(ul) = uplink
+    {
+        let content = format!("<agent-result name=\"{name}\">\n{output_text}\n</agent-result>");
+        // Use Agent(local(child)) so uplink SNAT stamps the origin hub.
+        // System("agent-completed") cannot carry hub info — see review #3.
+        let envelope = Envelope::new(
+            MessageSource::Agent(QualifiedAddress::local(name)),
+            parent.clone(),
+            content,
+        );
+        if let Err(e) = ul.route(&envelope).await {
+            tracing::warn!(agent = %name, parent = %parent, error = %e,
+                "failed to deliver completion to remote parent");
         }
     }
 

--- a/crates/loopal-agent-hub/src/lib.rs
+++ b/crates/loopal-agent-hub/src/lib.rs
@@ -10,7 +10,7 @@ pub mod agent_io;
 pub mod agent_registry;
 pub mod dispatch;
 mod event_router;
-mod finish;
+pub mod finish;
 mod hub;
 pub mod hub_server;
 mod hub_ui_client;

--- a/crates/loopal-agent-hub/src/routing.rs
+++ b/crates/loopal-agent-hub/src/routing.rs
@@ -22,7 +22,7 @@ pub async fn route_to_agent(
         .map_err(|e| format!("delivery to '{}' failed: {e}", envelope.target))?;
 
     let event = AgentEvent::root(AgentEventPayload::MessageRouted {
-        source: envelope.source.label(),
+        source: envelope.source.clone(),
         target: envelope.target.clone(),
         content_preview: envelope.content_preview().to_string(),
     });

--- a/crates/loopal-agent-hub/src/spawn_manager.rs
+++ b/crates/loopal-agent-hub/src/spawn_manager.rs
@@ -117,6 +117,10 @@ pub async fn register_agent_connection(
     // Bridge task forwards to the agent process via IPC.
     let (completion_tx, completion_rx) = mpsc::channel::<Envelope>(32);
 
+    // String parent comes in qualified-or-bare form depending on caller
+    // (cross-hub spawn provides "hub/agent", local spawn provides "agent").
+    let parent_addr = parent.map(loopal_protocol::QualifiedAddress::parse);
+
     {
         let mut h = hub.lock().await;
 
@@ -134,15 +138,16 @@ pub async fn register_agent_connection(
             }
         }
 
-        if let Some(p) = parent
-            && !h.registry.agents.contains_key(p)
+        if let Some(p) = &parent_addr
+            && p.is_local()
+            && !h.registry.agents.contains_key(&p.agent)
         {
             warn!(agent = %name, parent = %p, "parent not found");
         }
         if let Err(e) = h.registry.register_connection_with_parent(
             name,
             conn.clone(),
-            parent,
+            parent_addr.clone(),
             model,
             Some(completion_tx),
         ) {
@@ -162,7 +167,7 @@ pub async fn register_agent_connection(
         let event = AgentEvent::root(AgentEventPayload::SubAgentSpawned {
             name: name.to_string(),
             agent_id: agent_id.clone(),
-            parent: parent.map(String::from),
+            parent: parent_addr.clone(),
             model: model.map(String::from),
             session_id: session_id.map(String::from),
         });

--- a/crates/loopal-agent-hub/src/topology.rs
+++ b/crates/loopal-agent-hub/src/topology.rs
@@ -2,6 +2,8 @@
 
 use std::time::Instant;
 
+use loopal_protocol::QualifiedAddress;
+
 /// Lifecycle state of an agent managed by the Hub.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentLifecycle {
@@ -19,9 +21,12 @@ pub enum AgentLifecycle {
 #[derive(Debug, Clone)]
 pub struct AgentInfo {
     pub name: String,
-    /// Who spawned this agent (None for root agent).
-    pub parent: Option<String>,
-    /// Agents spawned by this agent.
+    /// Who spawned this agent. `None` for root.
+    /// Local parents have `hub.is_empty()`; remote (cross-hub) parents
+    /// carry a hub path stamped at spawn time.
+    pub parent: Option<QualifiedAddress>,
+    /// Locally-visible children (bare names; cross-hub children appear
+    /// here as shadow entries by their final-hop name).
     pub children: Vec<String>,
     pub lifecycle: AgentLifecycle,
     pub model: Option<String>,
@@ -29,10 +34,10 @@ pub struct AgentInfo {
 }
 
 impl AgentInfo {
-    pub fn new(name: &str, parent: Option<&str>, model: Option<&str>) -> Self {
+    pub fn new(name: &str, parent: Option<QualifiedAddress>, model: Option<&str>) -> Self {
         Self {
             name: name.to_string(),
-            parent: parent.map(String::from),
+            parent,
             children: Vec::new(),
             lifecycle: AgentLifecycle::Spawning,
             model: model.map(String::from),

--- a/crates/loopal-agent-hub/src/uplink.rs
+++ b/crates/loopal-agent-hub/src/uplink.rs
@@ -48,9 +48,13 @@ impl HubUplink {
     }
 
     /// Route an envelope to a remote agent via MetaHub.
+    ///
+    /// Applies SNAT before forwarding: stamps this hub's name onto the
+    /// envelope source so the receiver sees the full return path.
     pub async fn route(&self, envelope: &Envelope) -> Result<(), String> {
-        let params =
-            serde_json::to_value(envelope).map_err(|e| format!("serialize envelope: {e}"))?;
+        let mut env = envelope.clone();
+        env.apply_snat(&self.hub_name);
+        let params = serde_json::to_value(&env).map_err(|e| format!("serialize envelope: {e}"))?;
         let resp = self
             .conn
             .send_request(methods::META_ROUTE.name, params)
@@ -104,7 +108,7 @@ impl HubUplink {
     }
 }
 
-/// Process reverse requests from MetaHub (meta/resolve, agent/message, hub/*).
+/// Process reverse requests from MetaHub (agent/message, hub/*).
 ///
 /// Shared implementation used by both production bootstrap and integration tests.
 /// Runs until the connection closes.
@@ -118,29 +122,26 @@ pub async fn handle_reverse_requests(
     while let Some(msg) = rx.recv().await {
         match msg {
             Incoming::Request { id, method, params } => {
-                if method == methods::META_RESOLVE.name {
-                    let agent = params["agent_name"].as_str().unwrap_or("");
-                    let found = hub
-                        .lock()
-                        .await
-                        .registry
-                        .get_agent_connection(agent)
-                        .is_some();
-                    let _ = conn.respond(id, json!({"found": found})).await;
-                } else if method == methods::AGENT_MESSAGE.name {
+                if method == methods::AGENT_MESSAGE.name {
                     let ok = if let Ok(env) =
                         serde_json::from_value::<loopal_protocol::Envelope>(params)
                     {
-                        // If this is a remote agent completion, trigger shadow entry
-                        if let loopal_protocol::MessageSource::System(ref tag) = env.source
-                            && tag == "agent-completed"
-                            && let Some(child) = extract_agent_result_name(&env)
-                        {
+                        // Remote agent completions arrive with the agent-result
+                        // marker in content. Detect by content (not source tag)
+                        // so it works with the typed Agent source after SNAT.
+                        if let Some(child) = extract_agent_result_name(&env) {
                             let output = env.content.text.clone();
                             let mut h = hub.lock().await;
                             h.registry.emit_agent_finished(&child, Some(output));
                             h.registry.unregister_connection(&child);
                         }
+                        // Defense in depth: target should be local at this point
+                        // (MetaHub router consumed the next-hop hub via DNAT).
+                        debug_assert!(
+                            env.target.is_local(),
+                            "target should be local after MetaHub DNAT, got {:?}",
+                            env.target
+                        );
                         hub.lock().await.registry.route_message(&env).await.is_ok()
                     } else {
                         false
@@ -170,6 +171,11 @@ pub async fn handle_reverse_requests(
                 if method == methods::AGENT_MESSAGE.name
                     && let Ok(env) = serde_json::from_value::<loopal_protocol::Envelope>(params)
                 {
+                    debug_assert!(
+                        env.target.is_local(),
+                        "notification target should be local after DNAT, got {:?}",
+                        env.target
+                    );
                     let _ = hub.lock().await.registry.route_message(&env).await;
                 }
             }

--- a/crates/loopal-agent-hub/tests/suite/advanced_scenarios_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/advanced_scenarios_test.rs
@@ -22,8 +22,8 @@ fn make_hub() -> (Arc<Mutex<Hub>>, mpsc::Receiver<AgentEvent>) {
 fn envelope(from: &str, target: &str, text: &str) -> serde_json::Value {
     json!({
         "id": uuid::Uuid::new_v4().to_string(),
-        "source": {"Agent": from},
-        "target": target,
+        "source": {"Agent": {"hub": [], "agent": from}},
+        "target": {"hub": [], "agent": target},
         "content": {"text": text, "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     })
@@ -206,7 +206,7 @@ async fn concurrent_events_all_reach_hub() {
     let mut received_names: Vec<String> = Vec::new();
     while let Ok(event) = event_rx.try_recv() {
         if let Some(name) = event.agent_name {
-            received_names.push(name);
+            received_names.push(name.to_string());
         }
     }
 

--- a/crates/loopal-agent-hub/tests/suite/collaboration_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/collaboration_test.rs
@@ -174,8 +174,8 @@ async fn send_message_running_vs_finished() {
     // Route to running agent → should succeed
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000001",
-        "source": {"Agent": "sender"},
-        "target": "receiver",
+        "source": {"Agent": {"hub": [], "agent": "sender"}},
+        "target": {"hub": [], "agent": "receiver"},
         "content": {"text": "hello", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });
@@ -192,8 +192,8 @@ async fn send_message_running_vs_finished() {
     // Route to finished agent → should fail
     let envelope2 = json!({
         "id": "00000000-0000-0000-0000-000000000002",
-        "source": {"Agent": "sender"},
-        "target": "receiver",
+        "source": {"Agent": {"hub": [], "agent": "sender"}},
+        "target": {"hub": [], "agent": "receiver"},
         "content": {"text": "hello again", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });

--- a/crates/loopal-agent-hub/tests/suite/completion_injection_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/completion_injection_test.rs
@@ -96,8 +96,11 @@ async fn child_completion_delivered_to_parent_via_bridge() {
         .expect("channel should not close");
 
     assert!(
-        matches!(envelope.source, MessageSource::System(ref k) if k == "agent-completed"),
-        "source should be System(agent-completed), got: {:?}",
+        matches!(
+            envelope.source,
+            MessageSource::Agent(ref qa) if qa.agent == "child-a" && qa.is_local()
+        ),
+        "source should be Agent(local('child-a')), got: {:?}",
         envelope.source
     );
     let text = &envelope.content.text;

--- a/crates/loopal-agent-hub/tests/suite/completion_output_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/completion_output_test.rs
@@ -150,7 +150,10 @@ async fn topology_tracks_parent_child() {
         .registry
         .agent_info("child-1")
         .expect("child should exist");
-    assert_eq!(child_info.parent.as_deref(), Some("parent"));
+    assert_eq!(
+        child_info.parent.as_ref().map(|p| p.to_string()).as_deref(),
+        Some("parent")
+    );
     assert_eq!(child_info.model.as_deref(), Some("sonnet"));
 
     let descendants = h.registry.descendants("parent");

--- a/crates/loopal-agent-hub/tests/suite/dispatch_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/dispatch_test.rs
@@ -57,12 +57,16 @@ async fn dispatch_route_without_target_fails() {
     let hub = make_hub();
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000000",
-        "source": {"Agent": "sender"},
-        "target": "nonexistent",
+        "source": {"Agent": {"hub": [], "agent": "sender"}},
+        "target": {"hub": [], "agent": "nonexistent"},
         "content": {"text": "hi", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });
     let result = dispatch_hub_request(&hub, "hub/route", envelope, "sender".into()).await;
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("not found"));
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("no agent") || err.contains("uplink"),
+        "expected local-miss error, got: {err}"
+    );
 }

--- a/crates/loopal-agent-hub/tests/suite/hub_integration_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/hub_integration_test.rs
@@ -96,8 +96,8 @@ async fn agent_a_routes_message_to_agent_b() {
 
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000001",
-        "source": {"Agent": "agent-a"},
-        "target": "agent-b",
+        "source": {"Agent": {"hub": [], "agent": "agent-a"}},
+        "target": {"hub": [], "agent": "agent-b"},
         "content": {"text": "hello from A", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });
@@ -236,5 +236,8 @@ async fn agent_event_reaches_hub_event_channel() {
     let received = tokio::time::timeout(Duration::from_secs(2), event_rx.recv()).await;
     assert!(received.is_ok(), "Hub should forward event");
     let evt = received.unwrap().unwrap();
-    assert_eq!(evt.agent_name.as_deref(), Some("worker"));
+    assert_eq!(
+        evt.agent_name.as_ref().map(|a| a.to_string()).as_deref(),
+        Some("worker")
+    );
 }

--- a/crates/loopal-agent-hub/tests/suite/multi_agent_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/multi_agent_test.rs
@@ -103,8 +103,8 @@ async fn route_to_disconnected_agent_returns_error() {
 
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000003",
-        "source": {"Agent": "sender"},
-        "target": "ghost",
+        "source": {"Agent": {"hub": [], "agent": "sender"}},
+        "target": {"hub": [], "agent": "ghost"},
         "content": {"text": "are you there?", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });
@@ -141,8 +141,8 @@ async fn sibling_agents_communicate_via_hub() {
     // C sends to B directly (siblings, not parent-child)
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000004",
-        "source": {"Agent": "sibling-c"},
-        "target": "sibling-b",
+        "source": {"Agent": {"hub": [], "agent": "sibling-c"}},
+        "target": {"hub": [], "agent": "sibling-b"},
         "content": {"text": "hey sibling", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });

--- a/crates/loopal-agent-hub/tests/suite/spawn_lifecycle_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/spawn_lifecycle_test.rs
@@ -96,8 +96,8 @@ async fn register_agent_connection_makes_agent_routable() {
 
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000001",
-        "source": {"Agent": "sender"},
-        "target": "mock-worker",
+        "source": {"Agent": {"hub": [], "agent": "sender"}},
+        "target": {"hub": [], "agent": "mock-worker"},
         "content": {"text": "hello mock", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });
@@ -204,8 +204,8 @@ async fn spawned_agent_routes_message_to_parent() {
     // Child sends hub/route targeting parent
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000002",
-        "source": {"Agent": "child"},
-        "target": "parent",
+        "source": {"Agent": {"hub": [], "agent": "child"}},
+        "target": {"hub": [], "agent": "parent"},
         "content": {"text": "report from child", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });

--- a/crates/loopal-agent-server/src/hub_emitter.rs
+++ b/crates/loopal-agent-server/src/hub_emitter.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 
 use loopal_error::{LoopalError, Result};
 use loopal_ipc::protocol::methods;
-use loopal_protocol::{AgentEvent, AgentEventPayload};
+use loopal_protocol::{AgentEvent, AgentEventPayload, QualifiedAddress};
 use loopal_runtime::frontend::traits::EventEmitter;
 
 use crate::session_hub::SharedSession;
@@ -14,7 +14,7 @@ use crate::session_hub::SharedSession;
 #[derive(Clone)]
 pub(crate) struct HubEventEmitter {
     pub(crate) session: Option<Arc<SharedSession>>,
-    pub(crate) agent_name: Option<String>,
+    pub(crate) agent_name: Option<QualifiedAddress>,
 }
 
 #[async_trait]

--- a/crates/loopal-agent-server/src/hub_frontend.rs
+++ b/crates/loopal-agent-server/src/hub_frontend.rs
@@ -14,7 +14,9 @@ use tracing::{debug, info};
 
 use loopal_error::{LoopalError, Result};
 use loopal_ipc::protocol::methods;
-use loopal_protocol::{AgentEvent, AgentEventPayload, Question, UserQuestionResponse};
+use loopal_protocol::{
+    AgentEvent, AgentEventPayload, QualifiedAddress, Question, UserQuestionResponse,
+};
 use loopal_runtime::agent_input::AgentInput;
 use loopal_runtime::frontend::traits::{AgentFrontend, EventEmitter};
 use loopal_tool_api::PermissionDecision;
@@ -26,7 +28,8 @@ use crate::session_hub::SharedSession;
 pub struct HubFrontend {
     session: tokio::sync::RwLock<Arc<SharedSession>>,
     input_rx: tokio::sync::Mutex<tokio::sync::mpsc::Receiver<AgentInput>>,
-    agent_name: Option<String>,
+    /// Pre-converted to a local qualified address.
+    agent_name: Option<QualifiedAddress>,
     /// Watch channel for interrupt detection in recv_input.
     interrupt_rx: tokio::sync::Mutex<tokio::sync::watch::Receiver<u64>>,
 }
@@ -41,7 +44,7 @@ impl HubFrontend {
         Self {
             session: tokio::sync::RwLock::new(session),
             input_rx: tokio::sync::Mutex::new(input_rx),
-            agent_name,
+            agent_name: agent_name.map(QualifiedAddress::local),
             interrupt_rx: tokio::sync::Mutex::new(interrupt_rx),
         }
     }

--- a/crates/loopal-agent-server/src/ipc_emitter.rs
+++ b/crates/loopal-agent-server/src/ipc_emitter.rs
@@ -7,13 +7,14 @@ use async_trait::async_trait;
 use loopal_error::{LoopalError, Result};
 use loopal_ipc::connection::Connection;
 use loopal_ipc::protocol::methods;
-use loopal_protocol::{AgentEvent, AgentEventPayload};
+use loopal_protocol::{AgentEvent, AgentEventPayload, QualifiedAddress};
 use loopal_runtime::frontend::traits::EventEmitter;
 
 #[derive(Clone)]
 pub(crate) struct IpcEventEmitter {
     pub connection: Arc<Connection>,
-    pub agent_name: Option<String>,
+    /// Pre-converted to a local qualified address.
+    pub agent_name: Option<QualifiedAddress>,
 }
 
 #[async_trait]

--- a/crates/loopal-agent-server/src/ipc_frontend.rs
+++ b/crates/loopal-agent-server/src/ipc_frontend.rs
@@ -9,7 +9,8 @@ use loopal_error::{LoopalError, Result};
 use loopal_ipc::connection::{Connection, Incoming};
 use loopal_ipc::protocol::methods;
 use loopal_protocol::{
-    AgentEvent, AgentEventPayload, ControlCommand, Envelope, Question, UserQuestionResponse,
+    AgentEvent, AgentEventPayload, ControlCommand, Envelope, QualifiedAddress, Question,
+    UserQuestionResponse,
 };
 use loopal_runtime::agent_input::AgentInput;
 use loopal_runtime::frontend::traits::{AgentFrontend, EventEmitter};
@@ -22,7 +23,8 @@ use crate::ipc_emitter::IpcEventEmitter;
 pub struct IpcFrontend {
     connection: Arc<Connection>,
     incoming_rx: Mutex<mpsc::Receiver<Incoming>>,
-    agent_name: Option<String>,
+    /// Pre-converted to a local qualified address.
+    agent_name: Option<QualifiedAddress>,
 }
 
 impl IpcFrontend {
@@ -34,7 +36,7 @@ impl IpcFrontend {
         Self {
             connection,
             incoming_rx: Mutex::new(incoming_rx),
-            agent_name,
+            agent_name: agent_name.map(QualifiedAddress::local),
         }
     }
 }

--- a/crates/loopal-agent-server/tests/suite/ipc_frontend_test.rs
+++ b/crates/loopal-agent-server/tests/suite/ipc_frontend_test.rs
@@ -82,7 +82,8 @@ async fn recv_input_skips_unknown_notifications() {
                 methods::AGENT_MESSAGE.name,
                 serde_json::json!({
                     "id": "00000000-0000-0000-0000-000000000000",
-                    "source": "Human", "target": "main",
+                    "source": "Human",
+                    "target": {"hub": [], "agent": "main"},
                     "content": {"text": "test", "images": []},
                     "timestamp": "2024-01-01T00:00:00Z"
                 }),

--- a/crates/loopal-agent-server/tests/suite/params_test.rs
+++ b/crates/loopal-agent-server/tests/suite/params_test.rs
@@ -86,7 +86,10 @@ async fn event_forwarder_delivers_sub_agent_events() {
         Incoming::Notification { method, params } => {
             assert_eq!(method, methods::AGENT_EVENT.name);
             let ev: loopal_protocol::AgentEvent = serde_json::from_value(params).unwrap();
-            assert_eq!(ev.agent_name.as_deref(), Some("sub-1"));
+            assert_eq!(
+                ev.agent_name.as_ref().map(|a| a.to_string()).as_deref(),
+                Some("sub-1")
+            );
             match ev.payload {
                 loopal_protocol::AgentEventPayload::Stream { text } => {
                     assert_eq!(text, "from sub-agent");

--- a/crates/loopal-agent/src/tools/collaboration/send_message.rs
+++ b/crates/loopal-agent/src/tools/collaboration/send_message.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use loopal_error::LoopalError;
 use loopal_ipc::protocol::methods;
-use loopal_protocol::{Envelope, MessageSource};
+use loopal_protocol::{Envelope, MessageSource, QualifiedAddress};
 use loopal_tool_api::PermissionLevel;
 use loopal_tool_api::{Tool, ToolContext, ToolResult};
 
@@ -51,9 +51,11 @@ impl Tool for SendMessageTool {
         })?;
         let content = input["message"].as_str().unwrap_or("");
 
+        // Source carries this agent's local view (no hub prefix). Hub-A's
+        // uplink applies SNAT (`apply_snat`) before forwarding cross-hub.
         let envelope = Envelope::new(
-            MessageSource::Agent(shared.agent_name.clone()),
-            target,
+            MessageSource::Agent(QualifiedAddress::local(shared.agent_name.clone())),
+            QualifiedAddress::parse(target),
             content,
         );
         let params = serde_json::to_value(&envelope)

--- a/crates/loopal-ipc/src/protocol.rs
+++ b/crates/loopal-ipc/src/protocol.rs
@@ -141,11 +141,6 @@ pub mod methods {
     /// Cross-hub message routing (envelope forwarding).
     pub const META_ROUTE: Method = Method { name: "meta/route" };
 
-    /// MetaHub asks Sub-Hub if a named agent exists locally.
-    pub const META_RESOLVE: Method = Method {
-        name: "meta/resolve",
-    };
-
     /// Cross-hub agent spawn delegation.
     pub const META_SPAWN: Method = Method { name: "meta/spawn" };
 

--- a/crates/loopal-meta-hub/src/aggregator.rs
+++ b/crates/loopal-meta-hub/src/aggregator.rs
@@ -43,11 +43,17 @@ impl EventAggregator {
     }
 }
 
-/// Prefix the event's agent_name with `"hub_name/"` for global uniqueness.
+/// Stamp this hub's name into the event (SNAT-equivalent for events).
+///
+/// Two surfaces get NATed:
+/// 1. `event.agent_name` — always (hub itself is the originator if `None`).
+/// 2. `event.payload` — every still-local qualified address inside, so the
+///    payload is self-describing once it reaches the MetaHub broadcast plane.
 pub fn prefix_agent_name(event: &mut AgentEvent, hub_name: &str) {
-    if let Some(ref agent_name) = event.agent_name {
-        event.agent_name = Some(format!("{hub_name}/{agent_name}"));
+    if let Some(ref mut addr) = event.agent_name {
+        addr.prepend_hub_if_local(hub_name.to_string());
     } else {
-        event.agent_name = Some(hub_name.to_string());
+        event.agent_name = Some(loopal_protocol::QualifiedAddress::local(hub_name));
     }
+    event.payload.prepend_self_hub(hub_name);
 }

--- a/crates/loopal-meta-hub/src/dispatch.rs
+++ b/crates/loopal-meta-hub/src/dispatch.rs
@@ -16,7 +16,6 @@ pub async fn dispatch_meta_request(
 ) -> Result<Value, String> {
     match method {
         m if m == methods::META_ROUTE.name => handle_meta_route(meta_hub, params, &from_hub).await,
-        m if m == methods::META_RESOLVE.name => handle_meta_resolve(meta_hub, params).await,
         m if m == methods::META_SPAWN.name => handle_meta_spawn(meta_hub, params).await,
         m if m == methods::META_LIST_HUBS.name => handle_meta_list_hubs(meta_hub).await,
         m if m == methods::META_TOPOLOGY.name => handle_meta_topology(meta_hub).await,
@@ -37,11 +36,11 @@ async fn handle_meta_route(
     let envelope: loopal_protocol::Envelope =
         serde_json::from_value(params).map_err(|e| format!("invalid envelope: {e}"))?;
 
-    // Self-routing detection: if target explicitly names the originating hub, reject.
-    let addr = loopal_protocol::QualifiedAddress::parse(&envelope.target);
-    if addr.hub.as_deref() == Some(from_hub) {
+    // Self-routing detection: the next hop in target equals the originating hub.
+    if envelope.target.next_hop() == Some(from_hub) {
         return Err(format!(
-            "self-routing detected: target '{}' is on originating hub '{from_hub}', route locally",
+            "self-routing detected: target '{}' next-hop is originating hub '{from_hub}', \
+             route locally instead",
             envelope.target
         ));
     }
@@ -58,33 +57,6 @@ async fn handle_meta_route(
 
     mh.router.route(&envelope, &refs).await?;
     Ok(json!({"ok": true}))
-}
-
-/// Resolve whether an agent exists on any Sub-Hub.
-///
-/// Single lock acquisition — candidates snapshot and resolution happen together.
-async fn handle_meta_resolve(
-    meta_hub: &Arc<Mutex<MetaHub>>,
-    params: Value,
-) -> Result<Value, String> {
-    let agent_name = params["agent_name"]
-        .as_str()
-        .ok_or("missing 'agent_name'")?;
-
-    let mut mh = meta_hub.lock().await;
-    let candidates: Vec<(String, Arc<loopal_ipc::connection::Connection>)> = mh
-        .registry
-        .alive_hubs()
-        .into_iter()
-        .map(|(name, conn)| (name.to_string(), conn.clone()))
-        .collect();
-    let refs: Vec<(&str, &Arc<loopal_ipc::connection::Connection>)> =
-        candidates.iter().map(|(n, c)| (n.as_str(), c)).collect();
-
-    match mh.router.resolve_agent(agent_name, &refs).await {
-        Some(hub_name) => Ok(json!({"found": true, "hub": hub_name})),
-        None => Ok(json!({"found": false})),
-    }
 }
 
 /// Delegate agent spawn to a specific Sub-Hub.

--- a/crates/loopal-meta-hub/src/meta_hub.rs
+++ b/crates/loopal-meta-hub/src/meta_hub.rs
@@ -37,10 +37,7 @@ impl MetaHub {
     }
 
     /// Remove a sub-hub (disconnect cleanup).
-    ///
-    /// Invalidates router cache and unregisters.
     pub fn remove_hub(&mut self, hub_name: &str) {
-        self.router.invalidate_hub(hub_name);
         self.registry.unregister(hub_name);
         tracing::info!(hub = %hub_name, "sub-hub fully removed");
     }

--- a/crates/loopal-meta-hub/src/router.rs
+++ b/crates/loopal-meta-hub/src/router.rs
@@ -1,162 +1,63 @@
-//! Global router — cross-hub address resolution and message forwarding.
+//! Global router — cross-hub message forwarding with NAT-style hop consumption.
 //!
-//! Uses a query-cache pattern: check local cache first, then broadcast
-//! `meta/resolve` to all sub-hubs on cache miss. Does NOT maintain a
-//! global agent registry (avoids distributed consistency problem).
+//! Targets carry a hub path; the router consumes the front hop (DNAT)
+//! before forwarding to the corresponding sub-hub. No agent-name
+//! resolution is needed — the address tells the router everything.
 
-use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use loopal_ipc::connection::Connection;
 use loopal_protocol::Envelope;
 
-use crate::address::QualifiedAddress;
-
-/// Cache entry with TTL.
-struct CacheEntry {
-    hub_name: String,
-    cached_at: Instant,
-}
-
-/// Default cache TTL — entries expire after this duration.
-const CACHE_TTL: Duration = Duration::from_secs(60);
-
-/// Cross-hub address resolution and message routing.
+/// Cross-hub message router.
 ///
-/// Resolves agent addresses to hub names via:
-/// 1. Local cache lookup (fast path)
-/// 2. Broadcast query to all sub-hubs (slow path, on cache miss)
-///
-/// Does NOT own connections — borrows from `HubRegistry`.
-pub struct GlobalRouter {
-    /// agent_name → (hub_name, cached_at). Not authoritative.
-    route_cache: HashMap<String, CacheEntry>,
-}
-
-impl Default for GlobalRouter {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+/// Routing decisions come from the envelope's qualified target.
+/// The router does not own connections — it borrows from `HubRegistry`.
+#[derive(Default)]
+pub struct GlobalRouter;
 
 impl GlobalRouter {
     pub fn new() -> Self {
-        Self {
-            route_cache: HashMap::new(),
-        }
+        Self
     }
 
-    /// Look up cached hub name for an agent. Returns `None` on miss or expiry.
-    pub fn cache_lookup(&self, agent_name: &str) -> Option<&str> {
-        let entry = self.route_cache.get(agent_name)?;
-        if entry.cached_at.elapsed() > CACHE_TTL {
-            return None;
-        }
-        Some(&entry.hub_name)
-    }
-
-    /// Insert or update a cache entry.
-    pub fn cache_insert(&mut self, agent_name: &str, hub_name: &str) {
-        self.route_cache.insert(
-            agent_name.to_string(),
-            CacheEntry {
-                hub_name: hub_name.to_string(),
-                cached_at: Instant::now(),
-            },
-        );
-    }
-
-    /// Remove a cache entry (on routing failure or agent departure).
-    pub fn cache_invalidate(&mut self, agent_name: &str) {
-        self.route_cache.remove(agent_name);
-    }
-
-    /// Remove all cache entries for a specific hub (on hub disconnect).
-    pub fn invalidate_hub(&mut self, hub_name: &str) {
-        self.route_cache
-            .retain(|_, entry| entry.hub_name != hub_name);
-    }
-
-    /// Evict expired entries. Call periodically to keep cache bounded.
-    pub fn evict_expired(&mut self) {
-        self.route_cache
-            .retain(|_, entry| entry.cached_at.elapsed() <= CACHE_TTL);
-    }
-
-    /// Resolve an agent's hub by querying all sub-hubs.
-    ///
-    /// Sends `meta/resolve` to each hub in `candidates`. Returns the first
-    /// hub that confirms the agent exists.
-    pub async fn resolve_agent(
-        &mut self,
-        agent_name: &str,
-        candidates: &[(&str, &Arc<Connection>)],
-    ) -> Option<String> {
-        // Fast path: cache hit
-        if let Some(hub) = self.cache_lookup(agent_name) {
-            return Some(hub.to_string());
-        }
-
-        // Slow path: broadcast resolve query
-        let params = serde_json::json!({ "agent_name": agent_name });
-
-        for &(hub_name, conn) in candidates {
-            let result = conn.send_request("meta/resolve", params.clone()).await;
-            if let Ok(resp) = result
-                && resp.get("found").and_then(|v| v.as_bool()).unwrap_or(false)
-            {
-                self.cache_insert(agent_name, hub_name);
-                return Some(hub_name.to_string());
-            }
-        }
-
-        None
-    }
-
-    /// Route an envelope to the target agent's hub.
-    ///
-    /// Resolves the target address, then forwards the envelope to the correct
-    /// sub-hub via `agent/message`.
+    /// Route an envelope: pop the next-hop hub from the target (DNAT),
+    /// then deliver the envelope to that sub-hub.
     pub async fn route(
         &mut self,
         envelope: &Envelope,
         candidates: &[(&str, &Arc<Connection>)],
     ) -> Result<(), String> {
-        let addr = QualifiedAddress::parse(&envelope.target);
+        let next_hop = envelope.target.next_hop().ok_or_else(|| {
+            format!(
+                "MetaHub received envelope without hub path: target='{}'. \
+                 Cross-hub targets must carry an explicit `hub/agent` path.",
+                envelope.target
+            )
+        })?;
 
-        // Direct hub targeting (address contains hub prefix)
-        let hub_name = if let Some(hub) = &addr.hub {
-            hub.clone()
-        } else {
-            // Resolve agent to hub
-            self.resolve_agent(&addr.agent, candidates)
-                .await
-                .ok_or_else(|| format!("agent '{}' not found on any sub-hub", addr.agent))?
-        };
-
-        // Find the connection for the resolved hub
         let conn = candidates
             .iter()
-            .find(|(name, _)| *name == hub_name)
+            .find(|(name, _)| *name == next_hop)
             .map(|(_, conn)| Arc::clone(conn))
-            .ok_or_else(|| format!("hub '{hub_name}' not connected"))?;
+            .ok_or_else(|| format!("hub '{next_hop}' not connected"))?;
 
-        // Forward envelope to sub-hub (strip hub prefix from target)
+        // DNAT: peel the consumed hop off target before forwarding.
         let mut forwarded = envelope.clone();
-        forwarded.target = addr.agent;
+        let consumed = forwarded.apply_dnat();
 
         let params =
             serde_json::to_value(&forwarded).map_err(|e| format!("serialize envelope: {e}"))?;
 
         conn.send_request("agent/message", params)
             .await
-            .map_err(|e| format!("route to hub '{hub_name}' failed: {e}"))?;
+            .map_err(|e| format!("route to hub '{next_hop}' failed: {e}"))?;
 
         tracing::debug!(
-            hub = %hub_name,
+            hub = %next_hop,
             target = %forwarded.target,
-            "routed cross-hub message"
+            consumed = ?consumed,
+            "routed cross-hub message (DNAT applied)"
         );
         Ok(())
     }

--- a/crates/loopal-meta-hub/tests/e2e/e2e_cluster_test.rs
+++ b/crates/loopal-meta-hub/tests/e2e/e2e_cluster_test.rs
@@ -98,8 +98,8 @@ async fn cluster_cross_hub_message_delivery() {
     // Route message from hub-a to hub-b/main
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000020",
-        "source": {"Agent": "main"},
-        "target": "hub-b/main",
+        "source": {"Agent": {"hub": [], "agent": "main"}},
+        "target": {"hub": ["hub-b"], "agent": "main"},
         "content": {"text": "hello from hub-a", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });

--- a/crates/loopal-meta-hub/tests/suite.rs
+++ b/crates/loopal-meta-hub/tests/suite.rs
@@ -3,8 +3,14 @@ mod test_helpers;
 
 #[path = "suite/address_test.rs"]
 mod address_test;
+#[path = "suite/aggregator_snat_test.rs"]
+mod aggregator_snat_test;
 #[path = "suite/e2e_tcp_test.rs"]
 mod e2e_tcp_test;
+#[path = "suite/hub_lifecycle_test.rs"]
+mod hub_lifecycle_test;
+#[path = "suite/nat_routing_test.rs"]
+mod nat_routing_test;
 #[path = "suite/relay_event_test.rs"]
 mod relay_event_test;
 #[path = "suite/routing_test.rs"]

--- a/crates/loopal-meta-hub/tests/suite/address_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/address_test.rs
@@ -5,7 +5,7 @@ use loopal_protocol::QualifiedAddress;
 #[test]
 fn parse_local() {
     let addr = QualifiedAddress::parse("main");
-    assert_eq!(addr.hub, None);
+    assert!(addr.hub.is_empty());
     assert_eq!(addr.agent, "main");
     assert_eq!(addr.to_string(), "main");
 }
@@ -13,7 +13,7 @@ fn parse_local() {
 #[test]
 fn parse_remote() {
     let addr = QualifiedAddress::parse("hub-west/researcher");
-    assert_eq!(addr.hub.as_deref(), Some("hub-west"));
+    assert_eq!(addr.hub, vec!["hub-west"]);
     assert_eq!(addr.agent, "researcher");
     assert_eq!(addr.to_string(), "hub-west/researcher");
 }
@@ -23,4 +23,11 @@ fn roundtrip() {
     let original = "code-hub/worker-3";
     let addr = QualifiedAddress::parse(original);
     assert_eq!(addr.to_string(), original);
+}
+
+#[test]
+fn parse_multi_hub_path() {
+    let addr = QualifiedAddress::parse("mh-1/hub-A/agent");
+    assert_eq!(addr.hub, vec!["mh-1", "hub-A"]);
+    assert_eq!(addr.agent, "agent");
 }

--- a/crates/loopal-meta-hub/tests/suite/aggregator_snat_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/aggregator_snat_test.rs
@@ -1,0 +1,157 @@
+//! Tests for `aggregator::prefix_agent_name` — the event-side SNAT that
+//! stamps the relaying hub onto both `event.agent_name` and any still-local
+//! qualified addresses inside `event.payload`.
+
+use loopal_protocol::{AgentEvent, AgentEventPayload, MessageSource, QualifiedAddress};
+
+#[tokio::test]
+async fn prefix_agent_name_snats_subagent_spawned_local_parent() {
+    let mut event = AgentEvent::named(
+        QualifiedAddress::local("child"),
+        AgentEventPayload::SubAgentSpawned {
+            name: "child".into(),
+            agent_id: "id-1".into(),
+            parent: Some(QualifiedAddress::local("parent")),
+            model: None,
+            session_id: None,
+        },
+    );
+    loopal_meta_hub::aggregator::prefix_agent_name(&mut event, "hub-a");
+
+    assert_eq!(
+        event.agent_name,
+        Some(QualifiedAddress::remote(["hub-a"], "child"))
+    );
+    let AgentEventPayload::SubAgentSpawned { parent, .. } = event.payload else {
+        unreachable!()
+    };
+    assert_eq!(
+        parent,
+        Some(QualifiedAddress::remote(["hub-a"], "parent")),
+        "local parent must be prefixed by aggregator SNAT"
+    );
+}
+
+#[tokio::test]
+async fn prefix_agent_name_does_not_double_stamp_qualified_parent() {
+    let mut event = AgentEvent::named(
+        QualifiedAddress::local("child"),
+        AgentEventPayload::SubAgentSpawned {
+            name: "child".into(),
+            agent_id: "id-2".into(),
+            parent: Some(QualifiedAddress::remote(["hub-a"], "alpha")),
+            model: None,
+            session_id: None,
+        },
+    );
+    loopal_meta_hub::aggregator::prefix_agent_name(&mut event, "hub-b");
+
+    let AgentEventPayload::SubAgentSpawned { parent, .. } = event.payload else {
+        unreachable!()
+    };
+    assert_eq!(
+        parent,
+        Some(QualifiedAddress::remote(["hub-a"], "alpha")),
+        "already-qualified parent must not be double-stamped"
+    );
+}
+
+#[tokio::test]
+async fn prefix_agent_name_snats_message_routed_local_addresses() {
+    let mut event = AgentEvent::root(AgentEventPayload::MessageRouted {
+        source: MessageSource::Agent(QualifiedAddress::local("alpha")),
+        target: QualifiedAddress::local("beta"),
+        content_preview: "hi".into(),
+    });
+    loopal_meta_hub::aggregator::prefix_agent_name(&mut event, "hub-a");
+
+    let AgentEventPayload::MessageRouted { source, target, .. } = event.payload else {
+        unreachable!()
+    };
+    assert_eq!(
+        source,
+        MessageSource::Agent(QualifiedAddress::remote(["hub-a"], "alpha"))
+    );
+    assert_eq!(target, QualifiedAddress::remote(["hub-a"], "beta"));
+}
+
+#[tokio::test]
+async fn prefix_agent_name_preserves_already_qualified_message_source() {
+    // hub-B receives a message from hub-A and routes it locally — the
+    // resulting MessageRouted source already carries hub-A; aggregator
+    // must leave it alone but still stamp the local target.
+    let mut event = AgentEvent::root(AgentEventPayload::MessageRouted {
+        source: MessageSource::Agent(QualifiedAddress::remote(["hub-a"], "alpha")),
+        target: QualifiedAddress::local("beta"),
+        content_preview: "hi".into(),
+    });
+    loopal_meta_hub::aggregator::prefix_agent_name(&mut event, "hub-b");
+
+    let AgentEventPayload::MessageRouted { source, target, .. } = event.payload else {
+        unreachable!()
+    };
+    assert_eq!(
+        source,
+        MessageSource::Agent(QualifiedAddress::remote(["hub-a"], "alpha")),
+        "cross-hub source must not be re-stamped"
+    );
+    assert_eq!(
+        target,
+        QualifiedAddress::remote(["hub-b"], "beta"),
+        "local target must still be stamped with the relaying hub"
+    );
+}
+
+// --- Channel source SNAT (parity with Agent source) ---
+
+#[tokio::test]
+async fn prefix_agent_name_snats_message_routed_channel_local_from() {
+    let mut event = AgentEvent::root(AgentEventPayload::MessageRouted {
+        source: MessageSource::Channel {
+            channel: "general".into(),
+            from: QualifiedAddress::local("alpha"),
+        },
+        target: QualifiedAddress::local("beta"),
+        content_preview: "hi".into(),
+    });
+    loopal_meta_hub::aggregator::prefix_agent_name(&mut event, "hub-a");
+
+    let AgentEventPayload::MessageRouted { source, target, .. } = event.payload else {
+        unreachable!()
+    };
+    let MessageSource::Channel { channel, from } = source else {
+        panic!("expected Channel source");
+    };
+    assert_eq!(channel, "general");
+    assert_eq!(
+        from,
+        QualifiedAddress::remote(["hub-a"], "alpha"),
+        "local Channel.from must be stamped just like Agent address"
+    );
+    assert_eq!(target, QualifiedAddress::remote(["hub-a"], "beta"));
+}
+
+#[tokio::test]
+async fn prefix_agent_name_does_not_double_stamp_channel_qualified_from() {
+    let mut event = AgentEvent::root(AgentEventPayload::MessageRouted {
+        source: MessageSource::Channel {
+            channel: "general".into(),
+            from: QualifiedAddress::remote(["hub-a"], "alpha"),
+        },
+        target: QualifiedAddress::local("beta"),
+        content_preview: "hi".into(),
+    });
+    loopal_meta_hub::aggregator::prefix_agent_name(&mut event, "hub-b");
+
+    let AgentEventPayload::MessageRouted { source, .. } = event.payload else {
+        unreachable!()
+    };
+    let MessageSource::Channel { from, .. } = source else {
+        panic!("expected Channel source");
+    };
+    assert_eq!(
+        from,
+        QualifiedAddress::remote(["hub-a"], "alpha"),
+        "already-qualified Channel.from must not be double-stamped"
+    );
+}

--- a/crates/loopal-meta-hub/tests/suite/e2e_tcp_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/e2e_tcp_test.rs
@@ -129,8 +129,8 @@ async fn tcp_cluster_cross_hub_route() {
     // Route from Hub-A to Hub-B's agent via uplink → MetaHub → Hub-B
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000001",
-        "source": {"Agent": "sender"},
-        "target": "target",
+        "source": {"Agent": {"hub": [], "agent": "sender"}},
+        "target": {"hub": ["hub-b"], "agent": "target"},
         "content": {"text": "hello via TCP", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });
@@ -146,33 +146,6 @@ async fn tcp_cluster_cross_hub_route() {
         result.is_ok(),
         "TCP cross-hub route should succeed: {result:?}"
     );
-}
-
-#[tokio::test]
-async fn tcp_cluster_resolve_agent() {
-    let (addr, token, meta_hub) = boot_meta_hub().await;
-    let (hub_a, _) = make_hub();
-    let (hub_b, _) = make_hub();
-
-    let _conn_a = join_hub_tcp(&hub_a, &addr, &token, "hub-a").await;
-    let _conn_b = join_hub_tcp(&hub_b, &addr, &token, "hub-b").await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    let (_agent, _rx) = register_mock(&hub_b, "researcher").await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    // Resolve via MetaHub dispatch (simulating a meta/resolve from hub-a)
-    let result = loopal_meta_hub::dispatch::dispatch_meta_request(
-        &meta_hub,
-        methods::META_RESOLVE.name,
-        json!({"agent_name": "researcher"}),
-        "hub-a".into(),
-    )
-    .await
-    .unwrap();
-
-    assert_eq!(result["found"].as_bool(), Some(true));
-    assert_eq!(result["hub"].as_str(), Some("hub-b"));
 }
 
 #[tokio::test]

--- a/crates/loopal-meta-hub/tests/suite/hub_lifecycle_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/hub_lifecycle_test.rs
@@ -1,0 +1,25 @@
+//! Tests: hub lifecycle (disconnect cleanup) at the MetaHub level.
+
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use loopal_ipc::connection::Connection;
+
+use loopal_meta_hub::MetaHub;
+
+#[tokio::test]
+async fn hub_disconnect_cleans_up_registry() {
+    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
+    let (_, meta_transport) = loopal_ipc::duplex_pair();
+    let meta_conn = Arc::new(Connection::new(meta_transport));
+    let _rx = meta_conn.start();
+    {
+        let mut mh = meta_hub.lock().await;
+        mh.registry
+            .register("dying-hub", meta_conn, vec![])
+            .unwrap();
+        mh.remove_hub("dying-hub");
+        assert_eq!(mh.registry.len(), 0);
+    }
+}

--- a/crates/loopal-meta-hub/tests/suite/nat_routing_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/nat_routing_test.rs
@@ -1,0 +1,386 @@
+//! End-to-end NAT routing tests — verify the SNAT/DNAT invariant across
+//! a real Sub-Hub ↔ MetaHub ↔ Sub-Hub topology.
+//!
+//! These tests are the system-level companion to the unit-level address
+//! tests in `loopal-protocol/tests/suite/envelope_test.rs`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+
+use loopal_ipc::connection::Incoming;
+use loopal_ipc::protocol::methods;
+use loopal_protocol::{Envelope, MessageSource, QualifiedAddress};
+use serde_json::json;
+
+use loopal_meta_hub::MetaHub;
+
+use crate::test_helpers::*;
+
+/// α (hub-A) → hub-B/β: β must observe `source.hub = ["hub-A"]` so it
+/// can reply via the symmetric NAT path.
+#[tokio::test]
+async fn nat_stamps_origin_hub_into_source_for_cross_hub_messages() {
+    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
+    let (hub_a, _) = make_hub();
+    let (hub_b, _) = make_hub();
+    let hub_a_conn = wire_hub_to_meta("hub-a", &hub_a, &meta_hub).await;
+    let _hub_b_conn = wire_hub_to_meta("hub-b", &hub_b, &meta_hub).await;
+    {
+        let ul = Arc::new(loopal_agent_hub::HubUplink::new(hub_a_conn, "hub-a".into()));
+        hub_a.lock().await.uplink = Some(ul);
+    }
+    let (_agent_conn, mut beta_rx) = register_mock_agent(&hub_b, "beta", None).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // α sends with a *local* source (no hub) — hub-A's uplink will SNAT it.
+    let envelope = json!({
+        "id": "00000000-0000-0000-0000-0000000000aa",
+        "source": {"Agent": {"hub": [], "agent": "alpha"}},
+        "target": {"hub": ["hub-b"], "agent": "beta"},
+        "content": {"text": "hi beta", "images": []},
+        "timestamp": "2026-01-01T00:00:00Z"
+    });
+    let result = loopal_agent_hub::dispatch::dispatch_hub_request(
+        &hub_a,
+        methods::HUB_ROUTE.name,
+        envelope,
+        "alpha".into(),
+    )
+    .await;
+    assert!(result.is_ok(), "cross-hub route failed: {result:?}");
+
+    let msg = tokio::time::timeout(Duration::from_secs(2), beta_rx.recv())
+        .await
+        .expect("beta should receive a message")
+        .expect("channel closed");
+
+    let Incoming::Request { method, params, .. } = msg else {
+        panic!("expected request, got {msg:?}");
+    };
+    assert_eq!(method, methods::AGENT_MESSAGE.name);
+    let env: Envelope = serde_json::from_value(params).expect("envelope deserializes at receiver");
+
+    // SNAT: source carries hub-A.
+    assert_eq!(
+        env.source,
+        MessageSource::Agent(QualifiedAddress::remote(["hub-a"], "alpha")),
+        "receiver must see hub-prefixed source"
+    );
+    // DNAT: target hub stripped down to local view.
+    assert_eq!(
+        env.target,
+        QualifiedAddress::local("beta"),
+        "target should appear local at the destination hub"
+    );
+}
+
+/// Local-only routes must remain hub-free in the source (no SNAT applied
+/// when the message never crosses an outbound boundary).
+#[tokio::test]
+async fn local_route_does_not_inject_hub_into_source() {
+    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
+    let (hub_a, _) = make_hub();
+    let hub_a_conn = wire_hub_to_meta("hub-a", &hub_a, &meta_hub).await;
+    {
+        let ul = Arc::new(loopal_agent_hub::HubUplink::new(hub_a_conn, "hub-a".into()));
+        hub_a.lock().await.uplink = Some(ul);
+    }
+    let (_agent_conn, mut peer_rx) = register_mock_agent(&hub_a, "peer", None).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let envelope = json!({
+        "id": "00000000-0000-0000-0000-0000000000bb",
+        "source": {"Agent": {"hub": [], "agent": "alpha"}},
+        "target": {"hub": [], "agent": "peer"},
+        "content": {"text": "intra-hub", "images": []},
+        "timestamp": "2026-01-01T00:00:00Z"
+    });
+    let result = loopal_agent_hub::dispatch::dispatch_hub_request(
+        &hub_a,
+        methods::HUB_ROUTE.name,
+        envelope,
+        "alpha".into(),
+    )
+    .await;
+    assert!(result.is_ok());
+
+    let msg = tokio::time::timeout(Duration::from_secs(2), peer_rx.recv())
+        .await
+        .expect("peer should receive")
+        .expect("channel closed");
+    let Incoming::Request { params, .. } = msg else {
+        panic!("expected request");
+    };
+    let env: Envelope = serde_json::from_value(params).unwrap();
+
+    // No SNAT happened — source remains local.
+    assert_eq!(
+        env.source,
+        MessageSource::Agent(QualifiedAddress::local("alpha"))
+    );
+    assert_eq!(env.target, QualifiedAddress::local("peer"));
+}
+
+/// MetaHub must reject envelopes whose next-hop hub is the originating hub
+/// — this catches loops before they cause a self-deliver storm.
+#[tokio::test]
+async fn metahub_rejects_self_routing() {
+    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
+    let (hub_a, _) = make_hub();
+    let _hub_a_conn = wire_hub_to_meta("hub-a", &hub_a, &meta_hub).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let envelope = json!({
+        "id": "00000000-0000-0000-0000-0000000000cc",
+        "source": {"Agent": {"hub": [], "agent": "alpha"}},
+        "target": {"hub": ["hub-a"], "agent": "anyone"},
+        "content": {"text": "boomerang", "images": []},
+        "timestamp": "2026-01-01T00:00:00Z"
+    });
+    let result = loopal_meta_hub::dispatch::dispatch_meta_request(
+        &meta_hub,
+        methods::META_ROUTE.name,
+        envelope,
+        "hub-a".into(),
+    )
+    .await;
+    let err = result.expect_err("self-routing must be rejected");
+    assert!(err.contains("self-routing"), "unexpected error: {err}");
+}
+
+/// Self-reply test: β receives a stamped source from α and uses it
+/// verbatim as the reply target. The reply must traverse the symmetric
+/// NAT path back to α with the right source/target shapes at each hop.
+#[tokio::test]
+async fn nat_round_trip_reply_returns_to_origin() {
+    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
+    let (hub_a, _) = make_hub();
+    let (hub_b, _) = make_hub();
+    let hub_a_conn = wire_hub_to_meta("hub-a", &hub_a, &meta_hub).await;
+    let hub_b_conn = wire_hub_to_meta("hub-b", &hub_b, &meta_hub).await;
+    {
+        let ul = Arc::new(loopal_agent_hub::HubUplink::new(hub_a_conn, "hub-a".into()));
+        hub_a.lock().await.uplink = Some(ul);
+    }
+    {
+        let ul = Arc::new(loopal_agent_hub::HubUplink::new(hub_b_conn, "hub-b".into()));
+        hub_b.lock().await.uplink = Some(ul);
+    }
+    let (_alpha_conn, mut alpha_rx) = register_mock_agent(&hub_a, "alpha", None).await;
+    let (_beta_conn, mut beta_rx) = register_mock_agent(&hub_b, "beta", None).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // ── Outbound: α → hub-B/β ──────────────────────────────────────
+    let outbound = json!({
+        "id": "00000000-0000-0000-0000-000000000100",
+        "source": {"Agent": {"hub": [], "agent": "alpha"}},
+        "target": {"hub": ["hub-b"], "agent": "beta"},
+        "content": {"text": "ping", "images": []},
+        "timestamp": "2026-01-01T00:00:00Z"
+    });
+    let r = loopal_agent_hub::dispatch::dispatch_hub_request(
+        &hub_a,
+        methods::HUB_ROUTE.name,
+        outbound,
+        "alpha".into(),
+    )
+    .await;
+    assert!(r.is_ok(), "outbound route failed: {r:?}");
+
+    let beta_msg = tokio::time::timeout(Duration::from_secs(2), beta_rx.recv())
+        .await
+        .expect("beta receives outbound")
+        .expect("channel open");
+    let Incoming::Request { params, .. } = beta_msg else {
+        panic!("expected request");
+    };
+    let outbound_env: Envelope = serde_json::from_value(params).unwrap();
+    let reply_target = match outbound_env.source.clone() {
+        MessageSource::Agent(qa) => qa,
+        other => panic!("expected Agent source, got {other:?}"),
+    };
+    assert_eq!(
+        reply_target,
+        QualifiedAddress::remote(["hub-a"], "alpha"),
+        "β should receive a hub-stamped source it can reply to"
+    );
+
+    // ── Reply: β uses the received source verbatim as target ───────
+    let reply = json!({
+        "id": "00000000-0000-0000-0000-000000000101",
+        "source": {"Agent": {"hub": [], "agent": "beta"}},
+        "target": {"hub": reply_target.hub, "agent": reply_target.agent},
+        "content": {"text": "pong", "images": []},
+        "timestamp": "2026-01-01T00:00:00Z"
+    });
+    let r = loopal_agent_hub::dispatch::dispatch_hub_request(
+        &hub_b,
+        methods::HUB_ROUTE.name,
+        reply,
+        "beta".into(),
+    )
+    .await;
+    assert!(r.is_ok(), "reply route failed: {r:?}");
+
+    // ── α receives the reply with hub-B stamped, target local ──────
+    let alpha_msg = tokio::time::timeout(Duration::from_secs(2), alpha_rx.recv())
+        .await
+        .expect("alpha receives reply")
+        .expect("channel open");
+    let Incoming::Request { params, .. } = alpha_msg else {
+        panic!("expected request");
+    };
+    let reply_env: Envelope = serde_json::from_value(params).unwrap();
+    assert_eq!(
+        reply_env.source,
+        MessageSource::Agent(QualifiedAddress::remote(["hub-b"], "beta")),
+        "α should see the symmetric hub-B stamp on the reply source"
+    );
+    assert_eq!(
+        reply_env.target,
+        QualifiedAddress::local("alpha"),
+        "α should see a local target after MetaHub DNAT"
+    );
+    assert_eq!(reply_env.content.text, "pong");
+}
+
+/// Cross-hub completion: hub-B child finishes → completion envelope reaches
+/// hub-A parent with the child's hub stamped onto `source` (so the parent
+/// can correlate the result with the originating hub even when child names
+/// collide across the cluster).
+#[tokio::test]
+async fn cross_hub_completion_carries_origin_hub_in_source() {
+    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
+    let (hub_a, _) = make_hub();
+    let (hub_b, _) = make_hub();
+    let _hub_a_conn = wire_hub_to_meta("hub-a", &hub_a, &meta_hub).await;
+    let hub_b_conn = wire_hub_to_meta("hub-b", &hub_b, &meta_hub).await;
+    {
+        let ul = Arc::new(loopal_agent_hub::HubUplink::new(hub_b_conn, "hub-b".into()));
+        hub_b.lock().await.uplink = Some(ul);
+    }
+
+    // Set up a "parent" on hub-A — it's the receiver of the completion.
+    let (_parent_conn, mut parent_rx) = register_mock_agent(&hub_a, "parent", None).await;
+
+    // Register a child on hub-B whose parent is *remote* (lives on hub-A).
+    // No completion_tx — finish_and_deliver will fall through to uplink.
+    let (client_t, server_t) = loopal_ipc::duplex_pair();
+    let child_conn = Arc::new(loopal_ipc::connection::Connection::new(server_t));
+    let _client_conn = Arc::new(loopal_ipc::connection::Connection::new(client_t));
+    let _server_rx = child_conn.start();
+    let _client_rx = _client_conn.start();
+    {
+        let mut h = hub_b.lock().await;
+        h.registry
+            .register_connection_with_parent(
+                "child",
+                child_conn.clone(),
+                Some(QualifiedAddress::remote(["hub-a"], "parent")),
+                None,
+                None,
+            )
+            .unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Trigger finish. finish_and_deliver detects the remote parent and
+    // routes the completion envelope through hub-B's uplink.
+    loopal_agent_hub::finish::finish_and_deliver(&hub_b, "child", Some("ok".into()), &child_conn)
+        .await;
+
+    // hub-A's parent should observe the completion envelope.
+    let msg = tokio::time::timeout(Duration::from_secs(2), parent_rx.recv())
+        .await
+        .expect("parent should receive completion")
+        .expect("channel open");
+    let Incoming::Request { params, .. } = msg else {
+        panic!("expected request");
+    };
+    let env: Envelope = serde_json::from_value(params).unwrap();
+
+    // Source: Agent(QA{hub=["hub-b"], agent="child"}) — proves SNAT applied.
+    assert_eq!(
+        env.source,
+        MessageSource::Agent(QualifiedAddress::remote(["hub-b"], "child")),
+        "completion source must carry origin hub"
+    );
+    // Target: local("parent") — proves DNAT consumed hub-A from the path.
+    assert_eq!(env.target, QualifiedAddress::local("parent"));
+    assert!(env.content.text.contains("<agent-result name=\"child\">"));
+    assert!(env.content.text.contains("ok"));
+}
+
+/// Cross-hub spawn: a child registered with a qualified `hub/agent` parent
+/// string lands typed in both `AgentInfo.parent` and the `SubAgentSpawned`
+/// event payload — proving the spawn protocol's wire format flows into
+/// the type system without lossy stringly-typed detours.
+#[tokio::test]
+async fn cross_hub_spawn_carries_qualified_parent_through_event_and_registry() {
+    use loopal_agent_hub::spawn_manager::register_agent_connection;
+    use loopal_ipc::connection::Connection;
+    use loopal_protocol::AgentEventPayload;
+
+    let (hub_b, mut event_rx) = make_hub();
+
+    // Simulate the IPC inbound side of a remote spawn — a client connection
+    // arrives over duplex and registers with a qualified parent string
+    // (the form produced by `dispatch_handlers::handle_spawn_agent` on the
+    // originating hub when target_hub is set).
+    let (client_t, server_t) = loopal_ipc::duplex_pair();
+    let server_conn = Arc::new(Connection::new(server_t));
+    let _client_conn = Arc::new(Connection::new(client_t));
+    let server_rx = server_conn.start();
+    let _client_rx = _client_conn.start();
+
+    let _ = register_agent_connection(
+        hub_b.clone(),
+        "child",
+        server_conn,
+        server_rx,
+        Some("hub-a/alpha"), // qualified parent over the wire
+        None,
+        None,
+    )
+    .await
+    .expect("registration succeeds");
+
+    // Drain events until the SubAgentSpawned arrives — Started may race ahead.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let spawned = loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let event = tokio::time::timeout(remaining, event_rx.recv())
+            .await
+            .expect("waiting for SubAgentSpawned timed out")
+            .expect("event channel open");
+        if matches!(event.payload, AgentEventPayload::SubAgentSpawned { .. }) {
+            break event;
+        }
+    };
+    let AgentEventPayload::SubAgentSpawned { name, parent, .. } = spawned.payload else {
+        unreachable!()
+    };
+    assert_eq!(name, "child");
+    assert_eq!(
+        parent,
+        Some(QualifiedAddress::remote(["hub-a"], "alpha")),
+        "event parent must be a typed qualified address"
+    );
+
+    // AgentInfo.parent on hub-B must mirror the same QA — it's the only
+    // way `finish::finish_and_deliver` knows to route the completion via
+    // uplink instead of looking for a local parent.
+    let h = hub_b.lock().await;
+    let info = h.registry.agent_info("child").expect("child registered");
+    assert_eq!(
+        info.parent,
+        Some(QualifiedAddress::remote(["hub-a"], "alpha")),
+        "AgentInfo.parent must hold the qualified address"
+    );
+    assert!(
+        info.parent.as_ref().is_some_and(|p| p.is_remote()),
+        "parent must be flagged remote so completion takes the uplink path"
+    );
+}

--- a/crates/loopal-meta-hub/tests/suite/relay_event_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/relay_event_test.rs
@@ -84,30 +84,16 @@ async fn event_aggregation_prefixes_hub_name() {
 
     let received = tokio::time::timeout(Duration::from_secs(1), event_rx.recv()).await;
     assert_eq!(
-        received.unwrap().unwrap().agent_name.as_deref(),
+        received
+            .unwrap()
+            .unwrap()
+            .agent_name
+            .map(|a| a.to_string())
+            .as_deref(),
         Some("hub-b/test-agent")
     );
 }
 
-#[tokio::test]
-async fn hub_disconnect_cleans_up_registry() {
-    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
-    let (_, meta_transport) = loopal_ipc::duplex_pair();
-    let meta_conn = Arc::new(Connection::new(meta_transport));
-    let _rx = meta_conn.start();
-    {
-        let mut mh = meta_hub.lock().await;
-        mh.registry
-            .register("dying-hub", meta_conn, vec![])
-            .unwrap();
-        mh.router.cache_insert("agent-on-dying", "dying-hub");
-        mh.remove_hub("dying-hub");
-        assert_eq!(mh.registry.len(), 0);
-        assert!(mh.router.cache_lookup("agent-on-dying").is_none());
-    }
-}
-
-/// Hub with local UI clients does NOT relay via uplink (regression).
 #[tokio::test]
 async fn local_ui_skips_uplink_relay() {
     let (hub, _) = make_hub();
@@ -192,9 +178,9 @@ async fn multi_hub_events_in_single_broadcast() {
         .unwrap()
         .unwrap();
 
-    let names: Vec<_> = [e1, e2]
+    let names: Vec<String> = [e1, e2]
         .iter()
-        .filter_map(|e| e.agent_name.clone())
+        .filter_map(|e| e.agent_name.as_ref().map(|a| a.to_string()))
         .collect();
     assert!(names.contains(&"hub-a/worker-1".to_string()));
     assert!(names.contains(&"hub-b/worker-2".to_string()));

--- a/crates/loopal-meta-hub/tests/suite/routing_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/routing_test.rs
@@ -20,9 +20,12 @@ async fn route_message_across_hubs() {
     let (_agent_conn, _rx) = register_mock_agent(&hub_b, "target", None).await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
+    // After hub-a's SNAT the target carries the next-hop hub name; here we
+    // feed MetaHub directly so we synthesize the post-SNAT envelope.
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000001",
-        "source": {"Agent": "sender"}, "target": "target",
+        "source": {"Agent": {"hub": ["hub-a"], "agent": "sender"}},
+        "target": {"hub": ["hub-b"], "agent": "target"},
         "content": {"text": "cross-hub hello", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });
@@ -50,9 +53,13 @@ async fn hub_uplink_escalates_unknown_agent() {
     let (_agent_conn, _rx) = register_mock_agent(&hub_b, "remote-worker", None).await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
+    // Targets must already carry the destination hub — NAT model no longer
+    // resolves bare agent names at MetaHub. The agent supplies a qualified
+    // address explicitly (or via tooling that knows about ListHubs).
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000002",
-        "source": {"Agent": "local"}, "target": "remote-worker",
+        "source": {"Agent": {"hub": [], "agent": "local"}},
+        "target": {"hub": ["hub-b"], "agent": "remote-worker"},
         "content": {"text": "find you", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });
@@ -85,7 +92,8 @@ async fn qualified_address_routes_via_uplink() {
 
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000003",
-        "source": {"Agent": "sender"}, "target": "hub-b/worker",
+        "source": {"Agent": {"hub": [], "agent": "sender"}},
+        "target": {"hub": ["hub-b"], "agent": "worker"},
         "content": {"text": "explicit hub target", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });
@@ -113,7 +121,8 @@ async fn route_to_nonexistent_agent_fails() {
 
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000004",
-        "source": {"Agent": "sender"}, "target": "ghost-agent",
+        "source": {"Agent": {"hub": [], "agent": "sender"}},
+        "target": {"hub": ["hub-b"], "agent": "ghost-agent"},
         "content": {"text": "nobody home", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });
@@ -151,7 +160,8 @@ async fn route_after_hub_disconnect_fails() {
 
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000005",
-        "source": {"Agent": "sender"}, "target": "target",
+        "source": {"Agent": {"hub": [], "agent": "sender"}},
+        "target": {"hub": ["hub-b"], "agent": "target"},
         "content": {"text": "too late", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });

--- a/crates/loopal-meta-hub/tests/suite/shadow_lifecycle_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/shadow_lifecycle_test.rs
@@ -24,16 +24,19 @@ async fn shadow_registered_with_correct_parent() {
     let (hub, _) = make_hub();
     let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
 
-    hub.lock()
-        .await
-        .registry
-        .register_shadow("remote-child", "parent");
+    hub.lock().await.registry.register_shadow(
+        "remote-child",
+        loopal_protocol::QualifiedAddress::local("parent"),
+    );
 
     let h = hub.lock().await;
     let info = h.registry.agent_info("remote-child");
     assert!(info.is_some(), "shadow should exist");
     let info = info.unwrap();
-    assert_eq!(info.parent.as_deref(), Some("parent"));
+    assert_eq!(
+        info.parent.as_ref().map(|p| p.to_string()).as_deref(),
+        Some("parent")
+    );
     assert_eq!(format!("{:?}", info.lifecycle), "Running");
 
     // Shadow should be in parent's children
@@ -47,10 +50,10 @@ async fn wait_agent_resolves_on_shadow_completion() {
     let (hub, _) = make_hub();
     // Register parent + shadow manually (simulate post-spawn state)
     let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
-    hub.lock()
-        .await
-        .registry
-        .register_shadow("remote-child", "parent");
+    hub.lock().await.registry.register_shadow(
+        "remote-child",
+        loopal_protocol::QualifiedAddress::local("parent"),
+    );
 
     // Start wait_agent in background
     let hub2 = hub.clone();
@@ -91,7 +94,10 @@ async fn wait_agent_resolves_on_shadow_completion() {
 async fn shadow_cleaned_up_after_completion() {
     let (hub, _) = make_hub();
     let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
-    hub.lock().await.registry.register_shadow("child", "parent");
+    hub.lock()
+        .await
+        .registry
+        .register_shadow("child", loopal_protocol::QualifiedAddress::local("parent"));
 
     // Verify shadow exists
     assert!(hub.lock().await.registry.agent_info("child").is_some());
@@ -144,10 +150,10 @@ async fn orphan_cascade_skips_shadows() {
     )
     .await;
 
-    hub.lock()
-        .await
-        .registry
-        .register_shadow("shadow-child", "parent");
+    hub.lock().await.registry.register_shadow(
+        "shadow-child",
+        loopal_protocol::QualifiedAddress::local("parent"),
+    );
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Parent finishes → should cascade interrupt to real-child only
@@ -176,15 +182,15 @@ async fn orphan_cascade_skips_shadows() {
 async fn route_to_shadow_fails() {
     let (hub, _) = make_hub();
     let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
-    hub.lock()
-        .await
-        .registry
-        .register_shadow("shadow-agent", "parent");
+    hub.lock().await.registry.register_shadow(
+        "shadow-agent",
+        loopal_protocol::QualifiedAddress::local("parent"),
+    );
 
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000010",
-        "source": {"Agent": "sender"},
-        "target": "shadow-agent",
+        "source": {"Agent": {"hub": [], "agent": "sender"}},
+        "target": {"hub": [], "agent": "shadow-agent"},
         "content": {"text": "can you hear me?", "images": []},
         "timestamp": "2026-01-01T00:00:00Z"
     });
@@ -206,10 +212,10 @@ async fn route_to_shadow_fails() {
 async fn shadow_visible_in_agent_list() {
     let (hub, _) = make_hub();
     let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
-    hub.lock()
-        .await
-        .registry
-        .register_shadow("remote-x", "parent");
+    hub.lock().await.registry.register_shadow(
+        "remote-x",
+        loopal_protocol::QualifiedAddress::local("parent"),
+    );
 
     let agents = hub.lock().await.registry.list_agents();
     let shadow = agents.iter().find(|(n, _)| n == "remote-x");

--- a/crates/loopal-meta-hub/tests/suite/status_resolve_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/status_resolve_test.rs
@@ -1,4 +1,4 @@
-//! Tests: hub/status, meta/list_hubs, meta/resolve, heartbeat.
+//! Tests: hub/status, meta/list_hubs, heartbeat.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -62,46 +62,6 @@ async fn list_hubs_returns_registered() {
     .await
     .unwrap();
     assert_eq!(r["hubs"].as_array().unwrap().len(), 2);
-}
-
-#[tokio::test]
-async fn resolve_agent_finds_correct_hub() {
-    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
-    let (ha, _) = make_hub();
-    let (hb, _) = make_hub();
-    let _a = wire_hub_to_meta("hub-a", &ha, &meta_hub).await;
-    let _b = wire_hub_to_meta("hub-b", &hb, &meta_hub).await;
-    let (_c, _rx) = register_mock_agent(&hb, "only-on-b", None).await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    let r = loopal_meta_hub::dispatch::dispatch_meta_request(
-        &meta_hub,
-        methods::META_RESOLVE.name,
-        json!({"agent_name": "only-on-b"}),
-        "hub-a".into(),
-    )
-    .await
-    .unwrap();
-    assert_eq!(r["found"].as_bool(), Some(true));
-    assert_eq!(r["hub"].as_str(), Some("hub-b"));
-}
-
-#[tokio::test]
-async fn resolve_nonexistent_returns_false() {
-    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
-    let (ha, _) = make_hub();
-    let _a = wire_hub_to_meta("hub-a", &ha, &meta_hub).await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    let r = loopal_meta_hub::dispatch::dispatch_meta_request(
-        &meta_hub,
-        methods::META_RESOLVE.name,
-        json!({"agent_name": "ghost"}),
-        "hub-a".into(),
-    )
-    .await
-    .unwrap();
-    assert_eq!(r["found"].as_bool(), Some(false));
 }
 
 #[tokio::test]

--- a/crates/loopal-protocol/src/address.rs
+++ b/crates/loopal-protocol/src/address.rs
@@ -1,120 +1,124 @@
-//! Qualified address — cross-hub agent addressing.
+//! Qualified address — cross-hub agent addressing for NAT-style routing.
 //!
-//! Addresses follow the format `"hub_name/agent_name"` for cross-hub routing,
-//! or plain `"agent_name"` for local (intra-hub) routing.
+//! Format: `"hub_1/hub_2/.../agent_name"`. Hub list grows when crossing
+//! outbound hub boundaries (SNAT) and shrinks when crossing inbound (DNAT).
+//! Empty hub list means a local address inside the current hub.
 
 use std::fmt;
 
-/// A parsed agent address that may span across hubs.
-///
-/// - `hub: None` — local address within the current hub.
-/// - `hub: Some(name)` — cross-hub address targeting a specific sub-hub.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+use serde::{Deserialize, Serialize};
+
+/// A parsed agent address that may span across one or more hub layers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct QualifiedAddress {
-    /// Target hub name. `None` means local (current hub).
-    pub hub: Option<String>,
-    /// Agent name within the target hub.
+    /// Hub path from the **receiver's view**. Empty = local agent.
+    /// Multi-element supports MetaHub-of-MetaHub: `["mh-1", "hub-A"]`.
+    pub hub: Vec<String>,
+    /// Agent name within the final hub (no `/` allowed).
     pub agent: String,
 }
 
 impl QualifiedAddress {
-    /// Create a local (intra-hub) address.
+    /// Local (intra-hub) address.
     pub fn local(agent: impl Into<String>) -> Self {
         Self {
-            hub: None,
+            hub: Vec::new(),
             agent: agent.into(),
         }
     }
 
-    /// Create a cross-hub address.
-    pub fn remote(hub: impl Into<String>, agent: impl Into<String>) -> Self {
+    /// Cross-hub address with an explicit hub path.
+    pub fn remote<H, S>(hubs: H, agent: impl Into<String>) -> Self
+    where
+        H: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
         Self {
-            hub: Some(hub.into()),
+            hub: hubs.into_iter().map(Into::into).collect(),
             agent: agent.into(),
         }
     }
 
-    /// Parse an address string.
-    ///
-    /// - `"researcher"` → local address
-    /// - `"hub-a/researcher"` → cross-hub address
-    ///
-    /// Hub names must not contain `/`.
+    /// Parse `"h1/h2/.../agent"` — last segment is the agent, the rest is
+    /// the hub path. Strings with empty segments fall back to a local
+    /// address whose name preserves the original input verbatim.
     pub fn parse(s: &str) -> Self {
-        match s.split_once('/') {
-            Some((hub, agent)) if !hub.is_empty() && !agent.is_empty() => Self {
-                hub: Some(hub.to_string()),
-                agent: agent.to_string(),
-            },
-            _ => Self {
-                hub: None,
-                agent: s.to_string(),
-            },
+        if s.is_empty() {
+            return Self::local("");
+        }
+        let parts: Vec<&str> = s.split('/').collect();
+        if parts.iter().any(|p| p.is_empty()) {
+            return Self::local(s);
+        }
+        let (agent, hubs) = parts.split_last().expect("non-empty after split");
+        Self {
+            hub: hubs.iter().map(|s| (*s).to_string()).collect(),
+            agent: (*agent).to_string(),
         }
     }
 
-    /// Whether this is a cross-hub address.
+    pub fn is_local(&self) -> bool {
+        self.hub.is_empty()
+    }
+
     pub fn is_remote(&self) -> bool {
-        self.hub.is_some()
+        !self.hub.is_empty()
+    }
+
+    /// SNAT — prepend a hub name when crossing an outbound boundary.
+    /// The new hub becomes the next hop from the receiver's view.
+    pub fn prepend_hub(&mut self, hub_name: impl Into<String>) {
+        self.hub.insert(0, hub_name.into());
+    }
+
+    /// Conditional SNAT — only prepend if this address is still local.
+    /// Used by event aggregation where some inner addresses already carry
+    /// a hub path (cross-hub references) and must not be double-stamped.
+    pub fn prepend_hub_if_local(&mut self, hub_name: impl Into<String>) {
+        if self.is_local() {
+            self.prepend_hub(hub_name);
+        }
+    }
+
+    /// DNAT — pop the front hub name (the next hop being consumed).
+    /// Returns the popped name for routing diagnostics.
+    pub fn pop_front_hub(&mut self) -> Option<String> {
+        if self.hub.is_empty() {
+            None
+        } else {
+            Some(self.hub.remove(0))
+        }
+    }
+
+    /// Peek the next hop without mutating.
+    pub fn next_hop(&self) -> Option<&str> {
+        self.hub.first().map(String::as_str)
     }
 }
 
 impl fmt::Display for QualifiedAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.hub {
-            Some(hub) => write!(f, "{hub}/{}", self.agent),
-            None => write!(f, "{}", self.agent),
+        for h in &self.hub {
+            write!(f, "{h}/")?;
         }
+        write!(f, "{}", self.agent)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_local_address() {
-        let addr = QualifiedAddress::parse("researcher");
-        assert_eq!(addr.hub, None);
-        assert_eq!(addr.agent, "researcher");
-        assert!(!addr.is_remote());
-        assert_eq!(addr.to_string(), "researcher");
+impl From<&str> for QualifiedAddress {
+    fn from(s: &str) -> Self {
+        Self::parse(s)
     }
+}
 
-    #[test]
-    fn parse_remote_address() {
-        let addr = QualifiedAddress::parse("hub-a/researcher");
-        assert_eq!(addr.hub.as_deref(), Some("hub-a"));
-        assert_eq!(addr.agent, "researcher");
-        assert!(addr.is_remote());
-        assert_eq!(addr.to_string(), "hub-a/researcher");
+impl From<String> for QualifiedAddress {
+    fn from(s: String) -> Self {
+        Self::parse(&s)
     }
+}
 
-    #[test]
-    fn parse_edge_cases() {
-        // Leading slash → local (empty hub name)
-        let addr = QualifiedAddress::parse("/researcher");
-        assert_eq!(addr.hub, None);
-        assert_eq!(addr.agent, "/researcher");
-
-        // Trailing slash → local (empty agent name)
-        let addr = QualifiedAddress::parse("hub-a/");
-        assert_eq!(addr.hub, None);
-        assert_eq!(addr.agent, "hub-a/");
-
-        // Empty string → local
-        let addr = QualifiedAddress::parse("");
-        assert_eq!(addr.hub, None);
-        assert_eq!(addr.agent, "");
-    }
-
-    #[test]
-    fn constructors() {
-        let local = QualifiedAddress::local("main");
-        assert!(!local.is_remote());
-
-        let remote = QualifiedAddress::remote("hub-b", "worker");
-        assert!(remote.is_remote());
-        assert_eq!(remote.to_string(), "hub-b/worker");
+impl From<&String> for QualifiedAddress {
+    fn from(s: &String) -> Self {
+        Self::parse(s)
     }
 }

--- a/crates/loopal-protocol/src/envelope.rs
+++ b/crates/loopal-protocol/src/envelope.rs
@@ -2,20 +2,22 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::address::QualifiedAddress;
 use crate::user_content::UserContent;
 
 /// Origin of a message in the three-plane architecture.
+///
+/// `Agent` and `Channel.from` carry a [`QualifiedAddress`] so receivers
+/// see the full return path after NAT (`apply_snat`) at hub boundaries.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MessageSource {
-    /// Message from a human user.
     Human,
-    /// Message from a named agent.
-    Agent(String),
-    /// Message delivered through a pub/sub channel.
-    Channel { channel: String, from: String },
-    /// Message injected by the cron scheduler.
+    Agent(QualifiedAddress),
+    Channel {
+        channel: String,
+        from: QualifiedAddress,
+    },
     Scheduled,
-    /// System-generated notification from Hub (e.g. agent completion).
     System(String),
 }
 
@@ -24,41 +26,54 @@ impl MessageSource {
     pub fn label(&self) -> String {
         match self {
             Self::Human => "human".to_string(),
-            Self::Agent(name) => name.clone(),
-            Self::Channel { from, .. } => from.clone(),
+            Self::Agent(addr) => addr.to_string(),
+            Self::Channel { from, .. } => from.to_string(),
             Self::Scheduled => "scheduled".to_string(),
             Self::System(kind) => format!("system:{kind}"),
+        }
+    }
+
+    /// SNAT — prepend a hub name into any addressable origin field.
+    /// Variants without an addressable origin (Human/Scheduled/System) are no-ops.
+    pub fn prepend_hub(&mut self, self_hub: &str) {
+        match self {
+            Self::Agent(addr) => addr.prepend_hub(self_hub.to_string()),
+            Self::Channel { from, .. } => from.prepend_hub(self_hub.to_string()),
+            _ => {}
+        }
+    }
+
+    /// Conditional SNAT — prepend only if the inner address is still local.
+    /// Used by event aggregation where the source may already be qualified
+    /// (e.g. an envelope routed from another hub).
+    pub fn prepend_hub_if_local(&mut self, self_hub: &str) {
+        match self {
+            Self::Agent(addr) => addr.prepend_hub_if_local(self_hub.to_string()),
+            Self::Channel { from, .. } => from.prepend_hub_if_local(self_hub.to_string()),
+            _ => {}
         }
     }
 }
 
 /// A routable message envelope.
 ///
-/// Every inter-agent or human→agent message is wrapped in an `Envelope`.
-/// The `MessageRouter` routes envelopes to the target's mailbox and
-/// simultaneously emits a `MessageRouted` observation event.
+/// `target` is a [`QualifiedAddress`]; routing layers consume hub segments
+/// via [`Envelope::apply_dnat`] as the envelope crosses boundaries inbound,
+/// and stamp source hub names via [`Envelope::apply_snat`] outbound.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Envelope {
-    /// Unique message ID for tracing and deduplication.
     pub id: Uuid,
-    /// Who sent this message.
     pub source: MessageSource,
-    /// Target agent name (e.g. "main", "researcher").
-    pub target: String,
-    /// Message content (text + optional images).
+    pub target: QualifiedAddress,
     pub content: UserContent,
-    /// UTC timestamp when the envelope was created.
     pub timestamp: DateTime<Utc>,
 }
 
 impl Envelope {
     /// Create a new envelope with auto-generated ID and current timestamp.
-    ///
-    /// Accepts `String`, `&str`, or `UserContent` as content thanks to
-    /// `Into<UserContent>` (backward-compatible with text-only callers).
     pub fn new(
         source: MessageSource,
-        target: impl Into<String>,
+        target: impl Into<QualifiedAddress>,
         content: impl Into<UserContent>,
     ) -> Self {
         Self {
@@ -73,5 +88,17 @@ impl Envelope {
     /// Short preview of the text content (max ~80 chars, safe for multi-byte).
     pub fn content_preview(&self) -> &str {
         self.content.text_preview()
+    }
+
+    /// SNAT — stamp this hub's name onto the source path. Apply once
+    /// when an envelope crosses an outbound hub boundary.
+    pub fn apply_snat(&mut self, self_hub: &str) {
+        self.source.prepend_hub(self_hub);
+    }
+
+    /// DNAT — pop the next-hop hub from the target path. Returns the
+    /// consumed hub for diagnostics, or `None` if already local.
+    pub fn apply_dnat(&mut self) -> Option<String> {
+        self.target.pop_front_hub()
     }
 }

--- a/crates/loopal-protocol/src/event.rs
+++ b/crates/loopal-protocol/src/event.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::address::QualifiedAddress;
 use crate::event_id::{current_correlation_id, current_turn_id, next_event_id};
 use crate::event_payload::AgentEventPayload;
 
@@ -7,10 +8,12 @@ use crate::event_payload::AgentEventPayload;
 /// transported via event channel to consumers.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentEvent {
-    /// Agent that produced this event. Hub fills this in for all agents
-    /// (root = `Some("main")`, sub-agent = `Some("name")`).
-    /// `None` only in the agent process before Hub injection.
-    pub agent_name: Option<String>,
+    /// Agent that produced this event. `Some(local("main"))` for the
+    /// root agent on a hub; sub-agents carry their local name. The
+    /// MetaHub event aggregator stamps the originating hub via
+    /// [`QualifiedAddress::prepend_hub`] when relaying events upward.
+    /// `None` only inside the agent process before Hub injection.
+    pub agent_name: Option<QualifiedAddress>,
     /// Monotonically increasing process-unique ID (0 = unset).
     #[serde(default)]
     pub event_id: u64,
@@ -36,7 +39,8 @@ impl AgentEvent {
     }
 
     /// Convenience: create a named sub-agent event.
-    pub fn named(name: impl Into<String>, payload: AgentEventPayload) -> Self {
+    /// `name` may be a bare agent name or a qualified `hub/agent` form.
+    pub fn named(name: impl Into<QualifiedAddress>, payload: AgentEventPayload) -> Self {
         Self {
             agent_name: Some(name.into()),
             event_id: next_event_id(),

--- a/crates/loopal-protocol/src/event_payload.rs
+++ b/crates/loopal-protocol/src/event_payload.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+use crate::address::QualifiedAddress;
 use crate::bg_task::BgTaskStatus;
 use crate::cron_snapshot::CronJobSnapshot;
+use crate::envelope::MessageSource;
 use crate::mcp_snapshot::McpServerSnapshot;
 use crate::question::Question;
 use crate::task_snapshot::TaskSnapshot;
@@ -89,8 +91,11 @@ pub enum AgentEventPayload {
     Finished,
     /// Inter-agent message routed through MessageRouter (Observation Plane).
     MessageRouted {
-        source: String,
-        target: String,
+        /// Origin: full `MessageSource` so observers see the kind
+        /// (Human/Agent/Channel/Scheduled/System) plus any qualified address.
+        source: MessageSource,
+        /// Routed-to address. Carries the post-NAT view of the receiver.
+        target: QualifiedAddress,
         content_preview: String,
     },
     /// Tool is requesting user to answer questions.
@@ -128,8 +133,9 @@ pub enum AgentEventPayload {
     SubAgentSpawned {
         name: String,
         agent_id: String,
+        /// Parent address (qualified when spawned cross-hub).
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        parent: Option<String>,
+        parent: Option<QualifiedAddress>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         model: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -180,4 +186,29 @@ pub enum AgentEventPayload {
     TasksChanged { tasks: Vec<TaskSnapshot> },
     /// Full scheduled cron jobs snapshot (emitted by the periodic bridge).
     CronsChanged { crons: Vec<CronJobSnapshot> },
+}
+
+impl AgentEventPayload {
+    /// SNAT — stamp `self_hub` onto every still-local qualified address
+    /// inside this payload. Already-qualified (cross-hub) addresses are
+    /// left untouched. Called by the event aggregator before relaying an
+    /// event upward to the MetaHub broadcast plane so receivers see a
+    /// fully-qualified, self-describing payload.
+    pub fn prepend_self_hub(&mut self, self_hub: &str) {
+        match self {
+            Self::MessageRouted { source, target, .. } => {
+                source.prepend_hub_if_local(self_hub);
+                target.prepend_hub_if_local(self_hub);
+            }
+            Self::SubAgentSpawned {
+                parent: Some(p), ..
+            } => {
+                p.prepend_hub_if_local(self_hub);
+            }
+            // Other variants either carry no qualified address or carry
+            // local-only data (tool ids, token counts, etc.) that are
+            // meaningful only inside the originating hub.
+            _ => {}
+        }
+    }
 }

--- a/crates/loopal-protocol/tests/suite.rs
+++ b/crates/loopal-protocol/tests/suite.rs
@@ -1,4 +1,6 @@
 // Single test binary — includes all test modules
+#[path = "suite/address_test.rs"]
+mod address_test;
 #[path = "suite/agent_state_test.rs"]
 mod agent_state_test;
 #[path = "suite/command_test.rs"]

--- a/crates/loopal-protocol/tests/suite/address_test.rs
+++ b/crates/loopal-protocol/tests/suite/address_test.rs
@@ -1,0 +1,119 @@
+use loopal_protocol::QualifiedAddress;
+
+#[test]
+fn parse_local_address_has_no_hub() {
+    let addr = QualifiedAddress::parse("researcher");
+    assert!(addr.hub.is_empty());
+    assert_eq!(addr.agent, "researcher");
+    assert!(addr.is_local());
+    assert_eq!(addr.to_string(), "researcher");
+}
+
+#[test]
+fn parse_single_hub_address() {
+    let addr = QualifiedAddress::parse("hub-a/researcher");
+    assert_eq!(addr.hub, vec!["hub-a"]);
+    assert_eq!(addr.agent, "researcher");
+    assert!(addr.is_remote());
+    assert_eq!(addr.to_string(), "hub-a/researcher");
+}
+
+#[test]
+fn parse_multi_hub_supports_metahub_of_metahub() {
+    let addr = QualifiedAddress::parse("mh-1/hub-A/agent");
+    assert_eq!(addr.hub, vec!["mh-1", "hub-A"]);
+    assert_eq!(addr.agent, "agent");
+    assert_eq!(addr.next_hop(), Some("mh-1"));
+    assert_eq!(addr.to_string(), "mh-1/hub-A/agent");
+}
+
+#[test]
+fn parse_malformed_falls_back_to_local() {
+    // Empty segments anywhere collapse to a local address verbatim.
+    let addr = QualifiedAddress::parse("/researcher");
+    assert!(addr.hub.is_empty());
+    assert_eq!(addr.agent, "/researcher");
+
+    let addr = QualifiedAddress::parse("hub-a/");
+    assert!(addr.hub.is_empty());
+
+    let addr = QualifiedAddress::parse("");
+    assert!(addr.hub.is_empty());
+    assert_eq!(addr.agent, "");
+}
+
+#[test]
+fn constructors_produce_expected_shape() {
+    let local = QualifiedAddress::local("main");
+    assert!(local.is_local());
+    assert_eq!(local.agent, "main");
+
+    let remote = QualifiedAddress::remote(["hub-b"], "worker");
+    assert!(remote.is_remote());
+    assert_eq!(remote.to_string(), "hub-b/worker");
+
+    let layered = QualifiedAddress::remote(["mh-1", "hub-A"], "agent");
+    assert_eq!(layered.hub.len(), 2);
+}
+
+#[test]
+fn snat_prepends_hub_at_front() {
+    let mut addr = QualifiedAddress::local("agent");
+    addr.prepend_hub("hub-A");
+    assert_eq!(addr.hub, vec!["hub-A"]);
+
+    addr.prepend_hub("mh-1");
+    assert_eq!(addr.hub, vec!["mh-1", "hub-A"]);
+    assert_eq!(addr.to_string(), "mh-1/hub-A/agent");
+}
+
+#[test]
+fn dnat_pops_front_and_returns_consumed_name() {
+    let mut addr = QualifiedAddress::remote(["mh-1", "hub-A"], "agent");
+    assert_eq!(addr.pop_front_hub().as_deref(), Some("mh-1"));
+    assert_eq!(addr.next_hop(), Some("hub-A"));
+    assert_eq!(addr.pop_front_hub().as_deref(), Some("hub-A"));
+    assert!(addr.is_local());
+    // Idempotent on already-local addresses.
+    assert!(addr.pop_front_hub().is_none());
+}
+
+#[test]
+fn parse_display_roundtrip_preserves_path() {
+    let cases = [
+        "agent",
+        "hub-a/agent",
+        "mh-1/hub-A/agent",
+        "a/b/c/d/e/agent",
+    ];
+    for s in cases {
+        let addr = QualifiedAddress::parse(s);
+        assert_eq!(addr.to_string(), s, "roundtrip failed for {s}");
+    }
+}
+
+#[test]
+fn from_str_impls_parse_to_qualified() {
+    let from_str: QualifiedAddress = "hub-a/agent".into();
+    let from_string: QualifiedAddress = String::from("hub-a/agent").into();
+    let parsed = QualifiedAddress::parse("hub-a/agent");
+    assert_eq!(from_str, parsed);
+    assert_eq!(from_string, parsed);
+}
+
+#[test]
+fn prepend_hub_if_local_is_idempotent_on_qualified() {
+    // Conditional SNAT — used by event aggregation to avoid double-stamping
+    // an address that already carries a hub path from upstream NAT.
+    let mut already_qualified = QualifiedAddress::remote(["hub-A"], "alpha");
+    already_qualified.prepend_hub_if_local("hub-B");
+    assert_eq!(
+        already_qualified,
+        QualifiedAddress::remote(["hub-A"], "alpha"),
+        "qualified address must not be re-stamped"
+    );
+
+    let mut local = QualifiedAddress::local("alpha");
+    local.prepend_hub_if_local("hub-B");
+    assert_eq!(local, QualifiedAddress::remote(["hub-B"], "alpha"));
+}

--- a/crates/loopal-protocol/tests/suite/envelope_test.rs
+++ b/crates/loopal-protocol/tests/suite/envelope_test.rs
@@ -1,4 +1,4 @@
-use loopal_protocol::{Envelope, MessageSource};
+use loopal_protocol::{Envelope, MessageSource, QualifiedAddress};
 
 #[test]
 fn test_envelope_new_generates_unique_ids() {
@@ -10,12 +10,15 @@ fn test_envelope_new_generates_unique_ids() {
 #[test]
 fn test_envelope_fields_stored_correctly() {
     let env = Envelope::new(
-        MessageSource::Agent("researcher".into()),
+        MessageSource::Agent(QualifiedAddress::local("researcher")),
         "main",
         "found results",
     );
-    assert_eq!(env.source, MessageSource::Agent("researcher".into()));
-    assert_eq!(env.target, "main");
+    assert_eq!(
+        env.source,
+        MessageSource::Agent(QualifiedAddress::local("researcher"))
+    );
+    assert_eq!(env.target, QualifiedAddress::local("main"));
     assert_eq!(env.content.text, "found results");
 }
 
@@ -37,7 +40,7 @@ fn test_envelope_serde_roundtrip() {
     let env = Envelope::new(
         MessageSource::Channel {
             channel: "general".into(),
-            from: "bot".into(),
+            from: QualifiedAddress::local("bot"),
         },
         "worker-1",
         "task update",
@@ -53,13 +56,12 @@ fn test_envelope_serde_roundtrip() {
 #[test]
 fn test_message_source_variants() {
     let human = MessageSource::Human;
-    let agent = MessageSource::Agent("coder".into());
+    let agent = MessageSource::Agent(QualifiedAddress::local("coder"));
     let channel = MessageSource::Channel {
         channel: "updates".into(),
-        from: "notifier".into(),
+        from: QualifiedAddress::local("notifier"),
     };
 
-    // Ensure PartialEq works across variants
     assert_ne!(human, agent);
     assert_ne!(agent, channel);
     assert_eq!(human, MessageSource::Human);
@@ -71,10 +73,116 @@ fn test_scheduled_source_label() {
 }
 
 #[test]
+fn test_agent_label_uses_qualified_form() {
+    let local = MessageSource::Agent(QualifiedAddress::local("alpha"));
+    assert_eq!(local.label(), "alpha");
+
+    let remote = MessageSource::Agent(QualifiedAddress::remote(["hub-A"], "alpha"));
+    assert_eq!(remote.label(), "hub-A/alpha");
+}
+
+#[test]
 fn test_scheduled_source_serde_roundtrip() {
     let env = Envelope::new(MessageSource::Scheduled, "main", "check deploys");
     let json = serde_json::to_string(&env).unwrap();
     let restored: Envelope = serde_json::from_str(&json).unwrap();
     assert_eq!(restored.source, MessageSource::Scheduled);
     assert_eq!(restored.content.text, "check deploys");
+}
+
+#[test]
+fn test_apply_snat_stamps_source_with_self_hub() {
+    let mut env = Envelope::new(
+        MessageSource::Agent(QualifiedAddress::local("alpha")),
+        "hub-B/beta",
+        "hi",
+    );
+    env.apply_snat("hub-A");
+    let MessageSource::Agent(addr) = &env.source else {
+        panic!("expected Agent source");
+    };
+    assert_eq!(addr, &QualifiedAddress::remote(["hub-A"], "alpha"));
+    assert_eq!(env.target, QualifiedAddress::remote(["hub-B"], "beta"));
+}
+
+#[test]
+fn test_apply_dnat_pops_target_next_hop() {
+    let mut env = Envelope::new(
+        MessageSource::Agent(QualifiedAddress::remote(["hub-A"], "alpha")),
+        "hub-B/beta",
+        "hi",
+    );
+    let consumed = env.apply_dnat();
+    assert_eq!(consumed.as_deref(), Some("hub-B"));
+    assert_eq!(env.target, QualifiedAddress::local("beta"));
+}
+
+#[test]
+fn test_apply_snat_is_noop_for_non_addressable_sources() {
+    // Human / Scheduled / System sources have no qualified address to
+    // stamp — apply_snat must leave them untouched. This guards against
+    // future MessageSource refactors accidentally promoting these
+    // variants into the NAT path.
+    for source in [
+        MessageSource::Human,
+        MessageSource::Scheduled,
+        MessageSource::System("agent-completed".into()),
+    ] {
+        let mut env = Envelope::new(source.clone(), "main", "x");
+        env.apply_snat("hub-A");
+        assert_eq!(env.source, source, "non-addressable source must not change");
+        // Target SNAT is not envelope-side; target only changes via DNAT.
+        assert_eq!(env.target, QualifiedAddress::local("main"));
+    }
+}
+
+#[test]
+fn test_apply_snat_stamps_channel_from() {
+    let mut env = Envelope::new(
+        MessageSource::Channel {
+            channel: "general".into(),
+            from: QualifiedAddress::local("alpha"),
+        },
+        "hub-B/beta",
+        "hi",
+    );
+    env.apply_snat("hub-A");
+    let MessageSource::Channel { from, .. } = &env.source else {
+        panic!("expected Channel source");
+    };
+    assert_eq!(from, &QualifiedAddress::remote(["hub-A"], "alpha"));
+}
+
+#[test]
+fn test_snat_dnat_compose_for_round_trip() {
+    // α in hub-A → β in hub-B
+    let mut out = Envelope::new(
+        MessageSource::Agent(QualifiedAddress::local("alpha")),
+        "hub-B/beta",
+        "ping",
+    );
+    out.apply_snat("hub-A"); // hub-A uplink stamps source
+
+    // arrives at hub-B; meta-hub strips next hop in target
+    out.apply_dnat();
+
+    // β replies using the source it received
+    let reply_target = match &out.source {
+        MessageSource::Agent(addr) => addr.clone(),
+        _ => panic!("expected Agent source"),
+    };
+    let mut reply = Envelope::new(
+        MessageSource::Agent(QualifiedAddress::local("beta")),
+        reply_target,
+        "pong",
+    );
+    reply.apply_snat("hub-B");
+    reply.apply_dnat();
+
+    // α receives the reply with hub-B in source
+    assert_eq!(
+        reply.source,
+        MessageSource::Agent(QualifiedAddress::remote(["hub-B"], "beta"))
+    );
+    assert_eq!(reply.target, QualifiedAddress::local("alpha"));
 }

--- a/crates/loopal-protocol/tests/suite/event_edge_test.rs
+++ b/crates/loopal-protocol/tests/suite/event_edge_test.rs
@@ -1,10 +1,10 @@
-use loopal_protocol::{AgentEvent, AgentEventPayload};
+use loopal_protocol::{AgentEvent, AgentEventPayload, MessageSource, QualifiedAddress};
 
 #[test]
 fn test_event_message_routed_serde_roundtrip() {
     let event = AgentEvent::root(AgentEventPayload::MessageRouted {
-        source: "agent-a".into(),
-        target: "agent-b".into(),
+        source: MessageSource::Agent(QualifiedAddress::local("agent-a")),
+        target: QualifiedAddress::local("agent-b"),
         content_preview: "hello world".into(),
     });
     let json = serde_json::to_string(&event).unwrap();
@@ -15,8 +15,11 @@ fn test_event_message_routed_serde_roundtrip() {
         content_preview,
     } = deserialized.payload
     {
-        assert_eq!(source, "agent-a");
-        assert_eq!(target, "agent-b");
+        assert_eq!(
+            source,
+            MessageSource::Agent(QualifiedAddress::local("agent-a"))
+        );
+        assert_eq!(target, QualifiedAddress::local("agent-b"));
         assert_eq!(content_preview, "hello world");
     } else {
         panic!("expected AgentEventPayload::MessageRouted");
@@ -28,7 +31,10 @@ fn test_event_named_agent_serde_roundtrip() {
     let event = AgentEvent::named("worker", AgentEventPayload::Started);
     let json = serde_json::to_string(&event).unwrap();
     let deserialized: AgentEvent = serde_json::from_str(&json).unwrap();
-    assert_eq!(deserialized.agent_name, Some("worker".to_string()));
+    assert_eq!(
+        deserialized.agent_name,
+        Some(QualifiedAddress::local("worker"))
+    );
     assert!(matches!(deserialized.payload, AgentEventPayload::Started));
 }
 

--- a/crates/loopal-runtime/src/agent_input.rs
+++ b/crates/loopal-runtime/src/agent_input.rs
@@ -6,6 +6,11 @@ use loopal_protocol::Envelope;
 /// Replaces the former `UserCommand` enum by preserving the full `Envelope`
 /// (with source/target/id/timestamp) instead of flattening to a plain string.
 /// Control commands pass through without adaptation.
+///
+/// `Envelope` carries qualified addresses (variable hub paths), so the
+/// variant sizes diverge — but boxing on every input would add a heap
+/// allocation in the hot dispatch path. Allow the size difference instead.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum AgentInput {
     /// A data-plane message (human, agent, or channel).

--- a/crates/loopal-runtime/src/agent_loop/loop_detector.rs
+++ b/crates/loopal-runtime/src/agent_loop/loop_detector.rs
@@ -12,8 +12,6 @@ use super::turn_observer::{ObserverAction, TurnObserver};
 
 const WARN_THRESHOLD: u32 = 3;
 const ABORT_THRESHOLD: u32 = 5;
-/// Max bytes of input JSON used for signature (avoids hashing huge payloads).
-const SIGNATURE_INPUT_LIMIT: usize = 200;
 
 /// Tracks tool call signatures and their cumulative occurrence count.
 pub struct LoopDetector {
@@ -82,20 +80,16 @@ impl TurnObserver for LoopDetector {
     }
 }
 
-/// Build a stable signature from tool name + truncated input JSON.
+/// Build a stable signature from tool name + full input JSON.
+///
+/// We hash the **entire** serialized JSON (not a byte prefix). Prefix-based
+/// hashing collided when distinguishing fields sorted late in the JSON
+/// (e.g. `to` in `SendMessage`) were pushed past the cutoff by long
+/// earlier fields — causing legitimate fan-out calls to be flagged as
+/// loops. `serde_json::Value::Object` uses `BTreeMap`, so full-JSON
+/// serialization is deterministic across equivalent inputs.
 fn tool_signature(name: &str, input: &serde_json::Value) -> String {
-    let json = input.to_string();
-    let truncated = if json.len() > SIGNATURE_INPUT_LIMIT {
-        // Floor to a char boundary — byte slicing a multi-byte UTF-8 string panics.
-        let mut end = SIGNATURE_INPUT_LIMIT;
-        while end > 0 && !json.is_char_boundary(end) {
-            end -= 1;
-        }
-        &json[..end]
-    } else {
-        &json
-    };
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    truncated.hash(&mut hasher);
+    input.to_string().hash(&mut hasher);
     format!("{name}|{:x}", hasher.finish())
 }

--- a/crates/loopal-runtime/src/frontend/emitter.rs
+++ b/crates/loopal-runtime/src/frontend/emitter.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::frontend::traits::EventEmitter;
 use loopal_error::{LoopalError, Result};
-use loopal_protocol::{AgentEvent, AgentEventPayload};
+use loopal_protocol::{AgentEvent, AgentEventPayload, QualifiedAddress};
 
 /// Cloneable event emitter backed by an mpsc sender.
 ///
@@ -12,11 +12,13 @@ use loopal_protocol::{AgentEvent, AgentEventPayload};
 #[derive(Clone)]
 pub struct ChannelEventEmitter {
     tx: mpsc::Sender<AgentEvent>,
-    agent_name: Option<String>,
+    /// Stored as a qualified local address so emit doesn't reconvert.
+    /// Hub uplinks promote this to a full `hub/agent` form via SNAT.
+    agent_name: Option<QualifiedAddress>,
 }
 
 impl ChannelEventEmitter {
-    pub fn new(tx: mpsc::Sender<AgentEvent>, agent_name: Option<String>) -> Self {
+    pub fn new(tx: mpsc::Sender<AgentEvent>, agent_name: Option<QualifiedAddress>) -> Self {
         Self { tx, agent_name }
     }
 }

--- a/crates/loopal-runtime/src/frontend/unified.rs
+++ b/crates/loopal-runtime/src/frontend/unified.rs
@@ -8,6 +8,7 @@ use crate::frontend::traits::{AgentFrontend, EventEmitter};
 use loopal_error::Result;
 use loopal_protocol::ControlCommand;
 use loopal_protocol::Envelope;
+use loopal_protocol::QualifiedAddress;
 use loopal_protocol::{AgentEvent, AgentEventPayload};
 use loopal_tool_api::PermissionDecision;
 
@@ -25,7 +26,8 @@ use super::question_handler::QuestionHandler;
 /// - Root agent:  `agent_name = None`, uses `RelayPermissionHandler`
 /// - Sub-agent:   `agent_name = Some(name)`, uses `AutoDenyHandler`
 pub struct UnifiedFrontend {
-    agent_name: Option<String>,
+    /// Pre-converted local qualified address; reused on every emit.
+    agent_name: Option<QualifiedAddress>,
     event_tx: mpsc::Sender<AgentEvent>,
     mailbox_rx: Mutex<mpsc::Receiver<Envelope>>,
     control_rx: Mutex<mpsc::Receiver<ControlCommand>>,
@@ -45,7 +47,7 @@ impl UnifiedFrontend {
         question_handler: Box<dyn QuestionHandler>,
     ) -> Self {
         Self {
-            agent_name,
+            agent_name: agent_name.map(QualifiedAddress::local),
             event_tx,
             mailbox_rx: Mutex::new(mailbox_rx),
             control_rx: Mutex::new(control_rx),

--- a/crates/loopal-runtime/tests/suite.rs
+++ b/crates/loopal-runtime/tests/suite.rs
@@ -11,6 +11,8 @@ mod env_context_test;
 mod frontend_unified_edge_test;
 #[path = "suite/frontend_unified_test.rs"]
 mod frontend_unified_test;
+#[path = "suite/loop_detector_edge_test.rs"]
+mod loop_detector_edge_test;
 #[path = "suite/loop_detector_test.rs"]
 mod loop_detector_test;
 #[path = "suite/mode_test.rs"]

--- a/crates/loopal-runtime/tests/suite/frontend_unified_test.rs
+++ b/crates/loopal-runtime/tests/suite/frontend_unified_test.rs
@@ -68,7 +68,10 @@ async fn test_unified_emit_wraps_agent_name() {
     f.emit(AgentEventPayload::Finished).await.unwrap();
 
     let event = event_rx.recv().await.unwrap();
-    assert_eq!(event.agent_name.as_deref(), Some("researcher"));
+    assert_eq!(
+        event.agent_name.as_ref().map(|a| a.to_string()).as_deref(),
+        Some("researcher")
+    );
 }
 
 #[tokio::test]

--- a/crates/loopal-runtime/tests/suite/loop_detector_edge_test.rs
+++ b/crates/loopal-runtime/tests/suite/loop_detector_edge_test.rs
@@ -1,0 +1,77 @@
+use loopal_protocol::InterruptSignal;
+use loopal_runtime::agent_loop::cancel::TurnCancel;
+use loopal_runtime::agent_loop::loop_detector::LoopDetector;
+use loopal_runtime::agent_loop::turn_context::TurnContext;
+use loopal_runtime::agent_loop::turn_observer::{ObserverAction, TurnObserver};
+use serde_json::json;
+use std::sync::Arc;
+
+fn make_ctx() -> TurnContext {
+    let cancel = TurnCancel::new(
+        InterruptSignal::new(),
+        Arc::new(tokio::sync::watch::channel(0u64).0),
+    );
+    TurnContext::new(0, cancel)
+}
+
+// --- Regression: fan-out with long shared prefix must not collide ---
+
+#[test]
+fn loop_detector_fanout_different_targets_does_not_trigger() {
+    // Regression for prefix-hash collision. When the signature was built
+    // from the first 200 bytes of the serialized JSON, and `serde_json`
+    // ordered keys alphabetically (BTreeMap), a SendMessage call with
+    // {"message": <long>, "summary": …, "to": <target>} would hash away
+    // the `to` field entirely — so 5 messages to 5 distinct recipients
+    // looked identical and tripped the abort threshold.
+    //
+    // With full-JSON hashing, each distinct `to` yields a distinct signature.
+    let mut det = LoopDetector::new();
+    let mut ctx = make_ctx();
+    let long_msg = "你好。我是 hub-83e6571f 的 agent。用户给我布置了一个任务：".repeat(6);
+    let targets = [
+        "hub-6d7d3682",
+        "hub-0d7124fc",
+        "hub-9b54624e",
+        "hub-4809c5a6",
+        "hub-f117ce0b",
+    ];
+    let calls: Vec<(String, String, serde_json::Value)> = targets
+        .iter()
+        .map(|t| {
+            (
+                format!("id-{t}"),
+                "SendMessage".into(),
+                json!({"to": *t, "message": long_msg, "summary": "intro ping"}),
+            )
+        })
+        .collect();
+
+    let action = det.on_before_tools(&mut ctx, &calls);
+    assert!(
+        matches!(action, ObserverAction::Continue),
+        "fan-out to 5 distinct targets must not trigger loop detector, got {action:?}"
+    );
+}
+
+#[test]
+fn loop_detector_fanout_with_identical_payload_still_triggers() {
+    // Sanity check: the fix must not mask genuine loops. Repeating the
+    // *exact same* call (identical `to` + `message`) 5 times should still
+    // abort — this is the behavior the detector was designed to protect.
+    let mut det = LoopDetector::new();
+    let mut ctx = make_ctx();
+    let call = vec![(
+        "id".into(),
+        "SendMessage".into(),
+        json!({"to": "hub-a", "message": "hello", "summary": "s"}),
+    )];
+    for _ in 0..4 {
+        det.on_before_tools(&mut ctx, &call);
+    }
+    let action = det.on_before_tools(&mut ctx, &call);
+    assert!(
+        matches!(action, ObserverAction::AbortTurn(_)),
+        "identical SendMessage repeated 5 times should still abort, got {action:?}"
+    );
+}

--- a/crates/loopal-runtime/tests/suite/loop_detector_test.rs
+++ b/crates/loopal-runtime/tests/suite/loop_detector_test.rs
@@ -128,9 +128,9 @@ fn loop_detector_different_inputs_independent() {
 fn loop_detector_multibyte_utf8_input_does_not_panic() {
     let mut det = LoopDetector::new();
     let mut ctx = make_ctx();
-    // Large CJK input — byte-slicing at SIGNATURE_INPUT_LIMIT (200) could land
-    // mid-character. This must not panic.
-    let cjk = "中".repeat(200); // 600 bytes, well over the 200-byte limit
+    // Large CJK input — we hash full JSON, so this only exercises UTF-8
+    // safety of the serialized string. Must not panic.
+    let cjk = "中".repeat(200); // 600 bytes
     let call = vec![("id".into(), "Write".into(), json!({"result": cjk}))];
     let action = det.on_before_tools(&mut ctx, &call);
     assert!(matches!(action, ObserverAction::Continue));

--- a/crates/loopal-session/src/event_handler.rs
+++ b/crates/loopal-session/src/event_handler.rs
@@ -27,10 +27,12 @@ pub fn apply_event(state: &mut SessionState, event: AgentEvent) {
         ..
     } = event.payload
     {
+        // Session/UI deal in flat strings — flatten the qualified address.
+        let parent_str = parent.as_ref().map(|p| p.to_string());
         crate::agent_lifecycle::register_spawned_agent(
             state,
             name,
-            parent.as_deref(),
+            parent_str.as_deref(),
             model.as_deref(),
             session_id.as_deref(),
         );
@@ -41,7 +43,7 @@ pub fn apply_event(state: &mut SessionState, event: AgentEvent) {
                 .push(crate::state::PendingSubAgentRef {
                     name: name.clone(),
                     session_id: sid.clone(),
-                    parent: parent.clone(),
+                    parent: parent_str,
                     model: model.clone(),
                 });
         }
@@ -49,7 +51,11 @@ pub fn apply_event(state: &mut SessionState, event: AgentEvent) {
 
     // Session-level mode sync: when the active agent's mode changes, update state.mode
     if let AgentEventPayload::ModeChanged { ref mode } = event.payload {
-        let agent_name = event.agent_name.as_deref().unwrap_or(ROOT_AGENT);
+        let agent_name = event
+            .agent_name
+            .as_ref()
+            .map(|a| a.to_string())
+            .unwrap_or_else(|| ROOT_AGENT.to_string());
         if agent_name == state.active_view && state.mode != *mode {
             state.mode.clone_from(mode);
         }
@@ -66,6 +72,10 @@ pub fn apply_event(state: &mut SessionState, event: AgentEvent) {
     }
 
     // Unified: route to agent conversation by name (root = "main")
-    let name = event.agent_name.unwrap_or_else(|| ROOT_AGENT.into());
+    let name = event
+        .agent_name
+        .as_ref()
+        .map(|a| a.to_string())
+        .unwrap_or_else(|| ROOT_AGENT.to_string());
     crate::agent_handler::apply_agent_event(state, &name, event.payload);
 }

--- a/crates/loopal-session/src/message_log.rs
+++ b/crates/loopal-session/src/message_log.rs
@@ -6,6 +6,7 @@
 use std::collections::VecDeque;
 
 use chrono::{DateTime, Utc};
+use loopal_protocol::{MessageSource, QualifiedAddress};
 
 /// Single entry in the message log (observation plane).
 #[derive(Debug, Clone)]
@@ -79,17 +80,39 @@ impl MessageFeed {
 }
 
 /// Record a MessageRouted event to the global feed and per-agent logs.
+///
+/// Per-agent attribution applies only when the source/target reference a
+/// **local** agent (the message log lives inside this hub's session state).
 pub(crate) fn record_message_routed(
     state: &mut crate::state::SessionState,
-    source: &str,
-    target: &str,
+    source: &MessageSource,
+    target: &QualifiedAddress,
     preview: &str,
 ) {
-    let entry = MessageLogEntry::new(source, target, preview);
+    let entry = MessageLogEntry::new(source.label(), target.to_string(), preview);
     state.message_feed.record(entry.clone());
-    for name in [source, target] {
-        if let Some(agent) = state.agents.get_mut(name) {
-            agent.message_log.push(entry.clone());
+
+    // Source-side attribution: only Agent / Channel sources name a local agent.
+    let source_local = match source {
+        MessageSource::Agent(addr) | MessageSource::Channel { from: addr, .. } => {
+            if addr.is_local() {
+                Some(&addr.agent)
+            } else {
+                None
+            }
         }
+        _ => None,
+    };
+    if let Some(name) = source_local
+        && let Some(agent) = state.agents.get_mut(name)
+    {
+        agent.message_log.push(entry.clone());
+    }
+
+    // Target-side attribution: same local-only rule.
+    if target.is_local()
+        && let Some(agent) = state.agents.get_mut(&target.agent)
+    {
+        agent.message_log.push(entry);
     }
 }

--- a/crates/loopal-session/tests/suite/event_handler_test.rs
+++ b/crates/loopal-session/tests/suite/event_handler_test.rs
@@ -48,7 +48,9 @@ fn test_apply_event_records_message_routed_to_feed() {
     apply_event(
         &mut state,
         AgentEvent::root(AgentEventPayload::MessageRouted {
-            source: "agent-a".into(),
+            source: loopal_protocol::MessageSource::Agent(
+                loopal_protocol::QualifiedAddress::local("agent-a"),
+            ),
             target: "agent-b".into(),
             content_preview: "test msg".into(),
         }),
@@ -73,7 +75,9 @@ fn test_apply_event_records_message_routed_to_agent_logs() {
     apply_event(
         &mut state,
         AgentEvent::root(AgentEventPayload::MessageRouted {
-            source: "sender".into(),
+            source: loopal_protocol::MessageSource::Agent(
+                loopal_protocol::QualifiedAddress::local("sender"),
+            ),
             target: "receiver".into(),
             content_preview: "hello".into(),
         }),


### PR DESCRIPTION
## Summary
- Model cross-hub envelope/event traversal as NAT: hub uplinks SNAT (`source.hub.push_front(self_hub)`), metahub router DNATs (`target.hub.pop_front()`). Receivers now see a fully-qualified return path and can reply symmetrically.
- `QualifiedAddress` (with `hub: Vec<String>`) becomes the only typed address in memory — `Envelope.target`, `MessageSource::{Agent,Channel}`, `AgentInfo.parent`, `AgentEvent.agent_name`, `MessageRouted.{source,target}`, `SubAgentSpawned.parent` are all typed; strings only survive at IPC wire-format boundaries.
- Bundled fix for the `LoopDetector` signature collision (hash full input JSON instead of first 200 bytes) and removal of dead `meta/resolve` path.

## Why
Previously `MessageSource::Agent(name)` carried only an agent name. After hub-A's uplink forwarded an envelope to MetaHub, the receiving hub's LLM saw `[from: 协调员]` with no way to know which hub to reply to (or even disambiguate against a same-named local agent). The LoopDetector signature bug — flagging fan-out to 5 distinct targets as a loop — was the proximate symptom users observed. Both root in stringly-typed addressing across hub boundaries.

## Changes

### Protocol (`loopal-protocol`)
- `QualifiedAddress`: `hub: Option<String>` → `Vec<String>`; added `prepend_hub` / `pop_front_hub` / `next_hop` / `prepend_hub_if_local` helpers.
- `Envelope.target: QualifiedAddress`; `MessageSource::Agent(QA)`, `MessageSource::Channel { from: QA }`; `apply_snat` / `apply_dnat` on `Envelope`.
- `AgentEvent.agent_name: Option<QualifiedAddress>`; `AgentEventPayload::prepend_self_hub` for event-side SNAT (covers `MessageRouted` + `SubAgentSpawned`).
- `MessageRouted` keeps full `MessageSource` (no more `QA::local("human")` hack).

### Hub boundary (`loopal-agent-hub`)
- `uplink::route` applies SNAT before forwarding.
- `dispatch_handlers::handle_route` uses `target.is_local()/is_remote()` instead of manual parse.
- `agent_registry`: `parent: Option<QualifiedAddress>`; `register_shadow(name, QA)`; local children only attributed when parent is local.
- `finish_and_deliver` reuses typed parent, source becomes `Agent(QA::local(child))` (was `System("agent-completed")`) so SNAT applies uniformly.
- inbound `agent/message` `debug_assert!(env.target.is_local())`.

### MetaHub (`loopal-meta-hub`)
- `router::route` consumes hub via `apply_dnat`; legacy `resolve_agent` cache and `meta/resolve` protocol method deleted.
- `dispatch::handle_meta_route` self-routing detected via `target.next_hop() == from_hub`.
- `aggregator::prefix_agent_name` SNATs both `event.agent_name` and payload-internal QA fields.

### Runtime / agent
- `SendMessageTool` constructs `Agent(QA::local(self.name))` + `QA::parse(target)`.
- 5 frontends (Channel/Unified/Ipc/Hub Frontend + their EventEmitters) hold `Option<QualifiedAddress>` field, eliminating 6 sites of `.as_deref().map(QA::local)` duplication.
- `LoopDetector::tool_signature` hashes full input JSON; the 200-byte prefix scheme collided when distinguishing fields sorted late in JSON (e.g. `to` in SendMessage) caused legitimate fan-out to abort.

## Test plan
- [x] 52 test targets pass (Bazel)
- [x] Clippy clean (`--config=clippy`)
- [x] Rustfmt clean (`--config=rustfmt`)
- New tests:
  - 9 unit tests on `QualifiedAddress` (parse multi-hop, SNAT/DNAT, idempotence)
  - 12 unit tests on Envelope/Event SNAT (Agent + Channel + no-op variants)
  - 6 integration tests (single-hop SNAT / round-trip reply / self-routing / cross-hub completion / cross-hub spawn / local-no-NAT)
  - 6 aggregator SNAT tests (MessageRouted + SubAgentSpawned payload-internal addresses)
  - 2 LoopDetector regression tests (fanout-not-loop / identical-still-aborts)
- [ ] CI passes