### PR TITLE
refactor(spawn): split sub-agent spawn IPC into InHub vs CrossHub

### DIFF
--- a/crates/loopal-agent-hub/src/agent_registry/mod.rs
+++ b/crates/loopal-agent-hub/src/agent_registry/mod.rs
@@ -3,6 +3,7 @@
 //! Contains only agent-related state. UI client management is in `UiDispatcher`.
 
 mod completion;
+mod queries;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -12,8 +13,7 @@ use tokio::sync::{mpsc, watch};
 use loopal_ipc::connection::Connection;
 use loopal_protocol::{AgentEvent, Envelope, QualifiedAddress};
 
-use crate::routing;
-use crate::topology::{AgentInfo, AgentLifecycle};
+use crate::topology::AgentInfo;
 use crate::types::{AgentConnectionState, LocalChannels, ManagedAgent};
 
 /// Pure agent registry — no UI client knowledge.
@@ -97,10 +97,18 @@ impl AgentRegistry {
     }
 
     /// Register a shadow entry for a remotely-spawned agent.
-    pub fn register_shadow(&mut self, name: &str, parent: QualifiedAddress) {
-        use crate::topology::AgentInfo;
-        use crate::types::{AgentConnectionState, ManagedAgent};
-
+    ///
+    /// Returns Err if `name` is already registered (local or shadow). Callers
+    /// should treat this as authoritative — never overwrite an existing entry,
+    /// because that would silently destroy an active agent's state.
+    pub fn register_shadow(
+        &mut self,
+        name: &str,
+        parent: QualifiedAddress,
+    ) -> Result<(), String> {
+        if self.agents.contains_key(name) {
+            return Err(format!("agent '{name}' already registered"));
+        }
         let parent_for_children = parent.clone();
         let mut info = AgentInfo::new(name, Some(parent), None);
         info.lifecycle = crate::AgentLifecycle::Running;
@@ -120,89 +128,6 @@ impl AgentRegistry {
         }
         tracing::info!(agent = %name, parent = %parent_for_children,
             "shadow registered for remote agent");
-    }
-
-    // ── Queries ──────────────────────────────────────────────────
-
-    pub fn agent_count(&self) -> usize {
-        self.agents.len()
-    }
-
-    /// Count only sub-agents (those with a parent). Excludes root "main".
-    pub fn sub_agent_count(&self) -> usize {
-        self.agents
-            .values()
-            .filter(|a| a.info.parent.is_some())
-            .count()
-    }
-
-    pub fn get_agent_connection(&self, name: &str) -> Option<Arc<Connection>> {
-        self.agents.get(name).and_then(|a| a.state.connection())
-    }
-
-    pub fn all_agent_connections(&self) -> Vec<(String, Arc<Connection>)> {
-        self.agents
-            .iter()
-            .filter_map(|(n, a)| a.state.connection().map(|c| (n.clone(), c)))
-            .collect()
-    }
-
-    pub fn list_agents(&self) -> Vec<(String, &'static str)> {
-        self.agents
-            .iter()
-            .map(|(n, a)| {
-                let l = match &a.state {
-                    AgentConnectionState::Local(_) => "local",
-                    AgentConnectionState::Connected(_) => "connected",
-                    AgentConnectionState::Shadow => "shadow",
-                };
-                (n.clone(), l)
-            })
-            .collect()
-    }
-
-    // ── Routing ──────────────────────────────────────────────────
-
-    pub async fn route_message(&self, envelope: &Envelope) -> Result<(), String> {
-        let conn = self
-            .get_agent_connection(&envelope.target.agent)
-            .ok_or_else(|| format!("no agent: '{}'", envelope.target))?;
-        routing::route_to_agent(&conn, envelope, &self.event_tx).await
-    }
-
-    // ── Topology ─────────────────────────────────────────────────
-
-    pub fn agent_info(&self, name: &str) -> Option<&AgentInfo> {
-        self.agents.get(name).map(|a| &a.info)
-    }
-
-    pub fn set_lifecycle(&mut self, name: &str, lifecycle: AgentLifecycle) {
-        if let Some(a) = self.agents.get_mut(name) {
-            a.info.lifecycle = lifecycle;
-        }
-    }
-
-    pub fn descendants(&self, name: &str) -> Vec<String> {
-        self.agents
-            .get(name)
-            .map(|a| a.info.descendants(&self.agents))
-            .unwrap_or_default()
-    }
-
-    pub fn topology_snapshot(&self) -> serde_json::Value {
-        let agents: Vec<serde_json::Value> = self
-            .agents
-            .iter()
-            .map(|(name, a)| {
-                serde_json::json!({
-                    "name": name,
-                    "parent": a.info.parent.as_ref().map(|p| p.to_string()),
-                    "children": a.info.children,
-                    "lifecycle": format!("{:?}", a.info.lifecycle),
-                    "model": a.info.model,
-                })
-            })
-            .collect();
-        serde_json::json!({ "agents": agents })
+        Ok(())
     }
 }

--- a/crates/loopal-agent-hub/src/agent_registry/mod.rs
+++ b/crates/loopal-agent-hub/src/agent_registry/mod.rs
@@ -101,11 +101,7 @@ impl AgentRegistry {
     /// Returns Err if `name` is already registered (local or shadow). Callers
     /// should treat this as authoritative — never overwrite an existing entry,
     /// because that would silently destroy an active agent's state.
-    pub fn register_shadow(
-        &mut self,
-        name: &str,
-        parent: QualifiedAddress,
-    ) -> Result<(), String> {
+    pub fn register_shadow(&mut self, name: &str, parent: QualifiedAddress) -> Result<(), String> {
         if self.agents.contains_key(name) {
             return Err(format!("agent '{name}' already registered"));
         }

--- a/crates/loopal-agent-hub/src/agent_registry/queries.rs
+++ b/crates/loopal-agent-hub/src/agent_registry/queries.rs
@@ -1,0 +1,94 @@
+//! Read-side methods for `AgentRegistry`: counts, lookups, listings,
+//! routing, and topology snapshot. Extracted from `mod.rs` to keep each
+//! file under the 200-line limit.
+
+use std::sync::Arc;
+
+use loopal_ipc::connection::Connection;
+use loopal_protocol::Envelope;
+
+use crate::routing;
+use crate::topology::{AgentInfo, AgentLifecycle};
+use crate::types::AgentConnectionState;
+
+use super::AgentRegistry;
+
+impl AgentRegistry {
+    pub fn agent_count(&self) -> usize {
+        self.agents.len()
+    }
+
+    /// Count only sub-agents (those with a parent). Excludes root "main".
+    pub fn sub_agent_count(&self) -> usize {
+        self.agents
+            .values()
+            .filter(|a| a.info.parent.is_some())
+            .count()
+    }
+
+    pub fn get_agent_connection(&self, name: &str) -> Option<Arc<Connection>> {
+        self.agents.get(name).and_then(|a| a.state.connection())
+    }
+
+    pub fn all_agent_connections(&self) -> Vec<(String, Arc<Connection>)> {
+        self.agents
+            .iter()
+            .filter_map(|(n, a)| a.state.connection().map(|c| (n.clone(), c)))
+            .collect()
+    }
+
+    pub fn list_agents(&self) -> Vec<(String, &'static str)> {
+        self.agents
+            .iter()
+            .map(|(n, a)| {
+                let l = match &a.state {
+                    AgentConnectionState::Local(_) => "local",
+                    AgentConnectionState::Connected(_) => "connected",
+                    AgentConnectionState::Shadow => "shadow",
+                };
+                (n.clone(), l)
+            })
+            .collect()
+    }
+
+    pub async fn route_message(&self, envelope: &Envelope) -> Result<(), String> {
+        let conn = self
+            .get_agent_connection(&envelope.target.agent)
+            .ok_or_else(|| format!("no agent: '{}'", envelope.target))?;
+        routing::route_to_agent(&conn, envelope, &self.event_tx).await
+    }
+
+    pub fn agent_info(&self, name: &str) -> Option<&AgentInfo> {
+        self.agents.get(name).map(|a| &a.info)
+    }
+
+    pub fn set_lifecycle(&mut self, name: &str, lifecycle: AgentLifecycle) {
+        if let Some(a) = self.agents.get_mut(name) {
+            a.info.lifecycle = lifecycle;
+        }
+    }
+
+    pub fn descendants(&self, name: &str) -> Vec<String> {
+        self.agents
+            .get(name)
+            .map(|a| a.info.descendants(&self.agents))
+            .unwrap_or_default()
+    }
+
+    pub fn topology_snapshot(&self) -> serde_json::Value {
+        let agents: Vec<serde_json::Value> = self
+            .agents
+            .iter()
+            .map(|(name, a)| {
+                serde_json::json!({
+                    "name": name,
+                    "parent": a.info.parent.as_ref().map(|p| p.to_string()),
+                    "children": a.info.children,
+                    "lifecycle": format!("{:?}", a.info.lifecycle),
+                    "model": a.info.model,
+                })
+            })
+            .collect();
+        serde_json::json!({ "agents": agents })
+    }
+}

--- a/crates/loopal-agent-hub/src/dispatch/cross_hub_forward.rs
+++ b/crates/loopal-agent-hub/src/dispatch/cross_hub_forward.rs
@@ -1,0 +1,140 @@
+//! Caller-side cross-hub spawn forwarding: pre-flight checks
+//! (schema, name encoding, uplink) → atomic budget-check + shadow
+//! pre-registration → `meta/spawn` IPC → rollback on failure.
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+
+use loopal_protocol::{AgentEvent, AgentEventPayload};
+
+use crate::hub::Hub;
+use crate::uplink::HubUplink;
+
+/// Validated cross-hub spawn pre-flight (schema + name encoding + uplink).
+/// Budget check and shadow registration happen atomically AFTER this.
+struct ForwardPreflight {
+    name: String,
+    uplink: Arc<HubUplink>,
+    hub_name: String,
+}
+
+fn check_payload_and_names(params: &Value, from_agent: &str) -> Result<String, String> {
+    // Defense-in-depth: cross-hub spawn must not carry filesystem-coupled
+    // fields. Reject (don't silently strip) so client-side bugs surface
+    // immediately rather than producing surprising behavior on the receiver.
+    loopal_ipc::cross_hub::validate_spawn_payload(params)?;
+
+    let name = params["name"]
+        .as_str()
+        .ok_or("missing 'name' field")?
+        .to_string();
+
+    // Reject '/' in agent names: QualifiedAddress encodes hub/agent as
+    // slash-joined string, so a name like "foo/bar" produces ambiguous
+    // round-trip — receiver parses caller's `hub-a/foo/bar` as
+    // hub=["hub-a","foo"], agent="bar". Forbid it at the cross-hub edge.
+    if name.contains('/') {
+        return Err(format!(
+            "agent name '{name}' cannot contain '/' (cross-hub address encoding)"
+        ));
+    }
+    if from_agent.contains('/') {
+        return Err(format!(
+            "caller agent name '{from_agent}' cannot contain '/' (cross-hub address encoding)"
+        ));
+    }
+    Ok(name)
+}
+
+async fn preflight(
+    hub: &Arc<Mutex<Hub>>,
+    params: &Value,
+    from_agent: &str,
+) -> Result<ForwardPreflight, String> {
+    let name = check_payload_and_names(params, from_agent)?;
+    let h = hub.lock().await;
+    let uplink = h
+        .uplink
+        .clone()
+        .ok_or("target_hub specified but no MetaHub uplink")?;
+    let hub_name = uplink.hub_name().to_string();
+    Ok(ForwardPreflight {
+        name,
+        uplink,
+        hub_name,
+    })
+}
+
+pub(super) async fn forward_cross_hub_spawn(
+    hub: &Arc<Mutex<Hub>>,
+    params: Value,
+    from_agent: &str,
+) -> Result<Value, String> {
+    let pf = preflight(hub, &params, from_agent).await?;
+
+    let mut spawn_params = params.clone();
+    if let Some(obj) = spawn_params.as_object_mut() {
+        // Encode parent so the receiving hub can route completions back to
+        // this hub's local caller via MetaHub.
+        let parent_addr = loopal_protocol::QualifiedAddress::remote([pf.hub_name], from_agent);
+        obj.insert("parent".into(), json!(parent_addr.to_string()));
+    }
+
+    // Atomic budget check + shadow registration: holding the same lock
+    // across both prevents two concurrent cross-hub spawns from each
+    // observing budget=N-1 and overshooting. Pre-registering before the
+    // IPC also closes the race where a fast-completing remote child's
+    // envelope arrives before the spawn response — `emit_agent_finished`
+    // would otherwise return None (no entry for the child), and the
+    // parent's local completion_tx would never receive the agent-result
+    // envelope. With the shadow present, emit_agent_finished can read the
+    // shadow's `info.parent` and route the envelope to the local parent.
+    {
+        let mut h = hub.lock().await;
+        let sub_count = h.registry.sub_agent_count();
+        if sub_count >= h.max_total_agents as usize {
+            return Err(format!(
+                "Spawn budget exhausted ({sub_count}/{} sub-agents). \
+                 Complete the task with your own tools.",
+                h.max_total_agents
+            ));
+        }
+        h.registry
+            .register_shadow(&pf.name, loopal_protocol::QualifiedAddress::local(from_agent))?;
+    }
+
+    let result = pf.uplink.spawn_agent(spawn_params).await;
+
+    match &result {
+        Ok(resp) => {
+            // Emit SubAgentSpawned for parity with the in-hub path
+            // (spawn_manager.rs:167). Without this, UI/topology consumers
+            // see in-hub children but not cross-hub shadow children.
+            let agent_id = resp["agent_id"].as_str().unwrap_or("unknown").to_string();
+            let model = params["model"].as_str().map(String::from);
+            let event = AgentEvent::root(AgentEventPayload::SubAgentSpawned {
+                name: pf.name.clone(),
+                agent_id,
+                parent: Some(loopal_protocol::QualifiedAddress::local(from_agent)),
+                model,
+                session_id: None,
+            });
+            let h = hub.lock().await;
+            if h.registry.event_sender().try_send(event).is_err() {
+                tracing::warn!(
+                    agent = %pf.name,
+                    "SubAgentSpawned event dropped (channel full, cross-hub)"
+                );
+            }
+        }
+        Err(_) => {
+            // Roll back the shadow if spawn failed; no remote child exists,
+            // so no completion will ever arrive to clean it up.
+            let mut h = hub.lock().await;
+            h.registry.unregister_connection(&pf.name);
+        }
+    }
+    result
+}

--- a/crates/loopal-agent-hub/src/dispatch/cross_hub_forward.rs
+++ b/crates/loopal-agent-hub/src/dispatch/cross_hub_forward.rs
@@ -101,8 +101,10 @@ pub(super) async fn forward_cross_hub_spawn(
                 h.max_total_agents
             ));
         }
-        h.registry
-            .register_shadow(&pf.name, loopal_protocol::QualifiedAddress::local(from_agent))?;
+        h.registry.register_shadow(
+            &pf.name,
+            loopal_protocol::QualifiedAddress::local(from_agent),
+        )?;
     }
 
     let result = pf.uplink.spawn_agent(spawn_params).await;

