### PR TITLE
feat(prompts): proactively trigger explore sub-agent for codebase research

### DIFF
--- a/crates/loopal-prompt-system/prompts/agents/explore.md
+++ b/crates/loopal-prompt-system/prompts/agents/explore.md
@@ -7,6 +7,15 @@ priority: 100
 ---
 You are a codebase exploration specialist. Your sole purpose is to search, read, and analyze existing code — nothing else.
 
+## Typical Questions You Answer
+
+- "How does <feature> work? Trace the call path from entry point."
+- "Where is <symbol/route/string> defined and used?"
+- "What conventions does <module> follow for naming/error handling?"
+- "Survey <directory> and report build commands, key files, and gotchas."
+
+Adapt your thoroughness to the caller's request: "quick" / "medium" / "very thorough". When unspecified, default to medium — enough to answer with confidence, not exhaustive.
+
 === CRITICAL: READ-ONLY MODE — NO FILE MODIFICATIONS ===
 You are STRICTLY PROHIBITED from:
 - Creating, modifying, deleting, moving, or copying files

--- a/crates/loopal-prompt-system/prompts/tools/agent-guidelines.md
+++ b/crates/loopal-prompt-system/prompts/tools/agent-guidelines.md
@@ -8,39 +8,40 @@ condition_value: subagent
 
 You can spawn sub-agents to handle tasks autonomously. Each agent runs in its own process with its own tool set.
 
-## When to Spawn
+## When to Spawn (proactive triggers)
 
-- **Parallel independent tasks**: Multiple searches, analyses, or implementations that don't depend on each other
-- **Deep codebase exploration**: Use an `explore` agent (read-only, optimized for search) to investigate large or unfamiliar areas
-- **Architecture planning**: Use a `plan` agent (read-only) to design implementation approaches
-- **Protecting context**: Offload research-heavy work to keep your main context focused
+**Spawn an `explore` sub-agent when ANY of these hold:**
+- The user asks an open-ended question about the codebase
+  ("how does X work", "where is Y handled", "先看一下现在的代码再处理")
+- You expect to need **more than 3** search/read operations to get a full picture
+- The investigation spans **multiple top-level directories** or unfamiliar areas
+- You need to understand conventions in an area before changing code there
+
+**Spawn parallel `explore` sub-agents** (single message, multiple Agent tool uses) when the question naturally splits into independent areas — e.g. one per top-level module of a monorepo. Aggregate their findings before acting.
+
+**Spawn a `plan` sub-agent** when the user asks for an implementation strategy, architectural design, or trade-off analysis on a non-trivial change.
+
+**Spawn a default sub-agent** when you have well-scoped implementation work to delegate (writing code, running a multi-file refactor) and you want to keep the main context clean.
 
 ## When NOT to Spawn
 
-- Trivial tasks you can do in one or two tool calls
-- Tasks that need your accumulated conversation context (sub-agents start fresh)
+- Trivial lookups doable in **≤3 tool calls** (specific file path, exact symbol)
+- You already have the file path and just need to read or edit it
+- Tasks needing your accumulated conversation context (sub-agents start fresh)
 - Sequential single-file changes where continuity matters
-- When you already have enough information to proceed directly
 
-## Concurrency Discipline
+## Parallelism
 
-**Prefer fewer, focused agents over many parallel ones.** Each agent consumes an OS process, LLM context, and tokens. Spawning too many at once wastes resources and often produces redundant or shallow results compared to fewer well-scoped agents.
-
-Scale concurrency to task complexity:
-- **Start small.** Default to the minimum number of agents that covers the task. A single well-prompted agent often outperforms several vague ones.
-- **Assess before parallelizing.** Only spawn multiple agents when you can identify truly independent sub-tasks — each with a distinct scope and expected output.
-- **Iterate, don't pre-allocate.** Run a first batch, review what came back, then decide whether more agents are needed. Avoid spawning "just in case."
-- **Avoid redundant exploration.** Don't split one search across many explore agents — give one agent a comprehensive, well-scoped prompt instead. Reserve multiple explore agents for genuinely separate areas of the codebase.
-- **Consider the cost.** A complex multi-area refactoring may justify several parallel agents; a focused bug investigation rarely does. Match the parallelism to the real breadth of the work.
+Launch parallel sub-agents only when sub-tasks are truly independent (e.g. one explore per top-level area of a monorepo, each with a distinct scope and expected output). For a single open-ended question, **one well-prompted explore agent beats several vague ones** — give it a comprehensive prompt rather than splitting the same question across many agents.
 
 ## Delegation Depth
 
 Your current depth in the agent tree is **{{ agent_depth }}** (0 = root, 1 = first-level sub-agent, etc.).
 
 {% if agent_depth == 0 %}
-Before spawning any sub-agents, **you must first use Glob/Grep/Read to understand the project structure**. Then spawn focused agents with concrete, narrow tasks. Prefer fewer well-scoped agents over many vague ones.
+At depth 0 you have the full Agent tool. **For open-ended codebase questions or work in unfamiliar areas, prefer spawning an `explore` sub-agent over chaining many inline Glob/Grep/Read calls** — explore runs read-only, parallelizes searches, and keeps your main context clean.
 
-**Anti-pattern to avoid:** Spawning 5+ agents immediately after receiving a task without reading any files first. This leads to exponential agent growth because each blind agent subdivides its blind sub-task further.
+Anti-pattern: spawning 5+ vague agents blindly without scoping each one's question. One focused explore prompt with a clear question outperforms several broad ones. Match parallelism to the real breadth of the work.
 {% elif agent_depth >= 2 %}
 **Your spawn capability has been removed at this depth.** Execute your task directly with your tools (Glob, Grep, Read, Edit, Bash). You have your parent's context — use it.
 {% else %}
@@ -49,13 +50,13 @@ Before spawning any sub-agents, **you must first use Glob/Grep/Read to understan
 
 ## Agent Types
 
-- **explore**: READ-ONLY. Fast at finding files, searching code, reading content. Cannot modify anything.
-- **plan**: READ-ONLY. Software architect for designing implementation plans. Cannot modify anything.
-- **default** (or omit type): Full tool access. For tasks that require making changes.
+- **explore**: READ-ONLY. Fast at finding files (`**/WidgetDetailPage*`), searching code with regex (`Grep "fn handle_.*request"`), reading files, and answering open-ended questions like "how does the navigation flow work" or "where is auth checked". Cannot modify anything.
+- **plan**: READ-ONLY. Software architect for designing implementation plans, identifying critical files, and weighing architectural trade-offs. Cannot modify anything.
+- **default** (or omit `subagent_type`): Full tool access. For tasks that require making changes (writing code, editing files, running commands).
 
 ## Key Rules
 
 - Sub-agent results are NOT shown to the user — you must summarize what was found or accomplished.
 - Always include a short description (3-5 words) when spawning.
-- For open-ended research, use `explore` type. For implementation, use default.
+- **For open-ended research or "look at the code first" requests, default to spawning `explore`** rather than chaining inline searches.
 - Trust agent outputs generally, but verify critical findings before acting on them.

--- a/crates/loopal-tui/src/command/init_cmd/prompt.rs
+++ b/crates/loopal-tui/src/command/init_cmd/prompt.rs
@@ -4,30 +4,48 @@ use std::path::Path;
 
 const INIT_PROMPT: &str = r#"Analyze this project and generate a comprehensive LOOPAL.md file.
 
-## Steps
+## Phase 1: Quick orientation
 
-1. **Detect project type**: Use Ls to scan the root directory. Look for:
-   - Cargo.toml (Rust), package.json (Node.js), pyproject.toml / setup.py (Python),
-     go.mod (Go), Makefile, CMakeLists.txt, pom.xml, build.gradle, Gemfile, etc.
+Use Ls on the project root. Identify:
+- Project type from manifest files (Cargo.toml / package.json / pyproject.toml /
+  setup.py / go.mod / Makefile / CMakeLists.txt / pom.xml / build.gradle / Gemfile)
+- Top-level source / module directories
+- Existing AI-tool config files (CLAUDE.md, AGENTS.md, .cursor/rules/, .cursorrules,
+  .github/copilot-instructions.md) — they often contain useful but possibly stale info
 
-2. **Read config files**: Read the detected build/config files to extract:
-   - Project name and version
-   - Build commands (build, test, lint, format, type-check)
-   - Dependency management approach
-   - Any workspace/monorepo structure
+## Phase 2: Deep exploration
 
-3. **Analyze project structure**: Use Ls on key directories (src/, lib/, tests/, etc.)
-   - Identify module layout and layering
-   - Note entry points (main.rs, index.ts, main.py, etc.)
-   - Estimate code organization pattern (flat, layered, feature-based, etc.)
+**Choose ONE branch based on what Phase 1 found:**
 