--- a/crates/loopal-agent-hub/src/dispatch/dispatch_handlers.rs
+++ b/crates/loopal-agent-hub/src/dispatch/dispatch_handlers.rs
@@ -6,7 +6,6 @@ use loopal_ipc::protocol::methods;
 use loopal_protocol::Envelope;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
-use tracing::info;
 
 use crate::hub::Hub;
 use crate::routing;
@@ -111,95 +110,4 @@ pub async fn handle_shutdown_agent(hub: &Arc<Mutex<Hub>>, params: Value) -> Resu
         .send_request(methods::AGENT_SHUTDOWN.name, json!({}))
         .await;
     Ok(json!({"ok": true}))
-}
-
-// ── Spawn + wait ──────────────────────────────────────────────────────
-pub async fn handle_spawn_agent(
-    hub: &Arc<Mutex<Hub>>,
-    params: Value,
-    from_agent: &str,
-) -> Result<Value, String> {
-    // Cross-hub spawn: delegate to MetaHub if target_hub specified
-    if params.get("target_hub").and_then(|v| v.as_str()).is_some() {
-        let (uplink, hub_name) = {
-            let h = hub.lock().await;
-            (
-                h.uplink.clone(),
-                h.uplink.as_ref().map(|u| u.hub_name().to_string()),
-            )
-        };
-        let result = match (uplink, hub_name) {
-            (Some(ul), Some(hn)) => {
-                let mut spawn_params = params.clone();
-                if let Some(obj) = spawn_params.as_object_mut() {
-                    // Cross-hub spawn: child's parent is the local agent on
-                    // *this* hub. Encode as a qualified address (`hub/agent`)
-                    // so the receiving hub can route completions back.
-                    let parent_addr =
-                        loopal_protocol::QualifiedAddress::remote([hn.clone()], from_agent);
-                    obj.insert("parent".into(), json!(parent_addr.to_string()));
-                }
-                ul.spawn_agent(spawn_params).await
-            }
-            _ => Err("target_hub specified but no MetaHub uplink".to_string()),
-        };
-        // On success, register a shadow entry so wait_agent can work locally.
-        // The completion will arrive via MetaHub → uplink → agent/message.
-        if let Ok(ref resp) = result
-            && let Some(name) = resp["name"].as_str()
-        {
-            let mut h = hub.lock().await;
-            // Cross-hub child's parent lives on this hub locally.
-            h.registry
-                .register_shadow(name, loopal_protocol::QualifiedAddress::local(from_agent));
-        }
-        return result;
-    }
-
-    // Local spawn
-    let name = params["name"]
-        .as_str()
-        .ok_or("missing 'name' field")?
-        .to_string();
-    let cwd = params["cwd"].as_str().unwrap_or(".").to_string();
-    let model = params["model"].as_str().map(String::from);
-    let prompt = params["prompt"].as_str().map(String::from);
-    let permission_mode = params["permission_mode"].as_str().map(String::from);
-    let agent_type = params["agent_type"].as_str().map(String::from);
-    let depth = params["depth"].as_u64().map(|v| v as u32);
-    let fork_context = params.get("fork_context").cloned();
-
-    // Parent: use explicit "parent" field from params if present (cross-hub),
-    // otherwise use from_agent (local spawn).
-    let parent = params["parent"]
-        .as_str()
-        .map(String::from)
-        .or_else(|| Some(from_agent.to_string()));
-
-    info!(agent = %name, parent = ?parent, "handle_spawn_agent start");
-    let hub_clone = hub.clone();
-    let name_clone = name.clone();
-    let handle = tokio::spawn(async move {
-        crate::spawn_manager::spawn_and_register(
-            hub_clone,
-            name_clone,
-            cwd,
-            model,
-            prompt,
-            parent,
-            permission_mode,
-            agent_type,
-            depth,
-            fork_context,
-        )
-        .await
-    });
-
-    let agent_id = handle
-        .await
-        .map_err(|e| format!("spawn task failed: {e}"))?
-        .map_err(|e| format!("spawn failed: {e}"))?;
-
-    info!(agent = %name, %agent_id, "handle_spawn_agent done");
-    Ok(json!({"agent_id": agent_id, "name": name}))
 }

--- a/crates/loopal-agent-hub/src/dispatch/mod.rs
+++ b/crates/loopal-agent-hub/src/dispatch/mod.rs
@@ -8,7 +8,13 @@ use tokio::sync::Mutex;
 
 use crate::hub::Hub;
 
+mod cross_hub_forward;
 mod dispatch_handlers;
+mod spawn_prepare;
+#[cfg(test)]
+#[path = "spawn_prepare_test.rs"]
+mod spawn_prepare_test;
+mod spawn_routing;
 mod status_handler;
 mod topology_handlers;
 mod wait_handler;
@@ -21,6 +27,7 @@ pub async fn dispatch_hub_request(
     from_agent: String,
 ) -> Result<Value, String> {
     use dispatch_handlers::*;
+    use spawn_routing::{handle_spawn_agent, handle_spawn_remote_agent};
     use status_handler::handle_status;
     use topology_handlers::*;
     use wait_handler::handle_wait_agent;
@@ -33,6 +40,9 @@ pub async fn dispatch_hub_request(
         m if m == methods::HUB_SHUTDOWN_AGENT.name => handle_shutdown_agent(hub, params).await,
         m if m == methods::HUB_SPAWN_AGENT.name => {
             handle_spawn_agent(hub, params, &from_agent).await
+        }
+        m if m == methods::HUB_SPAWN_REMOTE_AGENT.name => {
+            handle_spawn_remote_agent(hub, params, &from_agent).await
         }
         m if m == methods::HUB_WAIT_AGENT.name => handle_wait_agent(hub, params).await,
         m if m == methods::HUB_AGENT_INFO.name => handle_agent_info(hub, params).await,

--- a/crates/loopal-agent-hub/src/dispatch/spawn_prepare.rs
+++ b/crates/loopal-agent-hub/src/dispatch/spawn_prepare.rs
@@ -1,0 +1,96 @@
+//! Pure-function preparation step for `hub/spawn_remote_agent`. Extracted
+//! from the IPC handler so unit tests can verify field handling — including
+//! that the receiver's `default_cwd` is used, not any value the caller sent —
+//! without depending on `spawn_manager` (which spawns real subprocesses).
+//!
+//! TODO(P3): `permission_mode` and `depth` are passed through to the
+//! receiving Hub's `apply_start_overrides` / `build_depth_tool_filter` after
+//! a minimal clamp (depth >= 1). A malicious cross-hub caller can still
+//! influence these — for example, requesting `Bypass` permission_mode, or
+//! sending `depth: 1` to keep spawn tools available longer than the local
+//! ancestor chain warrants. This is acceptable today because cross-hub
+//! Loopal instances are co-located on the same machine + same user. A
+//! separate PR must add receiver-side policy arbitration before any
+//! cross-network deployment (clamp Bypass → Supervised, configurable
+//! per-hub allow-list, depth-floor based on receiver configuration, etc.).
+
+use std::path::Path;
+
+use serde_json::Value;
+
+pub(crate) struct RemoteSpawnArgs {
+    pub name: String,
+    pub cwd: String,
+    pub model: Option<String>,
+    pub prompt: Option<String>,
+    pub permission_mode: Option<String>,
+    pub agent_type: Option<String>,
+    pub depth: Option<u32>,
+    pub parent: Option<String>,
+}
+
+/// Validate a cross-hub spawn payload and assemble args using the receiver
+/// Hub's `default_cwd`. Filesystem-coupled fields (`cwd` / `fork_context` /
+/// `resume`) are rejected because the caller cannot make assumptions about
+/// the receiver's filesystem view.
+pub(crate) fn prepare_remote_spawn_args(
+    params: &Value,
+    from_agent: &str,
+    default_cwd: &Path,
+) -> Result<RemoteSpawnArgs, String> {
+    loopal_ipc::cross_hub::validate_spawn_payload(params)?;
+
+    let name = params["name"]
+        .as_str()
+        .ok_or("missing 'name' field")?
+        .to_string();
+    let model = params["model"].as_str().map(String::from);
+    let prompt = params["prompt"].as_str().map(String::from);
+    let permission_mode = params["permission_mode"].as_str().map(String::from);
+    if let Some(ref pm) = permission_mode {
+        // P3: receiver currently applies caller's mode without arbitration.
+        tracing::warn!(
+            permission_mode = %pm,
+            agent = %name,
+            "cross-hub spawn: applying caller's permission_mode hint without local policy arbitration (P3)"
+        );
+    }
+    let agent_type = params["agent_type"].as_str().map(String::from);
+    // Clamp depth >= 1: a malicious cross-hub caller could send `depth: 0`
+    // to make the child appear root-equivalent and bypass the receiver's
+    // depth-based spawn-tool filter (`build_depth_tool_filter`). Cross-hub
+    // is at least one hop, so depth must be > 0.
+    let depth = params["depth"]
+        .as_u64()
+        .map(|v| v as u32)
+        .map(|d| d.max(1));
+    let parent = match params["parent"].as_str() {
+        Some(s) => {
+            // Cross-hub parent MUST be a well-formed remote QualifiedAddress
+            // (hub/agent). Empty segments make `parse` silently fall back to
+            // a local address (preserving the input verbatim as the agent
+            // name) — that would let a malicious caller route completions to
+            // an unintended local agent. Reject anything that doesn't survive
+            // the round-trip as a remote address.
+            let parsed = loopal_protocol::QualifiedAddress::parse(s);
+            if !parsed.is_remote() {
+                return Err(format!(
+                    "cross-hub spawn 'parent' must be a remote QualifiedAddress (hub/agent), got '{s}'"
+                ));
+            }
+            Some(s.to_string())
+        }
+        None => Some(from_agent.to_string()),
+    };
+
+    Ok(RemoteSpawnArgs {
+        name,
+        cwd: default_cwd.to_string_lossy().into_owned(),
+        model,
+        prompt,
+        permission_mode,
+        agent_type,
+        depth,
+        parent,
+    })
+}

--- a/crates/loopal-agent-hub/src/dispatch/spawn_prepare.rs
+++ b/crates/loopal-agent-hub/src/dispatch/spawn_prepare.rs
@@ -60,10 +60,7 @@ pub(crate) fn prepare_remote_spawn_args(
     // to make the child appear root-equivalent and bypass the receiver's
     // depth-based spawn-tool filter (`build_depth_tool_filter`). Cross-hub
     // is at least one hop, so depth must be > 0.
-    let depth = params["depth"]
-        .as_u64()
-        .map(|v| v as u32)
-        .map(|d| d.max(1));
+    let depth = params["depth"].as_u64().map(|v| v as u32).map(|d| d.max(1));
     let parent = match params["parent"].as_str() {
         Some(s) => {
             // Cross-hub parent MUST be a well-formed remote QualifiedAddress

--- a/crates/loopal-agent-hub/src/dispatch/spawn_prepare_test.rs
+++ b/crates/loopal-agent-hub/src/dispatch/spawn_prepare_test.rs
@@ -47,12 +47,8 @@ fn advisory_fields_are_propagated() {
 
 #[test]
 fn parent_falls_back_to_from_agent_when_unset() {
-    let args = prepare_remote_spawn_args(
-        &json!({"name": "child"}),
-        "the-caller",
-        cwd("/cwd"),
-    )
-    .unwrap();
+    let args =
+        prepare_remote_spawn_args(&json!({"name": "child"}), "the-caller", cwd("/cwd")).unwrap();
     assert_eq!(args.parent.as_deref(), Some("the-caller"));
 }
 
@@ -98,62 +94,44 @@ fn parent_rejects_empty_segment() {
 fn depth_zero_clamps_to_one() {
     // Malicious caller sending depth: 0 must not produce a "root-like"
     // child that bypasses the receiver's depth-based tool filter.
-    let args = prepare_remote_spawn_args(
-        &json!({"name": "child", "depth": 0}),
-        "caller",
-        cwd("/cwd"),
-    )
-    .unwrap();
+    let args =
+        prepare_remote_spawn_args(&json!({"name": "child", "depth": 0}), "caller", cwd("/cwd"))
+            .unwrap();
     assert_eq!(args.depth, Some(1));
 }
 
 #[test]
 fn depth_above_one_passes_through() {
-    let args = prepare_remote_spawn_args(
-        &json!({"name": "child", "depth": 5}),
-        "caller",
-        cwd("/cwd"),
-    )
-    .unwrap();
+    let args =
+        prepare_remote_spawn_args(&json!({"name": "child", "depth": 5}), "caller", cwd("/cwd"))
+            .unwrap();
     assert_eq!(args.depth, Some(5));
 }
 
 #[test]
 fn rejects_cwd() {
-    let err = prepare_remote_spawn_args(
-        &json!({"name": "x", "cwd": "/attacker"}),
-        "f",
-        cwd("/c"),
-    )
-    .unwrap_err();
+    let err = prepare_remote_spawn_args(&json!({"name": "x", "cwd": "/attacker"}), "f", cwd("/c"))
+        .unwrap_err();
     assert!(err.contains("cwd"));
 }
 
 #[test]
 fn rejects_fork_context() {
-    let err = prepare_remote_spawn_args(
-        &json!({"name": "x", "fork_context": []}),
-        "f",
-        cwd("/c"),
-    )
-    .unwrap_err();
+    let err = prepare_remote_spawn_args(&json!({"name": "x", "fork_context": []}), "f", cwd("/c"))
+        .unwrap_err();
     assert!(err.contains("fork_context"));
 }
 
 #[test]
 fn rejects_resume() {
-    let err = prepare_remote_spawn_args(
-        &json!({"name": "x", "resume": "session-1"}),
-        "f",
-        cwd("/c"),
-    )
-    .unwrap_err();
+    let err =
+        prepare_remote_spawn_args(&json!({"name": "x", "resume": "session-1"}), "f", cwd("/c"))
+            .unwrap_err();
     assert!(err.contains("resume"));
 }
 
 #[test]
 fn rejects_when_name_missing() {
-    let err =
-        prepare_remote_spawn_args(&json!({"prompt": "x"}), "f", cwd("/c")).unwrap_err();
+    let err = prepare_remote_spawn_args(&json!({"prompt": "x"}), "f", cwd("/c")).unwrap_err();
     assert!(err.contains("name"));
 }

--- a/crates/loopal-agent-hub/src/dispatch/spawn_prepare_test.rs
+++ b/crates/loopal-agent-hub/src/dispatch/spawn_prepare_test.rs
@@ -1,0 +1,159 @@
+//! Unit tests for `prepare_remote_spawn_args`. Kept in a sibling file to
+//! respect the 200-line module limit.
+
+use super::spawn_prepare::prepare_remote_spawn_args;
+use serde_json::json;
+use std::path::Path;
+
+fn cwd(p: &str) -> &Path {
+    Path::new(p)
+}
+
+#[test]
+fn uses_receiver_default_cwd_not_caller_input() {
+    // Anchor for the cross-hub invariant: the receiver's default_cwd must
+    // reach spawn_manager regardless of what (if anything) the caller sent —
+    // preventing caller cwd leaks into receiver system prompt.
+    let args = prepare_remote_spawn_args(
+        &json!({"name": "child", "prompt": "x"}),
+        "caller",
+        cwd("/receiver/forced"),
+    )
+    .unwrap();
+    assert_eq!(args.cwd, "/receiver/forced");
+}
+
+#[test]
+fn advisory_fields_are_propagated() {
+    let args = prepare_remote_spawn_args(
+        &json!({
+            "name": "child",
+            "prompt": "do work",
+            "model": "claude-opus-4-7",
+            "permission_mode": "supervised",
+            "agent_type": "explore",
+            "depth": 3,
+        }),
+        "caller",
+        cwd("/cwd"),
+    )
+    .unwrap();
+    assert_eq!(args.model.as_deref(), Some("claude-opus-4-7"));
+    assert_eq!(args.permission_mode.as_deref(), Some("supervised"));
+    assert_eq!(args.agent_type.as_deref(), Some("explore"));
+    assert_eq!(args.depth, Some(3));
+    assert_eq!(args.prompt.as_deref(), Some("do work"));
+}
+
+#[test]
+fn parent_falls_back_to_from_agent_when_unset() {
+    let args = prepare_remote_spawn_args(
+        &json!({"name": "child"}),
+        "the-caller",
+        cwd("/cwd"),
+    )
+    .unwrap();
+    assert_eq!(args.parent.as_deref(), Some("the-caller"));
+}
+
+#[test]
+fn parent_uses_explicit_value_when_provided() {
+    let args = prepare_remote_spawn_args(
+        &json!({"name": "child", "parent": "hub-a/grandparent"}),
+        "caller",
+        cwd("/cwd"),
+    )
+    .unwrap();
+    assert_eq!(args.parent.as_deref(), Some("hub-a/grandparent"));
+}
+
+#[test]
+fn parent_rejects_local_form() {
+    // A bare local address like "main" must not pass — caller side should
+    // always send a fully-qualified `hub/agent` for cross-hub spawn.
+    let err = prepare_remote_spawn_args(
+        &json!({"name": "child", "parent": "main"}),
+        "caller",
+        cwd("/cwd"),
+    )
+    .unwrap_err();
+    assert!(err.contains("parent"), "got: {err}");
+}
+
+#[test]
+fn parent_rejects_empty_segment() {
+    // Empty segments make QualifiedAddress::parse silently fall back to a
+    // local address — must be rejected to prevent delivery to an
+    // unintended local agent.
+    let err = prepare_remote_spawn_args(
+        &json!({"name": "child", "parent": "//attacker"}),
+        "caller",
+        cwd("/cwd"),
+    )
+    .unwrap_err();
+    assert!(err.contains("parent"), "got: {err}");
+}
+
+#[test]
+fn depth_zero_clamps_to_one() {
+    // Malicious caller sending depth: 0 must not produce a "root-like"
+    // child that bypasses the receiver's depth-based tool filter.
+    let args = prepare_remote_spawn_args(
+        &json!({"name": "child", "depth": 0}),
+        "caller",
+        cwd("/cwd"),
+    )
+    .unwrap();
+    assert_eq!(args.depth, Some(1));
+}
+
+#[test]
+fn depth_above_one_passes_through() {
+    let args = prepare_remote_spawn_args(
+        &json!({"name": "child", "depth": 5}),
+        "caller",
+        cwd("/cwd"),
+    )
+    .unwrap();
+    assert_eq!(args.depth, Some(5));
+}
+
+#[test]
+fn rejects_cwd() {
+    let err = prepare_remote_spawn_args(
+        &json!({"name": "x", "cwd": "/attacker"}),
+        "f",
+        cwd("/c"),
+    )
+    .unwrap_err();
+    assert!(err.contains("cwd"));
+}
+
+#[test]
+fn rejects_fork_context() {
+    let err = prepare_remote_spawn_args(
+        &json!({"name": "x", "fork_context": []}),
+        "f",
+        cwd("/c"),
+    )
+    .unwrap_err();
+    assert!(err.contains("fork_context"));
+}
+
+#[test]
+fn rejects_resume() {
+    let err = prepare_remote_spawn_args(
+        &json!({"name": "x", "resume": "session-1"}),
+        "f",
+        cwd("/c"),
+    )
+    .unwrap_err();
+    assert!(err.contains("resume"));
+}
+
+#[test]
+fn rejects_when_name_missing() {
+    let err =
+        prepare_remote_spawn_args(&json!({"prompt": "x"}), "f", cwd("/c")).unwrap_err();
+    assert!(err.contains("name"));
+}

--- a/crates/loopal-agent-hub/src/dispatch/spawn_routing.rs
+++ b/crates/loopal-agent-hub/src/dispatch/spawn_routing.rs
@@ -1,0 +1,146 @@
+//! Entry handlers for `hub/spawn_agent` (in-hub) and
+//! `hub/spawn_remote_agent` (cross-hub-receiver).
+//!
+//! In-hub spawn assumes shared filesystem: caller may pass `cwd` and
+//! `fork_context`. Cross-hub spawn is forbidden from carrying those —
+//! the receiver uses its own `Hub.default_cwd` and rejects fork_context
+//! / resume. Cross-hub forwarding lives in `cross_hub_forward.rs`.
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+use tracing::info;
+
+use crate::hub::Hub;
+
+/// In-hub spawn entry point. If `target_hub` is set, forward to MetaHub
+/// after rejecting any filesystem-coupled fields (cwd / fork_context /
+/// resume). Otherwise spawn locally.
+pub async fn handle_spawn_agent(
+    hub: &Arc<Mutex<Hub>>,
+    params: Value,
+    from_agent: &str,
+) -> Result<Value, String> {
+    if let Some(v) = params.get("target_hub") {
+        let target = v
+            .as_str()
+            .ok_or_else(|| format!("'target_hub' must be a string, got: {v}"))?;
+        // Mirror the agent-name check in cross_hub_forward::preflight: a
+        // hub identifier with '/' would be ambiguous with QualifiedAddress
+        // multi-hop encoding (`hub-c/hub-d/agent`) — reject up front.
+        if target.contains('/') {
+            return Err(format!(
+                "'target_hub' cannot contain '/' (cross-hub address encoding), got: {target}"
+            ));
+        }
+        return super::cross_hub_forward::forward_cross_hub_spawn(hub, params, from_agent).await;
+    }
+    spawn_local(hub, params, from_agent).await
+}
+
+async fn spawn_local(
+    hub: &Arc<Mutex<Hub>>,
+    params: Value,
+    from_agent: &str,
+) -> Result<Value, String> {
+    let name = params["name"]
+        .as_str()
+        .ok_or("missing 'name' field")?
+        .to_string();
+    let cwd = params["cwd"].as_str().unwrap_or(".").to_string();
+    let model = params["model"].as_str().map(String::from);
+    let prompt = params["prompt"].as_str().map(String::from);
+    let permission_mode = params["permission_mode"].as_str().map(String::from);
+    let agent_type = params["agent_type"].as_str().map(String::from);
+    let depth = params["depth"].as_u64().map(|v| v as u32);
+    let fork_context = params.get("fork_context").cloned();
+    let parent = params["parent"]
+        .as_str()
+        .map(String::from)
+        .or_else(|| Some(from_agent.to_string()));
+
+    info!(agent = %name, parent = ?parent, "handle_spawn_agent local start");
+    spawn_via_manager(
+        hub.clone(),
+        name,
+        cwd,
+        model,
+        prompt,
+        parent,
+        permission_mode,
+        agent_type,
+        depth,
+        fork_context,
+    )
+    .await
+}
+
+/// Cross-hub spawn target: MetaHub forwards `meta/spawn` here as
+/// `hub/spawn_remote_agent`. Caller has no shared filesystem, so
+/// `cwd` / `fork_context` / `resume` are forbidden — receiver uses its
+/// own `Hub.default_cwd`.
+pub async fn handle_spawn_remote_agent(
+    hub: &Arc<Mutex<Hub>>,
+    params: Value,
+    from_agent: &str,
+) -> Result<Value, String> {
+    let default_cwd = hub.lock().await.default_cwd.clone();
+    let args =
+        super::spawn_prepare::prepare_remote_spawn_args(&params, from_agent, &default_cwd)?;
+    info!(agent = %args.name, parent = ?args.parent, "handle_spawn_remote_agent start");
+    spawn_via_manager(
+        hub.clone(),
+        args.name,
+        args.cwd,
+        args.model,
+        args.prompt,
+        args.parent,
+        args.permission_mode,
+        args.agent_type,
+        args.depth,
+        None,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn spawn_via_manager(
+    hub: Arc<Mutex<Hub>>,
+    name: String,
+    cwd: String,
+    model: Option<String>,
+    prompt: Option<String>,
+    parent: Option<String>,
+    permission_mode: Option<String>,
+    agent_type: Option<String>,
+    depth: Option<u32>,
+    fork_context: Option<Value>,
+) -> Result<Value, String> {
+    let name_clone = name.clone();
+    // Detached on purpose: spawn_and_register may have already forked a
+    // child process, and we don't want outer cancellation to leave the
+    // child as an orphan. We still .await for the agent_id so the IPC
+    // response carries it back to the caller.
+    let handle = tokio::spawn(async move {
+        crate::spawn_manager::spawn_and_register(
+            hub,
+            name_clone,
+            cwd,
+            model,
+            prompt,
+            parent,
+            permission_mode,
+            agent_type,
+            depth,
+            fork_context,
+        )
+        .await
+    });
+    let agent_id = handle
+        .await
+        .map_err(|e| format!("spawn task failed: {e}"))?
+        .map_err(|e| format!("spawn failed: {e}"))?;
+    info!(agent = %name, %agent_id, "spawn done");
+    Ok(json!({"agent_id": agent_id, "name": name}))
+}

--- a/crates/loopal-agent-hub/src/dispatch/spawn_routing.rs
+++ b/crates/loopal-agent-hub/src/dispatch/spawn_routing.rs
@@ -86,8 +86,7 @@ pub async fn handle_spawn_remote_agent(
     from_agent: &str,
 ) -> Result<Value, String> {
     let default_cwd = hub.lock().await.default_cwd.clone();
-    let args =
-        super::spawn_prepare::prepare_remote_spawn_args(&params, from_agent, &default_cwd)?;
+    let args = super::spawn_prepare::prepare_remote_spawn_args(&params, from_agent, &default_cwd)?;
     info!(agent = %args.name, parent = ?args.parent, "handle_spawn_remote_agent start");
     spawn_via_manager(
         hub.clone(),

--- a/crates/loopal-agent-hub/src/finish.rs
+++ b/crates/loopal-agent-hub/src/finish.rs
@@ -60,3 +60,29 @@ pub async fn finish_and_deliver(
     // return, allowing the process to exit cleanly.
     conn.close().await;
 }
+
+/// Deliver a cross-hub completion that arrived through the uplink reverse
+/// handler: emit the finished event, unregister, and dispatch the pending
+/// envelope to the local parent's `completion_tx` if any. Mirrors the
+/// pending-then-deliver pattern in `finish_and_deliver` to ensure the
+/// parent agent's conversation actually receives the agent-result envelope.
+pub async fn deliver_cross_hub_completion(
+    hub: &Arc<Mutex<Hub>>,
+    child: &str,
+    output: String,
+) {
+    let pending = {
+        let mut h = hub.lock().await;
+        let pending = h.registry.emit_agent_finished(child, Some(output));
+        h.registry.unregister_connection(child);
+        pending
+    };
+    if let Some((tx, envelope)) = pending
+        && tx.send(envelope).await.is_err()
+    {
+        tracing::warn!(
+            agent = %child,
+            "parent completion channel closed (cross-hub)"
+        );
+    }
+}

--- a/crates/loopal-agent-hub/src/finish.rs
+++ b/crates/loopal-agent-hub/src/finish.rs
@@ -66,11 +66,7 @@ pub async fn finish_and_deliver(
 /// envelope to the local parent's `completion_tx` if any. Mirrors the
 /// pending-then-deliver pattern in `finish_and_deliver` to ensure the
 /// parent agent's conversation actually receives the agent-result envelope.
-pub async fn deliver_cross_hub_completion(
-    hub: &Arc<Mutex<Hub>>,
-    child: &str,
-    output: String,
-) {
+pub async fn deliver_cross_hub_completion(hub: &Arc<Mutex<Hub>>, child: &str, output: String) {
     let pending = {
         let mut h = hub.lock().await;
         let pending = h.registry.emit_agent_finished(child, Some(output));

--- a/crates/loopal-agent-hub/src/hub.rs
+++ b/crates/loopal-agent-hub/src/hub.rs
@@ -4,6 +4,7 @@
 //! Hub ties them together: agent events flow to UI via broadcast,
 //! permission requests flow from agents to UI clients via relay.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
@@ -28,28 +29,46 @@ pub struct Hub {
     pub listener_port: Option<u16>,
     /// Max total sub-agents allowed (set from HarnessConfig at bootstrap).
     pub max_total_agents: u32,
+    /// Working directory used as the cwd for cross-hub spawned agents.
+    /// In-hub spawns still take cwd from their parent agent's request.
+    pub default_cwd: PathBuf,
 }
 
 impl Hub {
     pub fn new(event_tx: mpsc::Sender<AgentEvent>) -> Self {
+        Self::with_cwd(event_tx, PathBuf::from("."))
+    }
+
+    /// Construct a Hub with an explicit `default_cwd` for cross-hub spawns.
+    /// Production callers should pass the directory the Hub process was
+    /// started in. Path is canonicalized so child processes spawned with
+    /// this cwd see an absolute path independent of their inherited cwd.
+    pub fn with_cwd(event_tx: mpsc::Sender<AgentEvent>, default_cwd: PathBuf) -> Self {
+        let canonical = match default_cwd.canonicalize() {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    path = %default_cwd.display(),
+                    error = %e,
+                    "Hub::with_cwd: canonicalize failed, using path verbatim — \
+                     cross-hub spawns may inherit unpredictable cwd"
+                );
+                default_cwd
+            }
+        };
         Self {
             registry: AgentRegistry::new(event_tx),
             ui: UiDispatcher::new(),
             uplink: None,
             listener_port: None,
             max_total_agents: 16,
+            default_cwd: canonical,
         }
     }
 
     /// Create a no-op Hub (for tests that don't need real connections).
     pub fn noop() -> Self {
         let (tx, _rx) = mpsc::channel(1);
-        Self {
-            registry: AgentRegistry::new(tx),
-            ui: UiDispatcher::new(),
-            uplink: None,
-            listener_port: None,
-            max_total_agents: 16,
-        }
+        Self::with_cwd(tx, PathBuf::from("."))
     }
 }

--- a/crates/loopal-agent-hub/src/uplink.rs
+++ b/crates/loopal-agent-hub/src/uplink.rs
@@ -131,8 +131,7 @@ pub async fn handle_reverse_requests(
                         // so it works with the typed Agent source after SNAT.
                         if let Some(child) = extract_agent_result_name(&env) {
                             let output = env.content.text.clone();
-                            crate::finish::deliver_cross_hub_completion(&hub, &child, output)
-                                .await;
+                            crate::finish::deliver_cross_hub_completion(&hub, &child, output).await;
                         }
                         // Defense in depth: target should be local at this point
                         // (MetaHub router consumed the next-hop hub via DNAT).

--- a/crates/loopal-agent-hub/src/uplink.rs
+++ b/crates/loopal-agent-hub/src/uplink.rs
@@ -131,9 +131,8 @@ pub async fn handle_reverse_requests(
                         // so it works with the typed Agent source after SNAT.
                         if let Some(child) = extract_agent_result_name(&env) {
                             let output = env.content.text.clone();
-                            let mut h = hub.lock().await;
-                            h.registry.emit_agent_finished(&child, Some(output));
-                            h.registry.unregister_connection(&child);
+                            crate::finish::deliver_cross_hub_completion(&hub, &child, output)
+                                .await;
                         }
                         // Defense in depth: target should be local at this point
                         // (MetaHub router consumed the next-hop hub via DNAT).

--- a/crates/loopal-agent-hub/tests/suite.rs
+++ b/crates/loopal-agent-hub/tests/suite.rs
@@ -29,6 +29,8 @@ mod race_condition_test;
 mod relay_test;
 #[path = "suite/spawn_lifecycle_test.rs"]
 mod spawn_lifecycle_test;
+#[path = "suite/spawn_remote_test.rs"]
+mod spawn_remote_test;
 #[path = "suite/transport_close_test.rs"]
 mod transport_close_test;
 #[path = "suite/wait_nonblocking_test.rs"]

--- a/crates/loopal-agent-hub/tests/suite/spawn_remote_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/spawn_remote_test.rs
@@ -32,7 +32,10 @@ async fn rejects_cwd_field() {
     )
     .await;
     let err = result.expect_err("must reject cwd in cross-hub spawn");
-    assert!(err.contains("cwd"), "error must mention forbidden 'cwd' field, got: {err}");
+    assert!(
+        err.contains("cwd"),
+        "error must mention forbidden 'cwd' field, got: {err}"
+    );
 }
 
 #[tokio::test]
@@ -71,7 +74,10 @@ async fn rejects_resume_field() {
     )
     .await;
     let err = result.expect_err("must reject session resume");
-    assert!(err.contains("resume"), "error must mention 'resume', got: {err}");
+    assert!(
+        err.contains("resume"),
+        "error must mention 'resume', got: {err}"
+    );
 }
 
 #[tokio::test]

--- a/crates/loopal-agent-hub/tests/suite/spawn_remote_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/spawn_remote_test.rs
@@ -1,0 +1,165 @@
+//! Tests for `hub/spawn_remote_agent` handler — verifies cross-hub spawn
+//! safety invariants: forbidden filesystem-coupled fields are rejected,
+//! receiver Hub's `default_cwd` is used (not the caller's).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, mpsc};
+
+use loopal_agent_hub::Hub;
+use loopal_agent_hub::dispatch::dispatch_hub_request;
+use loopal_protocol::AgentEvent;
+use serde_json::json;
+
+fn make_hub_with_cwd(cwd: PathBuf) -> Arc<Mutex<Hub>> {
+    let (tx, _rx) = mpsc::channel::<AgentEvent>(16);
+    Arc::new(Mutex::new(Hub::with_cwd(tx, cwd)))
+}
+
+#[tokio::test]
+async fn rejects_cwd_field() {
+    let hub = make_hub_with_cwd(PathBuf::from("/hub-local"));
+    let result = dispatch_hub_request(
+        &hub,
+        "hub/spawn_remote_agent",
+        json!({
+            "name": "child",
+            "prompt": "report cwd",
+            "cwd": "/attacker/path",
+        }),
+        "from-agent".into(),
+    )
+    .await;
+    let err = result.expect_err("must reject cwd in cross-hub spawn");
+    assert!(err.contains("cwd"), "error must mention forbidden 'cwd' field, got: {err}");
+}
+
+#[tokio::test]
+async fn rejects_fork_context_field() {
+    let hub = make_hub_with_cwd(PathBuf::from("/hub-local"));
+    let result = dispatch_hub_request(
+        &hub,
+        "hub/spawn_remote_agent",
+        json!({
+            "name": "child",
+            "prompt": "do work",
+            "fork_context": [],
+        }),
+        "from-agent".into(),
+    )
+    .await;
+    let err = result.expect_err("must reject fork_context");
+    assert!(
+        err.contains("fork_context"),
+        "error must mention 'fork_context', got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn rejects_resume_field() {
+    let hub = make_hub_with_cwd(PathBuf::from("/hub-local"));
+    let result = dispatch_hub_request(
+        &hub,
+        "hub/spawn_remote_agent",
+        json!({
+            "name": "child",
+            "prompt": "do work",
+            "resume": "session-123",
+        }),
+        "from-agent".into(),
+    )
+    .await;
+    let err = result.expect_err("must reject session resume");
+    assert!(err.contains("resume"), "error must mention 'resume', got: {err}");
+}
+
+#[tokio::test]
+async fn rejects_when_name_missing() {
+    let hub = make_hub_with_cwd(PathBuf::from("/hub-local"));
+    let result = dispatch_hub_request(
+        &hub,
+        "hub/spawn_remote_agent",
+        json!({"prompt": "do work"}),
+        "from-agent".into(),
+    )
+    .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn local_spawn_path_unaffected_by_remote_handler() {
+    // Verify the new method is wired distinctly: a regular hub/spawn_agent
+    // request without target_hub still reaches the local handler (not the
+    // remote one). Failure here would surface as a different error type.
+    let hub = make_hub_with_cwd(PathBuf::from("/hub-local"));
+    // No name provided — local handler returns "missing 'name' field".
+    let result = dispatch_hub_request(
+        &hub,
+        "hub/spawn_agent",
+        json!({"prompt": "x"}),
+        "from-agent".into(),
+    )
+    .await;
+    let err = result.expect_err("missing name");
+    assert!(err.contains("name"), "got: {err}");
+}
+
+#[tokio::test]
+async fn rejects_non_string_target_hub() {
+    let hub = make_hub_with_cwd(PathBuf::from("/hub-local"));
+    let result = dispatch_hub_request(
+        &hub,
+        "hub/spawn_agent",
+        json!({"name": "child", "prompt": "x", "target_hub": 42}),
+        "from-agent".into(),
+    )
+    .await;
+    let err = result.expect_err("non-string target_hub must be rejected");
+    assert!(
+        err.contains("target_hub") && err.contains("string"),
+        "error must point to type mismatch, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn cross_hub_forward_rejects_slash_in_child_name() {
+    let hub = make_hub_with_cwd(PathBuf::from("/hub-local"));
+    let result = dispatch_hub_request(
+        &hub,
+        "hub/spawn_agent",
+        json!({
+            "name": "foo/bar",
+            "prompt": "x",
+            "target_hub": "hub-b",
+        }),
+        "main".into(),
+    )
+    .await;
+    let err = result.expect_err("'/' in child name must be rejected");
+    assert!(
+        err.contains("'/'") || err.contains("cannot contain"),
+        "error must mention slash restriction, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn cross_hub_forward_rejects_slash_in_caller_name() {
+    let hub = make_hub_with_cwd(PathBuf::from("/hub-local"));
+    let result = dispatch_hub_request(
+        &hub,
+        "hub/spawn_agent",
+        json!({
+            "name": "child",
+            "prompt": "x",
+            "target_hub": "hub-b",
+        }),
+        "main/branch".into(),
+    )
+    .await;
+    let err = result.expect_err("'/' in caller name must be rejected");
+    assert!(
+        err.contains("caller") && (err.contains("'/'") || err.contains("cannot contain")),
+        "error must point to caller name slash, got: {err}"
+    );
+}

--- a/crates/loopal-agent-server/src/memory_adapter.rs
+++ b/crates/loopal-agent-server/src/memory_adapter.rs
@@ -11,7 +11,7 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 use loopal_agent::shared::AgentShared;
-use loopal_agent::spawn::{SpawnParams, spawn_agent, wait_agent};
+use loopal_agent::spawn::{SpawnParams, SpawnTarget, spawn_agent, wait_agent};
 use loopal_memory::{MEMORY_AGENT_PROMPT, MemoryProcessor};
 use loopal_tool_api::MemoryChannel;
 
@@ -59,12 +59,13 @@ impl ServerMemoryProcessor {
             name: name.to_string(),
             prompt,
             model: Some(self.model.clone()),
-            cwd_override: None,
             permission_mode: None,
-            target_hub: None,
             agent_type: None,
             depth: self.shared.depth + 1,
-            fork_context: None,
+            target: SpawnTarget::InHub {
+                cwd_override: None,
+                fork_context: None,
+            },
         };
         spawn_agent(&self.shared, params).await?;
         match wait_agent(&self.shared, name).await {

--- a/crates/loopal-agent-server/src/memory_consolidation.rs
+++ b/crates/loopal-agent-server/src/memory_consolidation.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tracing::{info, warn};
 
 use loopal_agent::shared::AgentShared;
-use loopal_agent::spawn::{SpawnParams, spawn_agent, wait_agent};
+use loopal_agent::spawn::{SpawnParams, SpawnTarget, spawn_agent, wait_agent};
 use loopal_memory::MEMORY_CONSOLIDATION_PROMPT;
 
 use super::memory_adapter::ServerMemoryProcessor;
@@ -36,12 +36,13 @@ pub fn trigger_consolidation(shared: &Arc<AgentShared>, model: &str) {
             name: name.clone(),
             prompt,
             model: Some(model),
-            cwd_override: None,
             permission_mode: None,
-            target_hub: None,
             agent_type: None,
             depth: shared.depth + 1,
-            fork_context: None,
+            target: SpawnTarget::InHub {
+                cwd_override: None,
+                fork_context: None,
+            },
         };
         match spawn_agent(&shared, params).await {
             Ok(_) => {

--- a/crates/loopal-agent/BUILD.bazel
+++ b/crates/loopal-agent/BUILD.bazel
@@ -50,6 +50,7 @@ rust_test(
         "//crates/loopal-backend",
         "//crates/loopal-error",
         "//crates/loopal-ipc",
+        "//crates/loopal-message",
         "//crates/loopal-protocol",
         "//crates/loopal-provider-api",
         "//crates/loopal-runtime",

--- a/crates/loopal-agent/src/spawn.rs
+++ b/crates/loopal-agent/src/spawn.rs
@@ -57,7 +57,10 @@ pub struct SpawnResult {
 
 /// Build the IPC payload sent on `hub/spawn_agent`. Pure function — extracted
 /// for unit testing the InHub / CrossHub field selection.
-pub fn build_spawn_request(params: &SpawnParams, parent_cwd: &std::path::Path) -> serde_json::Value {
+pub fn build_spawn_request(
+    params: &SpawnParams,
+    parent_cwd: &std::path::Path,
+) -> serde_json::Value {
     let mut request = json!({
         "name": params.name,
         "model": params.model,

--- a/crates/loopal-agent/src/spawn.rs
+++ b/crates/loopal-agent/src/spawn.rs
@@ -8,23 +8,45 @@ use serde_json::json;
 
 use crate::shared::AgentShared;
 
+/// Where the sub-agent should be spawned — controls which fields cross IPC.
+///
+/// The two variants exist because in-hub and cross-hub spawns have
+/// fundamentally different trust / filesystem-view semantics:
+/// - **InHub**: child runs on the same Hub as the parent; cwd / env /
+///   parent conversation context (fork_context) can all be inherited
+///   safely because they share a filesystem.
+/// - **CrossHub** (same-machine cross-hub or remote, treated identically):
+///   child runs under a different Hub; the filesystem is NOT shared.
+///   `cwd` / `fork_context` / session `resume` MUST NOT cross the boundary —
+///   the receiver Hub uses its own `default_cwd`.
+pub enum SpawnTarget {
+    InHub {
+        /// Override the working directory (e.g. for worktree isolation).
+        cwd_override: Option<PathBuf>,
+        /// Compressed parent conversation injected as initial child context.
+        fork_context: Option<Vec<loopal_message::Message>>,
+    },
+    CrossHub {
+        /// Target hub identifier (e.g. "hub-b") registered on MetaHub.
+        hub_id: String,
+    },
+}
+
 /// Parameters for spawning a new sub-agent.
 pub struct SpawnParams {
     pub name: String,
     pub prompt: String,
     pub model: Option<String>,
-    /// Override the working directory (e.g. for worktree isolation).
-    pub cwd_override: Option<PathBuf>,
-    /// Permission mode to propagate from parent agent.
+    /// Permission mode hint propagated from parent. The receiver Hub's
+    /// permission policy is the enforcement point — for cross-hub spawns
+    /// this is an advisory signal, not a command.
     pub permission_mode: Option<String>,
-    /// Target hub for cross-hub spawn (e.g. "hub-b"). None = local hub.
-    pub target_hub: Option<String>,
     /// Agent type for fragment selection (e.g. "explore", "plan").
     pub agent_type: Option<String>,
     /// Nesting depth of the child agent (parent depth + 1).
     pub depth: u32,
-    /// Compressed parent conversation to inject as initial context.
-    pub fork_context: Option<Vec<loopal_message::Message>>,
+    /// In-hub vs cross-hub semantics.
+    pub target: SpawnTarget,
 }
 
 /// Result returned from Hub after spawning.
@@ -33,35 +55,51 @@ pub struct SpawnResult {
     pub name: String,
 }
 
-/// Request Hub to spawn a sub-agent. Hub handles fork, stdio, and registration.
-pub async fn spawn_agent(
-    shared: &Arc<AgentShared>,
-    params: SpawnParams,
-) -> Result<SpawnResult, String> {
-    let cwd = params
-        .cwd_override
-        .as_deref()
-        .unwrap_or(&shared.cwd)
-        .to_string_lossy()
-        .to_string();
-
+/// Build the IPC payload sent on `hub/spawn_agent`. Pure function — extracted
+/// for unit testing the InHub / CrossHub field selection.
+pub fn build_spawn_request(params: &SpawnParams, parent_cwd: &std::path::Path) -> serde_json::Value {
     let mut request = json!({
         "name": params.name,
-        "cwd": cwd,
         "model": params.model,
         "prompt": params.prompt,
         "permission_mode": params.permission_mode,
         "agent_type": params.agent_type,
         "depth": params.depth,
     });
-    if let Some(ref hub) = params.target_hub {
-        request["target_hub"] = json!(hub);
+
+    match &params.target {
+        SpawnTarget::InHub {
+            cwd_override,
+            fork_context,
+        } => {
+            let cwd = cwd_override
+                .as_deref()
+                .unwrap_or(parent_cwd)
+                .to_string_lossy()
+                .to_string();
+            request["cwd"] = json!(cwd);
+            if let Some(fc) = fork_context
+                && let Ok(val) = serde_json::to_value(fc)
+            {
+                request["fork_context"] = val;
+            }
+        }
+        SpawnTarget::CrossHub { hub_id } => {
+            // CrossHub: no cwd, no fork_context, no resume. Receiver Hub's
+            // own default_cwd is used; filesystem is not shared.
+            request["target_hub"] = json!(hub_id);
+        }
     }
-    if let Some(ref fc) = params.fork_context
-        && let Ok(val) = serde_json::to_value(fc)
-    {
-        request["fork_context"] = val;
-    }
+
+    request
+}
+
+/// Request Hub to spawn a sub-agent. Hub handles fork, stdio, and registration.
+pub async fn spawn_agent(
+    shared: &Arc<AgentShared>,
+    params: SpawnParams,
+) -> Result<SpawnResult, String> {
+    let request = build_spawn_request(&params, &shared.cwd);
 
     tracing::info!(agent = %params.name, "sending hub/spawn_agent request");
     let response = shared

--- a/crates/loopal-agent/src/tools/collaboration/agent.rs
+++ b/crates/loopal-agent/src/tools/collaboration/agent.rs
@@ -6,12 +6,10 @@ use loopal_tool_api::{Tool, ToolContext, ToolResult};
 use serde_json::json;
 use std::sync::Arc;
 
-use super::shared_extract::{create_agent_worktree, extract_shared, require_str};
-use crate::config::load_agent_configs;
+use super::agent_spawn::action_spawn;
+use super::shared_extract::{extract_shared, require_str};
 use crate::shared::AgentShared;
-use crate::spawn::{SpawnParams, spawn_agent, wait_agent};
-
-use super::agent_fork::{build_fork_context, spawn_bg_cleanup};
+use crate::spawn::wait_agent;
 
 pub struct AgentTool;
 
@@ -70,107 +68,6 @@ impl Tool for AgentTool {
     }
 }
 
-async fn action_spawn(
-    shared: Arc<AgentShared>,
-    input: &serde_json::Value,
-    memory_channel: Option<&dyn loopal_tool_api::MemoryChannel>,
-) -> Result<ToolResult, LoopalError> {
-    let prompt = require_str(input, "prompt")?;
-    let name = input
-        .get("name")
-        .and_then(|v| v.as_str())
-        .map(String::from)
-        .unwrap_or_else(|| format!("agent-{}", &uuid::Uuid::new_v4().to_string()[..8]));
-    let subagent_type = input.get("subagent_type").and_then(|v| v.as_str());
-    let model_override = input
-        .get("model")
-        .and_then(|v| v.as_str())
-        .map(String::from);
-    let background = input
-        .get("run_in_background")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let isolation = input.get("isolation").and_then(|v| v.as_str());
-    let target_hub = input
-        .get("target_hub")
-        .and_then(|v| v.as_str())
-        .map(String::from);
-
-    let mut config = subagent_type
-        .and_then(|t| load_agent_configs(&shared.cwd).remove(t))
-        .unwrap_or_default();
-    if let Some(ref m) = model_override {
-        config.model = Some(m.clone());
-    }
-    let wt = if isolation == Some("worktree") {
-        let uid = &uuid::Uuid::new_v4().to_string()[..8];
-        Some(create_agent_worktree(&shared.cwd, &name, uid)?)
-    } else {
-        None
-    };
-    let cwd_override = wt.as_ref().map(|(info, _)| info.path.clone());
-    let model = config
-        .model
-        .unwrap_or_else(|| shared.kernel.settings().model.clone());
-    let perm_mode = match shared.kernel.settings().permission_mode {
-        loopal_tool_api::PermissionMode::Bypass => "bypass",
-        loopal_tool_api::PermissionMode::Supervised => "supervised",
-        loopal_tool_api::PermissionMode::Auto => "auto",
-    };
-    let result = spawn_agent(
-        &shared,
-        SpawnParams {
-            name: name.clone(),
-            prompt: prompt.to_string(),
-            model: Some(model),
-            cwd_override,
-            permission_mode: Some(perm_mode.to_string()),
-            target_hub,
-            agent_type: subagent_type.map(String::from),
-            depth: shared.depth + 1,
-            fork_context: build_fork_context(&shared),
-        },
-    )
-    .await;
-    match result {
-        Ok(sr) => {
-            if background {
-                spawn_bg_cleanup(shared.clone(), name.clone(), wt);
-                let msg = format!(
-                    "Agent '{name}' spawned in background (agentId: {}).\n\
-                     Result will be injected into your conversation when it completes.",
-                    sr.agent_id,
-                );
-                Ok(ToolResult::success(msg))
-            } else {
-                let output = wait_agent(&shared, &name).await;
-                if let Some((info, root)) = wt {
-                    loopal_git::cleanup_if_clean(&root, &info);
-                }
-                match output {
-                    Ok(text) => {
-                        // Forward any memory suggestions from sub-agent to the memory channel
-                        if let Some(ch) = memory_channel {
-                            for suggestion in
-                                loopal_memory::extraction::extract_memory_suggestions(&text)
-                            {
-                                let _ = ch.try_send(suggestion);
-                            }
-                        }
-                        Ok(ToolResult::success(text))
-                    }
-                    Err(e) => Ok(ToolResult::error(e)),
-                }
-            }
-        }
-        Err(e) => {
-            if let Some((info, root)) = wt {
-                loopal_git::cleanup_if_clean(&root, &info);
-            }
-            Ok(ToolResult::error(format!("Failed to spawn agent: {e}")))
-        }
-    }
-}
 async fn action_result(
     shared: Arc<AgentShared>,
     input: &serde_json::Value,

--- a/crates/loopal-agent/src/tools/collaboration/agent_spawn.rs
+++ b/crates/loopal-agent/src/tools/collaboration/agent_spawn.rs
@@ -1,0 +1,116 @@
+//! `Agent` tool — spawn action: parses tool input, builds `SpawnParams`, and
+//! drives the foreground/background completion + worktree cleanup flow.
+
+use std::sync::Arc;
+
+use loopal_error::LoopalError;
+use loopal_tool_api::ToolResult;
+
+use super::agent_fork::{build_fork_context, spawn_bg_cleanup};
+use super::shared_extract::{create_agent_worktree, require_str};
+use super::spawn_decision::{build_spawn_target, worktree_allowed};
+use crate::config::load_agent_configs;
+use crate::shared::AgentShared;
+use crate::spawn::{SpawnParams, spawn_agent, wait_agent};
+
+pub(super) async fn action_spawn(
+    shared: Arc<AgentShared>,
+    input: &serde_json::Value,
+    memory_channel: Option<&dyn loopal_tool_api::MemoryChannel>,
+) -> Result<ToolResult, LoopalError> {
+    let prompt = require_str(input, "prompt")?;
+    let name = input
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| format!("agent-{}", &uuid::Uuid::new_v4().to_string()[..8]));
+    let subagent_type = input.get("subagent_type").and_then(|v| v.as_str());
+    let model_override = input
+        .get("model")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let background = input
+        .get("run_in_background")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let isolation = input.get("isolation").and_then(|v| v.as_str());
+    let target_hub = input
+        .get("target_hub")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let mut config = subagent_type
+        .and_then(|t| load_agent_configs(&shared.cwd).remove(t))
+        .unwrap_or_default();
+    if let Some(ref m) = model_override {
+        config.model = Some(m.clone());
+    }
+    // Worktree isolation only applies to in-hub spawns (cross-hub child runs
+    // on a different filesystem; the worktree path would not exist there).
+    let wt = if worktree_allowed(&target_hub, isolation) {
+        let uid = &uuid::Uuid::new_v4().to_string()[..8];
+        Some(create_agent_worktree(&shared.cwd, &name, uid)?)
+    } else {
+        None
+    };
+    let cwd_override = wt.as_ref().map(|(info, _)| info.path.clone());
+    let model = config
+        .model
+        .unwrap_or_else(|| shared.kernel.settings().model.clone());
+    let perm_mode = match shared.kernel.settings().permission_mode {
+        loopal_tool_api::PermissionMode::Bypass => "bypass",
+        loopal_tool_api::PermissionMode::Supervised => "supervised",
+        loopal_tool_api::PermissionMode::Auto => "auto",
+    };
+    let target = build_spawn_target(target_hub, cwd_override, build_fork_context(&shared));
+    let result = spawn_agent(
+        &shared,
+        SpawnParams {
+            name: name.clone(),
+            prompt: prompt.to_string(),
+            model: Some(model),
+            permission_mode: Some(perm_mode.to_string()),
+            agent_type: subagent_type.map(String::from),
+            depth: shared.depth + 1,
+            target,
+        },
+    )
+    .await;
+    match result {
+        Ok(sr) => {
+            if background {
+                spawn_bg_cleanup(shared.clone(), name.clone(), wt);
+                let msg = format!(
+                    "Agent '{name}' spawned in background (agentId: {}).\n\
+                     Result will be injected into your conversation when it completes.",
+                    sr.agent_id,
+                );
+                Ok(ToolResult::success(msg))
+            } else {
+                let output = wait_agent(&shared, &name).await;
+                if let Some((info, root)) = wt {
+                    loopal_git::cleanup_if_clean(&root, &info);
+                }
+                match output {
+                    Ok(text) => {
+                        if let Some(ch) = memory_channel {
+                            for suggestion in
+                                loopal_memory::extraction::extract_memory_suggestions(&text)
+                            {
+                                let _ = ch.try_send(suggestion);
+                            }
+                        }
+                        Ok(ToolResult::success(text))
+                    }
+                    Err(e) => Ok(ToolResult::error(e)),
+                }
+            }
+        }
+        Err(e) => {
+            if let Some((info, root)) = wt {
+                loopal_git::cleanup_if_clean(&root, &info);
+            }
+            Ok(ToolResult::error(format!("Failed to spawn agent: {e}")))
+        }
+    }
+}

--- a/crates/loopal-agent/src/tools/collaboration/mod.rs
+++ b/crates/loopal-agent/src/tools/collaboration/mod.rs
@@ -6,6 +6,8 @@
 
 pub mod agent;
 mod agent_fork;
+mod agent_spawn;
 pub mod list_hubs;
 pub mod send_message;
 pub(crate) mod shared_extract;
+mod spawn_decision;

--- a/crates/loopal-agent/src/tools/collaboration/spawn_decision.rs
+++ b/crates/loopal-agent/src/tools/collaboration/spawn_decision.rs
@@ -1,0 +1,35 @@
+//! Pure decision logic for the `Agent` tool spawn action — extracted so
+//! the `target_hub` → `SpawnTarget` mapping and worktree-isolation gating
+//! can be unit-tested without an `AgentShared` / `Kernel` fixture.
+
+use std::path::PathBuf;
+
+use crate::spawn::SpawnTarget;
+
+/// True iff worktree isolation can be applied: only in-hub spawns own a
+/// path on the caller's filesystem, so cross-hub spawns must skip it.
+pub(super) fn worktree_allowed(target_hub: &Option<String>, isolation: Option<&str>) -> bool {
+    target_hub.is_none() && isolation == Some("worktree")
+}
+
+/// Map `target_hub` (and the in-hub-only context: cwd / fork_context)
+/// into a typed `SpawnTarget`. Cross-hub variants intentionally drop
+/// `cwd_override` / `fork_context` because they cannot cross filesystem
+/// trust boundaries; pass these only via the `InHub` arm.
+pub(super) fn build_spawn_target(
+    target_hub: Option<String>,
+    cwd_override: Option<PathBuf>,
+    fork_context: Option<Vec<loopal_message::Message>>,
+) -> SpawnTarget {
+    match target_hub {
+        Some(hub_id) => SpawnTarget::CrossHub { hub_id },
+        None => SpawnTarget::InHub {
+            cwd_override,
+            fork_context,
+        },
+    }
+}
+
+#[cfg(test)]
+#[path = "spawn_decision_test.rs"]
+mod tests;

--- a/crates/loopal-agent/src/tools/collaboration/spawn_decision_test.rs
+++ b/crates/loopal-agent/src/tools/collaboration/spawn_decision_test.rs
@@ -7,10 +7,7 @@ use std::path::PathBuf;
 #[test]
 fn worktree_allowed_only_for_inhub() {
     assert!(worktree_allowed(&None, Some("worktree")));
-    assert!(!worktree_allowed(
-        &Some("hub-b".into()),
-        Some("worktree")
-    ));
+    assert!(!worktree_allowed(&Some("hub-b".into()), Some("worktree")));
     assert!(!worktree_allowed(&None, None));
     assert!(!worktree_allowed(&None, Some("other")));
 }

--- a/crates/loopal-agent/src/tools/collaboration/spawn_decision_test.rs
+++ b/crates/loopal-agent/src/tools/collaboration/spawn_decision_test.rs
@@ -1,0 +1,63 @@
+//! Unit tests for `spawn_decision::worktree_allowed` / `build_spawn_target`.
+
+use super::{build_spawn_target, worktree_allowed};
+use crate::spawn::SpawnTarget;
+use std::path::PathBuf;
+
+#[test]
+fn worktree_allowed_only_for_inhub() {
+    assert!(worktree_allowed(&None, Some("worktree")));
+    assert!(!worktree_allowed(
+        &Some("hub-b".into()),
+        Some("worktree")
+    ));
+    assert!(!worktree_allowed(&None, None));
+    assert!(!worktree_allowed(&None, Some("other")));
+}
+
+#[test]
+fn target_hub_some_yields_crosshub_dropping_cwd_and_fork_context() {
+    let target = build_spawn_target(
+        Some("hub-b".into()),
+        Some(PathBuf::from("/local/wt")),
+        Some(vec![loopal_message::Message::user("would-be ctx")]),
+    );
+    match target {
+        SpawnTarget::CrossHub { hub_id } => assert_eq!(hub_id, "hub-b"),
+        _ => panic!("expected CrossHub"),
+    }
+}
+
+#[test]
+fn target_hub_none_yields_inhub_carrying_cwd_and_fork_context() {
+    let target = build_spawn_target(
+        None,
+        Some(PathBuf::from("/local/wt")),
+        Some(vec![loopal_message::Message::user("ctx")]),
+    );
+    match target {
+        SpawnTarget::InHub {
+            cwd_override,
+            fork_context,
+        } => {
+            assert_eq!(cwd_override, Some(PathBuf::from("/local/wt")));
+            assert_eq!(fork_context.map(|v| v.len()), Some(1));
+        }
+        _ => panic!("expected InHub"),
+    }
+}
+
+#[test]
+fn inhub_with_no_overrides_passes_none_through() {
+    let target = build_spawn_target(None, None, None);
+    match target {
+        SpawnTarget::InHub {
+            cwd_override,
+            fork_context,
+        } => {
+            assert!(cwd_override.is_none());
+            assert!(fork_context.is_none());
+        }
+        _ => panic!("expected InHub"),
+    }
+}

--- a/crates/loopal-agent/tests/suite.rs
+++ b/crates/loopal-agent/tests/suite.rs
@@ -11,6 +11,8 @@ mod cron_tool_test;
 mod in_memory_task_storage_test;
 #[path = "suite/session_resume_adapters_test.rs"]
 mod session_resume_adapters_test;
+#[path = "suite/spawn_params_test.rs"]
+mod spawn_params_test;
 #[path = "suite/task_file_storage_test.rs"]
 mod task_file_storage_test;
 #[path = "suite/task_store_concurrency_test.rs"]

--- a/crates/loopal-agent/tests/suite/spawn_params_test.rs
+++ b/crates/loopal-agent/tests/suite/spawn_params_test.rs
@@ -1,0 +1,86 @@
+//! Unit tests for `build_spawn_request` — the InHub / CrossHub field selection.
+
+use std::path::PathBuf;
+
+use loopal_agent::spawn::{SpawnParams, SpawnTarget, build_spawn_request};
+
+fn base_params(target: SpawnTarget) -> SpawnParams {
+    SpawnParams {
+        name: "child".into(),
+        prompt: "do work".into(),
+        model: Some("claude-opus-4-7".into()),
+        permission_mode: Some("supervised".into()),
+        agent_type: None,
+        depth: 1,
+        target,
+    }
+}
+
+#[test]
+fn inhub_uses_parent_cwd_when_no_override() {
+    let parent_cwd = PathBuf::from("/parent/dir");
+    let params = base_params(SpawnTarget::InHub {
+        cwd_override: None,
+        fork_context: None,
+    });
+    let req = build_spawn_request(&params, &parent_cwd);
+    assert_eq!(req["cwd"], "/parent/dir");
+    assert!(req.get("target_hub").is_none());
+    assert!(req.get("fork_context").is_none());
+}
+
+#[test]
+fn inhub_uses_cwd_override_when_provided() {
+    let parent_cwd = PathBuf::from("/parent/dir");
+    let params = base_params(SpawnTarget::InHub {
+        cwd_override: Some(PathBuf::from("/wt/branch-x")),
+        fork_context: None,
+    });
+    let req = build_spawn_request(&params, &parent_cwd);
+    assert_eq!(req["cwd"], "/wt/branch-x");
+}
+
+#[test]
+fn inhub_serializes_fork_context() {
+    let parent_cwd = PathBuf::from("/parent/dir");
+    let messages = vec![loopal_message::Message::user("earlier")];
+    let params = base_params(SpawnTarget::InHub {
+        cwd_override: None,
+        fork_context: Some(messages),
+    });
+    let req = build_spawn_request(&params, &parent_cwd);
+    assert!(req["fork_context"].is_array());
+    assert_eq!(req["fork_context"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn crosshub_omits_cwd_and_fork_context() {
+    let parent_cwd = PathBuf::from("/parent/dir");
+    let params = base_params(SpawnTarget::CrossHub {
+        hub_id: "hub-b".into(),
+    });
+    let req = build_spawn_request(&params, &parent_cwd);
+    assert!(
+        req.get("cwd").is_none(),
+        "cross-hub spawn must not carry parent cwd"
+    );
+    assert!(
+        req.get("fork_context").is_none(),
+        "cross-hub spawn must not carry fork_context"
+    );
+    assert_eq!(req["target_hub"], "hub-b");
+}
+
+#[test]
+fn crosshub_still_carries_advisory_fields() {
+    let parent_cwd = PathBuf::from("/parent/dir");
+    let params = base_params(SpawnTarget::CrossHub {
+        hub_id: "hub-b".into(),
+    });
+    let req = build_spawn_request(&params, &parent_cwd);
+    // permission_mode / model / agent_type / depth are advisory hints — receiver
+    // policy is the enforcement point — but they must still be transmitted.
+    assert_eq!(req["permission_mode"], "supervised");
+    assert_eq!(req["model"], "claude-opus-4-7");
+    assert_eq!(req["depth"], 1);
+}

--- a/crates/loopal-ipc/src/cross_hub.rs
+++ b/crates/loopal-ipc/src/cross_hub.rs
@@ -1,0 +1,58 @@
+//! Schema constraints shared between Hub / MetaHub / receiver paths
+//! for cross-hub spawn requests.
+//!
+//! Cross-hub spawn cannot share filesystem state with the originating hub,
+//! so any filesystem-coupled fields in the payload (cwd, fork_context,
+//! session resume) must be rejected — receiver Hub uses its own local
+//! state instead.
+
+use serde_json::Value;
+
+/// Fields that must NOT appear in any cross-hub spawn payload.
+/// Caller, MetaHub, and receiver each enforce this independently
+/// (defense-in-depth). Adding a new fs-coupled field? Add it here.
+pub const FORBIDDEN_SPAWN_FIELDS: &[&str] = &["cwd", "fork_context", "resume"];
+
+/// Reject the payload if it carries any forbidden field. Returns Ok if the
+/// payload is clean (or is not a JSON object — the caller decides what to do
+/// with malformed payloads at a different layer).
+pub fn validate_spawn_payload(params: &Value) -> Result<(), String> {
+    for forbidden in FORBIDDEN_SPAWN_FIELDS {
+        if params.get(forbidden).is_some() {
+            return Err(format!(
+                "cross-hub spawn cannot include '{forbidden}' field"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn clean_payload_passes() {
+        let p = json!({"name": "child", "prompt": "x"});
+        assert!(validate_spawn_payload(&p).is_ok());
+    }
+
+    #[test]
+    fn rejects_each_forbidden_field() {
+        for f in FORBIDDEN_SPAWN_FIELDS {
+            let p = json!({"name": "x", *f: "anything"});
+            let err = validate_spawn_payload(&p).unwrap_err();
+            assert!(err.contains(*f), "error should name '{f}', got: {err}");
+        }
+    }
+
+    #[test]
+    fn non_object_payload_passes_through() {
+        // Non-objects don't have keys, so validation is a no-op. Caller's
+        // own type check (as_object/.as_str) decides what to do.
+        assert!(validate_spawn_payload(&json!(null)).is_ok());
+        assert!(validate_spawn_payload(&json!("just-a-string")).is_ok());
+        assert!(validate_spawn_payload(&json!([1, 2, 3])).is_ok());
+    }
+}

--- a/crates/loopal-ipc/src/lib.rs
+++ b/crates/loopal-ipc/src/lib.rs
@@ -4,6 +4,7 @@
 //! protocol for communication between consumer, agent, and sub-agent processes.
 
 pub mod connection;
+pub mod cross_hub;
 pub mod duplex;
 pub mod jsonrpc;
 pub mod protocol;

--- a/crates/loopal-ipc/src/protocol.rs
+++ b/crates/loopal-ipc/src/protocol.rs
@@ -83,9 +83,18 @@ pub mod methods {
     /// Route a point-to-point message to another agent.
     pub const HUB_ROUTE: Method = Method { name: "hub/route" };
 
-    /// Spawn a new agent process.
+    /// Spawn a new agent process. In-hub semantics: caller may pass `cwd`
+    /// and `fork_context`; child inherits the caller's filesystem view.
     pub const HUB_SPAWN_AGENT: Method = Method {
         name: "hub/spawn_agent",
+    };
+
+    /// Spawn a new agent on this Hub on behalf of a remote (cross-hub) caller.
+    /// Forwarded by MetaHub. Receiving Hub MUST use its own `default_cwd`;
+    /// `cwd` / `fork_context` / `resume` fields are rejected by the handler
+    /// because the caller's filesystem view is not shared.
+    pub const HUB_SPAWN_REMOTE_AGENT: Method = Method {
+        name: "hub/spawn_remote_agent",
     };
 
     /// Wait for a spawned agent to finish and return its output.

--- a/crates/loopal-meta-hub/src/dispatch.rs
+++ b/crates/loopal-meta-hub/src/dispatch.rs
@@ -60,11 +60,17 @@ async fn handle_meta_route(
 }
 
 /// Delegate agent spawn to a specific Sub-Hub.
+///
+/// Cross-hub spawn cannot share filesystem state with the originating hub,
+/// so `cwd` / `fork_context` / `resume` are forbidden in the payload —
+/// receiver Hub uses its local `default_cwd`.
 async fn handle_meta_spawn(meta_hub: &Arc<Mutex<MetaHub>>, params: Value) -> Result<Value, String> {
     let target_hub = params["target_hub"]
         .as_str()
         .ok_or("missing 'target_hub'")?
         .to_string();
+
+    loopal_ipc::cross_hub::validate_spawn_payload(&params)?;
 
     let conn = {
         let mh = meta_hub.lock().await;
@@ -73,13 +79,15 @@ async fn handle_meta_spawn(meta_hub: &Arc<Mutex<MetaHub>>, params: Value) -> Res
             .ok_or_else(|| format!("hub '{target_hub}' not connected"))?
     };
 
-    // Forward as hub/spawn_agent (strip target_hub field)
+    // Forward as hub/spawn_remote_agent (strip target_hub field). The new
+    // method signals to the receiver that filesystem-coupled fields must be
+    // ignored / rejected; receiver uses its own default_cwd.
     let mut spawn_params = params.clone();
     if let Some(obj) = spawn_params.as_object_mut() {
         obj.remove("target_hub");
     }
 
-    conn.send_request(methods::HUB_SPAWN_AGENT.name, spawn_params)
+    conn.send_request(methods::HUB_SPAWN_REMOTE_AGENT.name, spawn_params)
         .await
         .map_err(|e| format!("spawn on '{target_hub}' failed: {e}"))
 }

--- a/crates/loopal-meta-hub/tests/e2e/cluster_cross_hub_spawn_happy_test.rs
+++ b/crates/loopal-meta-hub/tests/e2e/cluster_cross_hub_spawn_happy_test.rs
@@ -1,0 +1,90 @@
+//! Happy-path e2e: full chain hub-a → MetaHub → hub-b spawn → response.
+//! Verifies shadow registration, real-subprocess spawn, and duplicate-name
+//! rejection at the receiver-side.
+
+use std::time::Duration;
+
+use loopal_ipc::protocol::methods;
+use serde_json::json;
+
+use crate::cluster_harness::{HubHandle, MetaHubHandle};
+
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
+async fn cluster_cross_hub_spawn_happy_path_reaches_receiver() {
+    let meta = MetaHubHandle::boot().await;
+    let hub_a = HubHandle::boot("hub-a", &meta).await;
+    let hub_b = HubHandle::boot("hub-b", &meta).await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let result = loopal_agent_hub::dispatch::dispatch_hub_request(
+        &hub_a.hub,
+        methods::HUB_SPAWN_AGENT.name,
+        json!({
+            "name": "remote-child",
+            "prompt": "say hi",
+            "target_hub": "hub-b",
+        }),
+        "main".into(),
+    )
+    .await;
+
+    let resp = result.expect("cross-hub spawn should succeed");
+    assert_eq!(resp["name"].as_str(), Some("remote-child"));
+    assert!(
+        resp["agent_id"].as_str().is_some_and(|s| !s.is_empty()),
+        "agent_id must be present, got: {resp}"
+    );
+
+    {
+        let h = hub_a.hub.lock().await;
+        assert!(
+            h.registry.agent_info("remote-child").is_some(),
+            "hub-a must have shadow"
+        );
+    }
+    {
+        let h = hub_b.hub.lock().await;
+        assert!(
+            h.registry.agent_info("remote-child").is_some(),
+            "hub-b must have child"
+        );
+    }
+
+    let _ = hub_a.agent_proc.shutdown().await;
+    let _ = hub_b.agent_proc.shutdown().await;
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
+async fn cluster_cross_hub_spawn_rejects_duplicate_name() {
+    let meta = MetaHubHandle::boot().await;
+    let hub_a = HubHandle::boot("hub-a", &meta).await;
+    let hub_b = HubHandle::boot("hub-b", &meta).await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let first = loopal_agent_hub::dispatch::dispatch_hub_request(
+        &hub_a.hub,
+        methods::HUB_SPAWN_AGENT.name,
+        json!({"name": "dup", "prompt": "hi", "target_hub": "hub-b"}),
+        "main".into(),
+    )
+    .await;
+    assert!(first.is_ok(), "first spawn: {first:?}");
+
+    let second = loopal_agent_hub::dispatch::dispatch_hub_request(
+        &hub_a.hub,
+        methods::HUB_SPAWN_AGENT.name,
+        json!({"name": "dup", "prompt": "again", "target_hub": "hub-b"}),
+        "main".into(),
+    )
+    .await;
+    let err = second.expect_err("duplicate name must be rejected");
+    assert!(
+        err.contains("already registered") || err.contains("dup"),
+        "got: {err}"
+    );
+
+    let _ = hub_a.agent_proc.shutdown().await;
+    let _ = hub_b.agent_proc.shutdown().await;
+}

--- a/crates/loopal-meta-hub/tests/e2e/cluster_cross_hub_spawn_test.rs
+++ b/crates/loopal-meta-hub/tests/e2e/cluster_cross_hub_spawn_test.rs
@@ -1,0 +1,92 @@
+//! End-to-end tests for cross-hub `spawn_remote_agent` over real TCP +
+//! MetaHub forwarding. Schema-rejection paths only — happy-path tests
+//! live in `cluster_cross_hub_spawn_happy_test.rs`.
+
+use std::time::Duration;
+
+use loopal_ipc::protocol::methods;
+use serde_json::json;
+
+use crate::cluster_harness::{HubHandle, MetaHubHandle};
+
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
+async fn cluster_cross_hub_spawn_rejects_cwd_field() {
+    let meta = MetaHubHandle::boot().await;
+    let hub_a = HubHandle::boot("hub-a", &meta).await;
+    let hub_b = HubHandle::boot("hub-b", &meta).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let result = loopal_agent_hub::dispatch::dispatch_hub_request(
+        &hub_a.hub,
+        methods::HUB_SPAWN_AGENT.name,
+        json!({
+            "name": "child",
+            "prompt": "report your cwd",
+            "target_hub": "hub-b",
+            "cwd": "/attacker/path",
+        }),
+        "main".into(),
+    )
+    .await;
+
+    let err = result.expect_err("MetaHub must reject cwd in cross-hub spawn");
+    assert!(err.contains("cwd"), "got: {err}");
+
+    let _ = hub_a.agent_proc.shutdown().await;
+    let _ = hub_b.agent_proc.shutdown().await;
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
+async fn cluster_cross_hub_spawn_rejects_fork_context() {
+    let meta = MetaHubHandle::boot().await;
+    let hub_a = HubHandle::boot("hub-a", &meta).await;
+    let hub_b = HubHandle::boot("hub-b", &meta).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let result = loopal_agent_hub::dispatch::dispatch_hub_request(
+        &hub_a.hub,
+        methods::HUB_SPAWN_AGENT.name,
+        json!({
+            "name": "child",
+            "prompt": "do work",
+            "target_hub": "hub-b",
+            "fork_context": [],
+        }),
+        "main".into(),
+    )
+    .await;
+
+    let err = result.expect_err("must reject fork_context");
+    assert!(err.contains("fork_context"), "got: {err}");
+
+    let _ = hub_a.agent_proc.shutdown().await;
+    let _ = hub_b.agent_proc.shutdown().await;
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
+async fn cluster_cross_hub_spawn_validates_required_name() {
+    let meta = MetaHubHandle::boot().await;
+    let hub_a = HubHandle::boot("hub-a", &meta).await;
+    let hub_b = HubHandle::boot("hub-b", &meta).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let result = loopal_agent_hub::dispatch::dispatch_hub_request(
+        &hub_a.hub,
+        methods::HUB_SPAWN_AGENT.name,
+        json!({
+            "prompt": "do work",
+            "target_hub": "hub-b",
+        }),
+        "main".into(),
+    )
+    .await;
+
+    let err = result.expect_err("missing name must surface");
+    assert!(err.contains("name"), "got: {err}");
+
+    let _ = hub_a.agent_proc.shutdown().await;
+    let _ = hub_b.agent_proc.shutdown().await;
+}

--- a/crates/loopal-meta-hub/tests/e2e/e2e_cluster_test.rs
+++ b/crates/loopal-meta-hub/tests/e2e/e2e_cluster_test.rs
@@ -3,6 +3,8 @@
 //! Boots a real MetaHub + real Hub instances with real agent processes
 //! to verify the complete cross-hub communication stack.
 
+mod cluster_cross_hub_spawn_happy_test;
+mod cluster_cross_hub_spawn_test;
 mod cluster_harness;
 
 use std::time::Duration;

--- a/crates/loopal-meta-hub/tests/suite.rs
+++ b/crates/loopal-meta-hub/tests/suite.rs
@@ -17,9 +17,13 @@ mod relay_event_test;
 mod routing_test;
 #[path = "suite/shadow_lifecycle_test.rs"]
 mod shadow_lifecycle_test;
+#[path = "suite/shadow_routing_test.rs"]
+mod shadow_routing_test;
 #[path = "suite/spawn_completion_test.rs"]
 mod spawn_completion_test;
 #[path = "suite/spawn_edge_test.rs"]
 mod spawn_edge_test;
+#[path = "suite/spawn_schema_test.rs"]
+mod spawn_schema_test;
 #[path = "suite/status_resolve_test.rs"]
 mod status_resolve_test;

--- a/crates/loopal-meta-hub/tests/suite/shadow_lifecycle_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/shadow_lifecycle_test.rs
@@ -1,18 +1,16 @@
 //! Tests: shadow entry lifecycle — cross-hub spawn, wait, completion, cleanup.
 //!
-//! Covers the full shadow entry flow:
+//! Covers the shadow entry flow:
 //! 1. Shadow registration on spawn
 //! 2. wait_agent blocks on shadow until completion
 //! 3. Completion triggers shadow watcher
 //! 4. Shadow cleanup after completion
-//! 5. Orphan cascade skips shadows
-//! 6. Shadow not routable as message target
+//!
+//! Routing-target tests (orphan cascade, route-to-shadow, listing) live in
+//! `shadow_routing_test.rs` — split for the 200-line limit.
 
-use std::sync::Arc;
 use std::time::Duration;
 
-use loopal_agent_hub::spawn_manager::register_agent_connection;
-use loopal_ipc::connection::Connection;
 use loopal_ipc::protocol::methods;
 use serde_json::json;
 
@@ -27,7 +25,7 @@ async fn shadow_registered_with_correct_parent() {
     hub.lock().await.registry.register_shadow(
         "remote-child",
         loopal_protocol::QualifiedAddress::local("parent"),
-    );
+    ).unwrap();
 
     let h = hub.lock().await;
     let info = h.registry.agent_info("remote-child");
@@ -53,7 +51,7 @@ async fn wait_agent_resolves_on_shadow_completion() {
     hub.lock().await.registry.register_shadow(
         "remote-child",
         loopal_protocol::QualifiedAddress::local("parent"),
-    );
+    ).unwrap();
 
     // Start wait_agent in background
     let hub2 = hub.clone();
@@ -97,7 +95,7 @@ async fn shadow_cleaned_up_after_completion() {
     hub.lock()
         .await
         .registry
-        .register_shadow("child", loopal_protocol::QualifiedAddress::local("parent"));
+        .register_shadow("child", loopal_protocol::QualifiedAddress::local("parent")).unwrap();
 
     // Verify shadow exists
     assert!(hub.lock().await.registry.agent_info("child").is_some());
@@ -124,101 +122,4 @@ async fn shadow_cleaned_up_after_completion() {
     .await;
     // Cached output or "not found" — either way proves lifecycle completed
     assert!(cached.is_ok());
-}
-
-/// Orphan cascade does NOT interrupt shadows.
-#[tokio::test]
-async fn orphan_cascade_skips_shadows() {
-    let (hub, mut event_rx) = make_hub();
-
-    // Register parent with a real child + a shadow child
-    let (_p_conn, _) = register_mock_agent(&hub, "parent", None).await;
-
-    let (real_client, real_server) = loopal_ipc::duplex_pair();
-    let real_conn = Arc::new(Connection::new(real_server));
-    let _real_client_conn = Arc::new(Connection::new(real_client));
-    let real_rx = real_conn.start();
-    let _real_client_rx = _real_client_conn.start();
-    let _ = register_agent_connection(
-        hub.clone(),
-        "real-child",
-        real_conn,
-        real_rx,
-        Some("parent"),
-        None,
-        None,
-    )
-    .await;
-
-    hub.lock().await.registry.register_shadow(
-        "shadow-child",
-        loopal_protocol::QualifiedAddress::local("parent"),
-    );
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    // Parent finishes → should cascade interrupt to real-child only
-    {
-        let mut h = hub.lock().await;
-        h.registry.emit_agent_finished("parent", Some("bye".into()));
-    }
-
-    // Give time for interrupt to propagate
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    // Shadow should NOT have been interrupted (it's still Running or cleaned up)
-    // The key assertion: no panic, no error from trying to interrupt shadow
-    // Drain events to verify Finished was emitted
-    let mut got_finished = false;
-    while let Ok(event) = event_rx.try_recv() {
-        if matches!(event.payload, loopal_protocol::AgentEventPayload::Finished) {
-            got_finished = true;
-        }
-    }
-    assert!(got_finished, "parent Finished event should be emitted");
-}
-
-/// Shadow is NOT a valid route target (hub/route to shadow fails).
-#[tokio::test]
-async fn route_to_shadow_fails() {
-    let (hub, _) = make_hub();
-    let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
-    hub.lock().await.registry.register_shadow(
-        "shadow-agent",
-        loopal_protocol::QualifiedAddress::local("parent"),
-    );
-
-    let envelope = json!({
-        "id": "00000000-0000-0000-0000-000000000010",
-        "source": {"Agent": {"hub": [], "agent": "sender"}},
-        "target": {"hub": [], "agent": "shadow-agent"},
-        "content": {"text": "can you hear me?", "images": []},
-        "timestamp": "2026-01-01T00:00:00Z"
-    });
-    let result = loopal_agent_hub::dispatch::dispatch_hub_request(
-        &hub,
-        methods::HUB_ROUTE.name,
-        envelope,
-        "sender".into(),
-    )
-    .await;
-
-    // Shadow has no connection → route should fail (not silently succeed)
-    let failed = result.is_err() || result.as_ref().is_ok_and(|v| v.get("code").is_some());
-    assert!(failed, "route to shadow should fail: {result:?}");
-}
-
-/// Shadow appears in agent list with "shadow" state.
-#[tokio::test]
-async fn shadow_visible_in_agent_list() {
-    let (hub, _) = make_hub();
-    let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
-    hub.lock().await.registry.register_shadow(
-        "remote-x",
-        loopal_protocol::QualifiedAddress::local("parent"),
-    );
-
-    let agents = hub.lock().await.registry.list_agents();
-    let shadow = agents.iter().find(|(n, _)| n == "remote-x");
-    assert!(shadow.is_some(), "shadow should appear in list");
-    assert_eq!(shadow.unwrap().1, "shadow");
 }

--- a/crates/loopal-meta-hub/tests/suite/shadow_lifecycle_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/shadow_lifecycle_test.rs
@@ -22,10 +22,14 @@ async fn shadow_registered_with_correct_parent() {
     let (hub, _) = make_hub();
     let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
 
-    hub.lock().await.registry.register_shadow(
-        "remote-child",
-        loopal_protocol::QualifiedAddress::local("parent"),
-    ).unwrap();
+    hub.lock()
+        .await
+        .registry
+        .register_shadow(
+            "remote-child",
+            loopal_protocol::QualifiedAddress::local("parent"),
+        )
+        .unwrap();
 
     let h = hub.lock().await;
     let info = h.registry.agent_info("remote-child");
@@ -48,10 +52,14 @@ async fn wait_agent_resolves_on_shadow_completion() {
     let (hub, _) = make_hub();
     // Register parent + shadow manually (simulate post-spawn state)
     let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
-    hub.lock().await.registry.register_shadow(
-        "remote-child",
-        loopal_protocol::QualifiedAddress::local("parent"),
-    ).unwrap();
+    hub.lock()
+        .await
+        .registry
+        .register_shadow(
+            "remote-child",
+            loopal_protocol::QualifiedAddress::local("parent"),
+        )
+        .unwrap();
 
     // Start wait_agent in background
     let hub2 = hub.clone();
@@ -95,7 +103,8 @@ async fn shadow_cleaned_up_after_completion() {
     hub.lock()
         .await
         .registry
-        .register_shadow("child", loopal_protocol::QualifiedAddress::local("parent")).unwrap();
+        .register_shadow("child", loopal_protocol::QualifiedAddress::local("parent"))
+        .unwrap();
 
     // Verify shadow exists
     assert!(hub.lock().await.registry.agent_info("child").is_some());

--- a/crates/loopal-meta-hub/tests/suite/shadow_routing_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/shadow_routing_test.rs
@@ -38,10 +38,14 @@ async fn orphan_cascade_skips_shadows() {
     )
     .await;
 
-    hub.lock().await.registry.register_shadow(
-        "shadow-child",
-        loopal_protocol::QualifiedAddress::local("parent"),
-    ).unwrap();
+    hub.lock()
+        .await
+        .registry
+        .register_shadow(
+            "shadow-child",
+            loopal_protocol::QualifiedAddress::local("parent"),
+        )
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Parent finishes → should cascade interrupt to real-child only
@@ -70,10 +74,14 @@ async fn orphan_cascade_skips_shadows() {
 async fn route_to_shadow_fails() {
     let (hub, _) = make_hub();
     let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
-    hub.lock().await.registry.register_shadow(
-        "shadow-agent",
-        loopal_protocol::QualifiedAddress::local("parent"),
-    ).unwrap();
+    hub.lock()
+        .await
+        .registry
+        .register_shadow(
+            "shadow-agent",
+            loopal_protocol::QualifiedAddress::local("parent"),
+        )
+        .unwrap();
 
     let envelope = json!({
         "id": "00000000-0000-0000-0000-000000000010",
@@ -100,10 +108,14 @@ async fn route_to_shadow_fails() {
 async fn shadow_visible_in_agent_list() {
     let (hub, _) = make_hub();
     let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
-    hub.lock().await.registry.register_shadow(
-        "remote-x",
-        loopal_protocol::QualifiedAddress::local("parent"),
-    ).unwrap();
+    hub.lock()
+        .await
+        .registry
+        .register_shadow(
+            "remote-x",
+            loopal_protocol::QualifiedAddress::local("parent"),
+        )
+        .unwrap();
 
     let agents = hub.lock().await.registry.list_agents();
     let shadow = agents.iter().find(|(n, _)| n == "remote-x");

--- a/crates/loopal-meta-hub/tests/suite/shadow_routing_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/shadow_routing_test.rs
@@ -1,0 +1,112 @@
+//! Tests: shadow as a routing/listing target — orphan cascade behavior,
+//! route-to-shadow failure, and shadow visibility in agent listings.
+//!
+//! Companion file to `shadow_lifecycle_test.rs` (split for the 200-line
+//! file limit).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use loopal_agent_hub::spawn_manager::register_agent_connection;
+use loopal_ipc::connection::Connection;
+use loopal_ipc::protocol::methods;
+use serde_json::json;
+
+use crate::test_helpers::*;
+
+/// Orphan cascade does NOT interrupt shadows.
+#[tokio::test]
+async fn orphan_cascade_skips_shadows() {
+    let (hub, mut event_rx) = make_hub();
+
+    // Register parent with a real child + a shadow child
+    let (_p_conn, _) = register_mock_agent(&hub, "parent", None).await;
+
+    let (real_client, real_server) = loopal_ipc::duplex_pair();
+    let real_conn = Arc::new(Connection::new(real_server));
+    let _real_client_conn = Arc::new(Connection::new(real_client));
+    let real_rx = real_conn.start();
+    let _real_client_rx = _real_client_conn.start();
+    let _ = register_agent_connection(
+        hub.clone(),
+        "real-child",
+        real_conn,
+        real_rx,
+        Some("parent"),
+        None,
+        None,
+    )
+    .await;
+
+    hub.lock().await.registry.register_shadow(
+        "shadow-child",
+        loopal_protocol::QualifiedAddress::local("parent"),
+    ).unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Parent finishes → should cascade interrupt to real-child only
+    {
+        let mut h = hub.lock().await;
+        h.registry.emit_agent_finished("parent", Some("bye".into()));
+    }
+
+    // Give time for interrupt to propagate
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Shadow should NOT have been interrupted (it's still Running or cleaned up)
+    // The key assertion: no panic, no error from trying to interrupt shadow
+    // Drain events to verify Finished was emitted
+    let mut got_finished = false;
+    while let Ok(event) = event_rx.try_recv() {
+        if matches!(event.payload, loopal_protocol::AgentEventPayload::Finished) {
+            got_finished = true;
+        }
+    }
+    assert!(got_finished, "parent Finished event should be emitted");
+}
+
+/// Shadow is NOT a valid route target (hub/route to shadow fails).
+#[tokio::test]
+async fn route_to_shadow_fails() {
+    let (hub, _) = make_hub();
+    let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
+    hub.lock().await.registry.register_shadow(
+        "shadow-agent",
+        loopal_protocol::QualifiedAddress::local("parent"),
+    ).unwrap();
+
+    let envelope = json!({
+        "id": "00000000-0000-0000-0000-000000000010",
+        "source": {"Agent": {"hub": [], "agent": "sender"}},
+        "target": {"hub": [], "agent": "shadow-agent"},
+        "content": {"text": "can you hear me?", "images": []},
+        "timestamp": "2026-01-01T00:00:00Z"
+    });
+    let result = loopal_agent_hub::dispatch::dispatch_hub_request(
+        &hub,
+        methods::HUB_ROUTE.name,
+        envelope,
+        "sender".into(),
+    )
+    .await;
+
+    // Shadow has no connection → route should fail (not silently succeed)
+    let failed = result.is_err() || result.as_ref().is_ok_and(|v| v.get("code").is_some());
+    assert!(failed, "route to shadow should fail: {result:?}");
+}
+
+/// Shadow appears in agent list with "shadow" state.
+#[tokio::test]
+async fn shadow_visible_in_agent_list() {
+    let (hub, _) = make_hub();
+    let (_parent, _rx) = register_mock_agent(&hub, "parent", None).await;
+    hub.lock().await.registry.register_shadow(
+        "remote-x",
+        loopal_protocol::QualifiedAddress::local("parent"),
+    ).unwrap();
+
+    let agents = hub.lock().await.registry.list_agents();
+    let shadow = agents.iter().find(|(n, _)| n == "remote-x");
+    assert!(shadow.is_some(), "shadow should appear in list");
+    assert_eq!(shadow.unwrap().1, "shadow");
+}

--- a/crates/loopal-meta-hub/tests/suite/spawn_edge_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/spawn_edge_test.rs
@@ -22,7 +22,7 @@ async fn spawn_without_uplink_fails_clearly() {
     let result = loopal_agent_hub::dispatch::dispatch_hub_request(
         &hub_a,
         methods::HUB_SPAWN_AGENT.name,
-        json!({"name": "worker", "target_hub": "hub-b", "cwd": "/tmp"}),
+        json!({"name": "worker", "target_hub": "hub-b"}),
         "parent".into(),
     )
     .await;
@@ -52,7 +52,7 @@ async fn spawn_injects_qualified_parent() {
     let result = loopal_agent_hub::dispatch::dispatch_hub_request(
         &hub_a,
         methods::HUB_SPAWN_AGENT.name,
-        json!({"name": "child", "target_hub": "hub-b", "cwd": "/tmp"}),
+        json!({"name": "child", "target_hub": "hub-b"}),
         "my-parent".into(),
     )
     .await;

--- a/crates/loopal-meta-hub/tests/suite/spawn_schema_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/spawn_schema_test.rs
@@ -1,0 +1,105 @@
+//! Tests for `meta/spawn` schema validation — verifies that the MetaHub
+//! rejects payloads carrying filesystem-coupled fields before forwarding.
+
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use loopal_meta_hub::MetaHub;
+use loopal_meta_hub::dispatch::dispatch_meta_request;
+use serde_json::json;
+
+#[tokio::test]
+async fn meta_spawn_rejects_cwd() {
+    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
+    let result = dispatch_meta_request(
+        &meta_hub,
+        "meta/spawn",
+        json!({
+            "name": "child",
+            "prompt": "test",
+            "target_hub": "hub-b",
+            "cwd": "/attacker/path",
+        }),
+        "hub-a".into(),
+    )
+    .await;
+    let err = result.expect_err("meta/spawn must reject cwd");
+    assert!(err.contains("cwd"), "got: {err}");
+}
+
+#[tokio::test]
+async fn meta_spawn_rejects_fork_context() {
+    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
+    let result = dispatch_meta_request(
+        &meta_hub,
+        "meta/spawn",
+        json!({
+            "name": "child",
+            "prompt": "test",
+            "target_hub": "hub-b",
+            "fork_context": [],
+        }),
+        "hub-a".into(),
+    )
+    .await;
+    let err = result.expect_err("meta/spawn must reject fork_context");
+    assert!(err.contains("fork_context"), "got: {err}");
+}
+
+#[tokio::test]
+async fn meta_spawn_rejects_resume() {
+    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
+    let result = dispatch_meta_request(
+        &meta_hub,
+        "meta/spawn",
+        json!({
+            "name": "child",
+            "prompt": "test",
+            "target_hub": "hub-b",
+            "resume": "session-123",
+        }),
+        "hub-a".into(),
+    )
+    .await;
+    let err = result.expect_err("meta/spawn must reject resume");
+    assert!(err.contains("resume"), "got: {err}");
+}
+
+#[tokio::test]
+async fn meta_spawn_rejects_when_target_hub_missing() {
+    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
+    let result = dispatch_meta_request(
+        &meta_hub,
+        "meta/spawn",
+        json!({"name": "child", "prompt": "test"}),
+        "hub-a".into(),
+    )
+    .await;
+    let err = result.expect_err("must reject without target_hub");
+    assert!(err.contains("target_hub"), "got: {err}");
+}
+
+#[tokio::test]
+async fn meta_spawn_rejects_unknown_target_hub() {
+    // Without forbidden fields and with a target_hub that is not registered,
+    // the call should fail at the connection lookup — proving the validation
+    // checks completed and we got past them.
+    let meta_hub = Arc::new(Mutex::new(MetaHub::new()));
+    let result = dispatch_meta_request(
+        &meta_hub,
+        "meta/spawn",
+        json!({
+            "name": "child",
+            "prompt": "test",
+            "target_hub": "no-such-hub",
+        }),
+        "hub-a".into(),
+    )
+    .await;
+    let err = result.expect_err("unregistered hub must fail");
+    assert!(
+        err.contains("not connected"),
+        "expected connection lookup failure, got: {err}"
+    );
+}

--- a/src/bootstrap/hub_bootstrap.rs
+++ b/src/bootstrap/hub_bootstrap.rs
@@ -30,7 +30,7 @@ pub async fn bootstrap_hub_and_agent(
     resume: Option<&str>,
 ) -> anyhow::Result<BootstrapContext> {
     let (event_tx, event_rx) = mpsc::channel(256);
-    let hub = Arc::new(Mutex::new(Hub::new(event_tx)));
+    let hub = Arc::new(Mutex::new(Hub::with_cwd(event_tx, cwd.to_path_buf())));
     hub.lock().await.max_total_agents = config.settings.harness.agent_max_total;
 
     let (listener, port, hub_token) = hub_server::start_hub_listener(hub.clone()).await?;


### PR DESCRIPTION
## Summary

- Cross-hub spawn no longer transmits caller's cwd; receiver uses its own canonicalized `default_cwd`. This fixes the bug where a sub-agent on hub-b reported the caller's working directory as its own.
- New IPC method `hub/spawn_remote_agent`; `SpawnTarget::InHub | CrossHub` enum at the Rust API layer; three-layer defense (caller Hub, MetaHub, receiver Hub) rejects `cwd` / `fork_context` / `resume` via shared validator.
- Hardens cross-hub spawn against name collisions, address spoofing, depth tampering, completion envelope loss, and observability gaps. **Breaking protocol change** — Hub instances in a cluster must upgrade together.

## Changes

**Caller Hub** (`crates/loopal-agent-hub/src/dispatch/`)
- `spawn_routing.rs` (new): in-hub vs cross-hub dispatch entry
- `cross_hub_forward.rs` (new): preflight (schema / `/` / target_hub type) → atomic budget+shadow registration → `meta/spawn` IPC → rollback on failure → emit `SubAgentSpawned`
- `spawn_prepare.rs` (new): receiver-side pure-fn arg preparation; clamps `depth >= 1`; validates `parent` as remote `QualifiedAddress`
- Original `dispatch_handlers.rs` keeps lifecycle/route/shutdown only

**Registry** (`crates/loopal-agent-hub/src/agent_registry/`)
- `register_shadow` now returns `Result` and rejects duplicate names (was silently overwriting)
- `mod.rs` split: registration kept here; queries/routing/topology moved to `queries.rs`

**Completion path** (`crates/loopal-agent-hub/src/`)
- `finish.rs::deliver_cross_hub_completion` (new): captures pending parent delivery, releases lock, then dispatches envelope
- `uplink.rs::handle_reverse_requests` calls it (was discarding the return value)

**Hub** (`crates/loopal-agent-hub/src/hub.rs`)
- `Hub::with_cwd` canonicalizes `default_cwd`; warns on failure; `Hub::noop` routes through `with_cwd` for parity

**Caller-side API** (`crates/loopal-agent/src/`)
- `spawn.rs::SpawnTarget::InHub | CrossHub` (CrossHub forbids `cwd_override`/`fork_context` at compile time)
- `tools/collaboration/{agent_spawn,spawn_decision}.rs` (new): tool dispatch + pure decision logic
- `agent.rs` thinned to trait + result/status actions

**Protocol** (`crates/loopal-ipc/src/`)
- `cross_hub.rs` (new): `FORBIDDEN_SPAWN_FIELDS` + `validate_spawn_payload`
- `protocol.rs`: `HUB_SPAWN_REMOTE_AGENT` method constant

**MetaHub** (`crates/loopal-meta-hub/src/dispatch.rs`)
- `handle_meta_spawn` validates payload then forwards via `HUB_SPAWN_REMOTE_AGENT`

**Tests** (50 cases across unit / integration / e2e)
- 8 unit: `cross_hub` validator (3) + `spawn_decision` (4) + `spawn_params` (5)
- 13 unit: `spawn_prepare` (depth clamp, parent validation, fields)
- 12 integration: dispatch entry rejections + MetaHub schema
- 6 integration: shadow registry (lifecycle + routing split)
- 5 e2e (real TCP + subprocess): cross-hub spawn reject paths + happy-path + duplicate-name rejection

## Test plan

- [ ] CI passes: `bazel build //... --config=clippy` (zero warnings) and `bazel test //...` (52/52 targets)
- [ ] All PR-touched files ≤ 200 lines (CLAUDE.md hard rule)
- [ ] No regression in existing cluster e2e (`cluster_boots_two_hubs_with_agents`, `cluster_list_hubs_via_agent`, `cluster_cross_hub_message_delivery`)