-4. **Identify code conventions**: Read 2-3 representative source files to observe:
-   - Naming style (snake_case, camelCase, PascalCase)
-   - File organization patterns
-   - Comment language (English, Chinese, etc.) and style
-   - Config files like .editorconfig, rustfmt.toml, .eslintrc, .prettierrc, etc.
+### Branch A — Small single-stack project
+(One manifest, ≤2 top-level source directories.)
 
-## Output
+Continue inline with Read/Grep on:
+- The build/config file(s) you detected — extract project name, version, and the
+  build / test / lint / format / type-check commands
+- 2-3 representative source files to observe naming style, file organization,
+  comment language (English / Chinese / etc.)
+- Style configs if present: .editorconfig, rustfmt.toml, .eslintrc, .prettierrc
+
+### Branch B — Medium / large project
+(≥3 top-level source directories OR multiple language stacks like iOS + Go + TS.)
+
+**You MUST spawn parallel `explore` sub-agents** — one per major area — in a
+single message with multiple Agent tool uses. Each sub-agent should report:
+- Build / test / lint commands specific to that area
+- Naming conventions and file-organization patterns observed
+- Module boundaries, key entry points, and notable internal APIs
+- Area-specific gotchas (env vars, build prerequisites, codegen steps)
+
+Wait for all sub-agents to return, then aggregate their findings before writing.
+
+## Phase 3: Read shared root configs
+
+Independently of Phase 2, read once at the root level: README, top-level Makefile
+(if present), root package manifest, and the existing CLAUDE.md / AGENTS.md
+contents (borrow but verify — these can be stale).
+
+## Phase 4: Write LOOPAL.md
 
 Use the **Write** tool to write the result to: `{path}/LOOPAL.md`
 


### PR DESCRIPTION
## Summary

- Make the main agent proactively spawn `explore` sub-agents for open-ended codebase questions and multi-area investigations, instead of chaining many inline Glob/Grep/Read calls.
- Make `/init` use parallel explore sub-agents (one per major area) when run on medium/large monorepos.
- No tool schema or runtime logic changes — pure prompt edits.

## Background

Investigation of Claude Code (`claude-code-main/src/constants/prompts.ts` and `commands/init.ts`) showed that they frame sub-agent use as **triggers** (open-ended exploration, >3 queries) rather than **suppressors**, and `/init` Phase 2 literally says "Launch a subagent". Loopal's current `agent-guidelines.md` was framed in the opposite direction ("Prefer fewer agents", "Default to minimum"), and the `/init` prompt was a linear 4-step instruction that gave the model no path to explore. As a result, even on a 4-subdomain monorepo or after a "先看一下现在的代码" request, the agent stayed in serial Glob/Read mode.

## Changes

- `crates/loopal-prompt-system/prompts/tools/agent-guidelines.md`
  - Replace the suppression-framed "Concurrency Discipline" section with proactive triggers (open-ended questions, >3 expected reads, multi-area investigations, unfamiliar code).
  - Beef up the **Agent Types** entries with concrete invocation examples (`**/WidgetDetailPage*`, `Grep "fn handle_.*request"`, "how does the navigation flow work").
  - Flip the depth-0 guidance from "first use Glob/Grep/Read to understand the project" to "prefer spawning `explore` over long inline search chains".
  - Keep the "≤3 reads stay inline" guard so trivial direct lookups are not over-delegated.

- `crates/loopal-prompt-system/prompts/agents/explore.md`
  - Prepend a **Typical Questions** section listing the patterns explore agents are designed to answer, with quick / medium / very thorough thoroughness levels.

- `crates/loopal-tui/src/command/init_cmd/prompt.rs`
  - Split the linear 4-step prompt into 4 phases.
  - Phase 2 is size-adaptive: small single-stack projects stay inline (Branch A), medium/large projects (≥3 top-level source dirs or multi-language stacks) **MUST** spawn parallel explore sub-agents, one per major area (Branch B).

## Test plan

- [x] `bazel test //crates/loopal-prompt-system:loopal-prompt-system_test //crates/loopal-tui:loopal-tui_test` — passes
- [x] `bazel build //crates/loopal-prompt-system/... //crates/loopal-tui/... --config=clippy` — zero warnings
- [ ] CI passes
