### PR TITLE
fix(spawn): propagate --no-sandbox to all sub-agents

### DIFF
--- a/crates/loopal-agent-hub/src/dispatch/spawn_prepare.rs
+++ b/crates/loopal-agent-hub/src/dispatch/spawn_prepare.rs
@@ -9,6 +9,13 @@
 //! is clamped `>= 1`. Cross-network deployment must add receiver-side
 //! policy arbitration (per-hub allow-list, depth-floor from receiver
 //! config) before becoming safe.
+//!
+//! TODO(cross-hub-trust): `no_sandbox` is currently passed through verbatim
+//! from the caller hub. Unlike `permission_mode` this has no UI dependency,
+//! so no clamp is needed on functional grounds — but it grants caller-side
+//! ability to disable the receiver's OS sandbox. Same arbitration story
+//! as `permission_mode`: receiver-side allow-list / per-hub policy must
+//! gate this before cross-hub is production-safe.
 
 use std::path::Path;
 
@@ -23,6 +30,7 @@ pub(crate) struct RemoteSpawnArgs {
     pub agent_type: Option<String>,
     pub depth: Option<u32>,
     pub parent: Option<String>,
+    pub no_sandbox: bool,
 }
 
 /// Validate a cross-hub spawn payload and assemble args using the receiver
@@ -92,5 +100,6 @@ pub(crate) fn prepare_remote_spawn_args(
         agent_type,
         depth,
         parent,
+        no_sandbox: params["no_sandbox"].as_bool().unwrap_or(false),
     })
 }

--- a/crates/loopal-agent-hub/src/dispatch/spawn_prepare_test.rs
+++ b/crates/loopal-agent-hub/src/dispatch/spawn_prepare_test.rs
@@ -143,3 +143,20 @@ fn rejects_when_name_missing() {
     let err = prepare_remote_spawn_args(&json!({"prompt": "x"}), "f", cwd("/c")).unwrap_err();
     assert!(err.contains("name"));
 }
+
+#[test]
+fn no_sandbox_passed_through_when_present() {
+    let args = prepare_remote_spawn_args(
+        &json!({"name": "child", "no_sandbox": true}),
+        "caller",
+        cwd("/cwd"),
+    )
+    .unwrap();
+    assert!(args.no_sandbox);
+}
+
+#[test]
+fn no_sandbox_defaults_false_when_missing() {
+    let args = prepare_remote_spawn_args(&json!({"name": "child"}), "caller", cwd("/cwd")).unwrap();
+    assert!(!args.no_sandbox);
+}

--- a/crates/loopal-agent-hub/src/dispatch/spawn_routing.rs
+++ b/crates/loopal-agent-hub/src/dispatch/spawn_routing.rs
@@ -55,6 +55,7 @@ async fn spawn_local(
     let agent_type = params["agent_type"].as_str().map(String::from);
     let depth = params["depth"].as_u64().map(|v| v as u32);
     let fork_context = params.get("fork_context").cloned();
+    let no_sandbox = params["no_sandbox"].as_bool().unwrap_or(false);
     let parent = params["parent"]
         .as_str()
         .map(String::from)
@@ -72,6 +73,7 @@ async fn spawn_local(
         agent_type,
         depth,
         fork_context,
+        no_sandbox,
     )
     .await
 }
@@ -99,6 +101,7 @@ pub async fn handle_spawn_remote_agent(
         args.agent_type,
         args.depth,
         None,
+        args.no_sandbox,
     )
     .await
 }
@@ -115,6 +118,7 @@ pub(super) async fn spawn_via_manager(
     agent_type: Option<String>,
     depth: Option<u32>,
     fork_context: Option<Value>,
+    no_sandbox: bool,
 ) -> Result<Value, String> {
     let name_clone = name.clone();
     // Detached on purpose: spawn_and_register may have already forked a
@@ -133,6 +137,7 @@ pub(super) async fn spawn_via_manager(
             agent_type,
             depth,
             fork_context,
+            no_sandbox,
         )
         .await
     });

--- a/crates/loopal-agent-hub/src/spawn_manager.rs
+++ b/crates/loopal-agent-hub/src/spawn_manager.rs
@@ -22,6 +22,7 @@ pub async fn spawn_and_register(
     agent_type: Option<String>,
     depth: Option<u32>,
     fork_context: Option<serde_json::Value>,
+    no_sandbox: bool,
 ) -> Result<String, String> {
     // Pre-check budget BEFORE spawning process to avoid orphans.
     if parent.is_some() {
@@ -57,11 +58,12 @@ pub async fn spawn_and_register(
             mode: Some("act".to_string()),
             prompt,
             permission_mode,
+            no_sandbox,
+            resume: None,
             lifecycle: Some("ephemeral".to_string()), // sub-agents always exit on idle
             agent_type,
             depth,
             fork_context,
-            ..Default::default()
         })
         .await
     {

--- a/crates/loopal-agent-server/src/memory_adapter.rs
+++ b/crates/loopal-agent-server/src/memory_adapter.rs
@@ -55,6 +55,7 @@ impl ServerMemoryProcessor {
     }
 
     async fn spawn_and_wait(&self, name: &str, prompt: String) -> Result<(), String> {
+        let no_sandbox = self.shared.no_sandbox();
         let params = SpawnParams {
             name: name.to_string(),
             prompt,
@@ -62,6 +63,7 @@ impl ServerMemoryProcessor {
             permission_mode: None,
             agent_type: None,
             depth: self.shared.depth + 1,
+            no_sandbox,
             target: SpawnTarget::InHub {
                 cwd_override: None,
                 fork_context: None,

--- a/crates/loopal-agent-server/src/memory_consolidation.rs
+++ b/crates/loopal-agent-server/src/memory_consolidation.rs
@@ -32,6 +32,7 @@ pub fn trigger_consolidation(shared: &Arc<AgentShared>, model: &str) {
         let today = loopal_memory::date::today_str();
         let name = ServerMemoryProcessor::make_agent_name("memory-consolidation");
         let prompt = format!("{MEMORY_CONSOLIDATION_PROMPT}\n\nToday: {today}");
+        let no_sandbox = shared.no_sandbox();
         let params = SpawnParams {
             name: name.clone(),
             prompt,
@@ -39,6 +40,7 @@ pub fn trigger_consolidation(shared: &Arc<AgentShared>, model: &str) {
             permission_mode: None,
             agent_type: None,
             depth: shared.depth + 1,
+            no_sandbox,
             target: SpawnTarget::InHub {
                 cwd_override: None,
                 fork_context: None,

--- a/crates/loopal-agent/src/shared.rs
+++ b/crates/loopal-agent/src/shared.rs
@@ -131,4 +131,14 @@ impl AgentShared {
             bg_tasks,
         }
     }
+
+    /// Single source of truth for spawn paths that need to propagate
+    /// the flag to children — derived from `kernel.settings()` so it
+    /// reflects post-`apply_start_overrides` state, not just config files.
+    pub fn no_sandbox(&self) -> bool {
+        matches!(
+            self.kernel.settings().sandbox.policy,
+            loopal_config::SandboxPolicy::Disabled
+        )
+    }
 }

--- a/crates/loopal-agent/src/spawn.rs
+++ b/crates/loopal-agent/src/spawn.rs
@@ -45,6 +45,10 @@ pub struct SpawnParams {
     pub agent_type: Option<String>,
     /// Nesting depth of the child agent (parent depth + 1).
     pub depth: u32,
+    /// Reflects the parent's effective `settings.sandbox.policy == Disabled`.
+    /// Behavior flag — not filesystem-coupled, so it crosses hub boundaries
+    /// safely (unlike `cwd` / `fork_context`).
+    pub no_sandbox: bool,
     /// In-hub vs cross-hub semantics.
     pub target: SpawnTarget,
 }
@@ -68,6 +72,7 @@ pub fn build_spawn_request(
         "permission_mode": params.permission_mode,
         "agent_type": params.agent_type,
         "depth": params.depth,
+        "no_sandbox": params.no_sandbox,
     });
 
     match &params.target {

--- a/crates/loopal-agent/src/tools/collaboration/agent_spawn.rs
+++ b/crates/loopal-agent/src/tools/collaboration/agent_spawn.rs
@@ -62,6 +62,7 @@ pub(super) async fn action_spawn(
         loopal_tool_api::PermissionMode::Supervised => "supervised",
         loopal_tool_api::PermissionMode::Auto => "auto",
     };
+    let no_sandbox = shared.no_sandbox();
     let target = build_spawn_target(target_hub, cwd_override, build_fork_context(&shared));
     let result = spawn_agent(
         &shared,
@@ -72,6 +73,7 @@ pub(super) async fn action_spawn(
             permission_mode: Some(perm_mode.to_string()),
             agent_type: subagent_type.map(String::from),
             depth: shared.depth + 1,
+            no_sandbox,
             target,
         },
     )

--- a/crates/loopal-agent/tests/suite.rs
+++ b/crates/loopal-agent/tests/suite.rs
@@ -1,6 +1,8 @@
 // Single test binary — includes all test modules
 #[path = "suite/agent_isolation_test.rs"]
 mod agent_isolation_test;
+#[path = "suite/agent_shared_test.rs"]
+mod agent_shared_test;
 #[path = "suite/agent_snapshot_test.rs"]
 mod agent_snapshot_test;
 #[path = "suite/bridge_chain_test.rs"]

--- a/crates/loopal-agent/tests/suite/agent_shared_test.rs
+++ b/crates/loopal-agent/tests/suite/agent_shared_test.rs
@@ -1,0 +1,34 @@
+use std::sync::Arc;
+
+use loopal_agent::shared::AgentShared;
+use loopal_config::{SandboxPolicy, Settings};
+use loopal_test_support::TestFixture;
+use loopal_test_support::agent_ctx::agent_tool_context_with_settings;
+
+fn shared_with_policy(fixture: &TestFixture, policy: SandboxPolicy) -> Arc<AgentShared> {
+    let mut settings = Settings::default();
+    settings.sandbox.policy = policy;
+    let (_ctx, shared) = agent_tool_context_with_settings(fixture, settings);
+    shared
+}
+
+#[test]
+fn no_sandbox_true_when_policy_disabled() {
+    let fixture = TestFixture::new();
+    let shared = shared_with_policy(&fixture, SandboxPolicy::Disabled);
+    assert!(shared.no_sandbox());
+}
+
+#[test]
+fn no_sandbox_false_when_policy_default_write() {
+    let fixture = TestFixture::new();
+    let shared = shared_with_policy(&fixture, SandboxPolicy::DefaultWrite);
+    assert!(!shared.no_sandbox());
+}
+
+#[test]
+fn no_sandbox_false_when_policy_read_only() {
+    let fixture = TestFixture::new();
+    let shared = shared_with_policy(&fixture, SandboxPolicy::ReadOnly);
+    assert!(!shared.no_sandbox());
+}

--- a/crates/loopal-agent/tests/suite/spawn_params_test.rs
+++ b/crates/loopal-agent/tests/suite/spawn_params_test.rs
@@ -12,6 +12,7 @@ fn base_params(target: SpawnTarget) -> SpawnParams {
         permission_mode: Some("supervised".into()),
         agent_type: None,
         depth: 1,
+        no_sandbox: false,
         target,
     }
 }
@@ -83,4 +84,39 @@ fn crosshub_still_carries_advisory_fields() {
     assert_eq!(req["permission_mode"], "supervised");
     assert_eq!(req["model"], "claude-opus-4-7");
     assert_eq!(req["depth"], 1);
+}
+
+#[test]
+fn inhub_propagates_no_sandbox_true() {
+    let parent_cwd = PathBuf::from("/parent/dir");
+    let mut params = base_params(SpawnTarget::InHub {
+        cwd_override: None,
+        fork_context: None,
+    });
+    params.no_sandbox = true;
+    let req = build_spawn_request(&params, &parent_cwd);
+    assert_eq!(req["no_sandbox"], true);
+}
+
+#[test]
+fn inhub_propagates_no_sandbox_false() {
+    let parent_cwd = PathBuf::from("/parent/dir");
+    let params = base_params(SpawnTarget::InHub {
+        cwd_override: None,
+        fork_context: None,
+    });
+    let req = build_spawn_request(&params, &parent_cwd);
+    assert_eq!(req["no_sandbox"], false);
+}
+
+#[test]
+fn crosshub_propagates_no_sandbox() {
+    let parent_cwd = PathBuf::from("/parent/dir");
+    let mut params = base_params(SpawnTarget::CrossHub {
+        hub_id: "hub-b".into(),
+    });
+    params.no_sandbox = true;
+    let req = build_spawn_request(&params, &parent_cwd);
+    // Behavior flag — not filesystem-coupled, so it crosses hub boundaries.
+    assert_eq!(req["no_sandbox"], true);
 }

--- a/crates/loopal-test-support/src/agent_ctx.rs
+++ b/crates/loopal-test-support/src/agent_ctx.rs
@@ -24,7 +24,7 @@ use crate::fixture::TestFixture;
 /// The returned `Arc<AgentShared>` can be used for post-execution assertions
 /// (e.g., checking the scheduler's task list after a CronCreate call).
 pub fn agent_tool_context(fixture: &TestFixture) -> (ToolContext, Arc<AgentShared>) {
-    agent_tool_context_inner(fixture, Arc::new(CronScheduler::new()))
+    agent_tool_context_inner(fixture, Arc::new(CronScheduler::new()), Settings::default())
 }
 
 /// Variant with a custom `CronScheduler` (e.g., one using `ManualClock`).
@@ -32,14 +32,24 @@ pub fn agent_tool_context_with_scheduler(
     fixture: &TestFixture,
     scheduler: Arc<CronScheduler>,
 ) -> (ToolContext, Arc<AgentShared>) {
-    agent_tool_context_inner(fixture, scheduler)
+    agent_tool_context_inner(fixture, scheduler, Settings::default())
+}
+
+/// Variant with custom `Settings`. Use to test paths that depend on
+/// `kernel.settings()` (e.g., sandbox policy, model routing).
+pub fn agent_tool_context_with_settings(
+    fixture: &TestFixture,
+    settings: Settings,
+) -> (ToolContext, Arc<AgentShared>) {
+    agent_tool_context_inner(fixture, Arc::new(CronScheduler::new()), settings)
 }
 
 fn agent_tool_context_inner(
     fixture: &TestFixture,
     scheduler: Arc<CronScheduler>,
+    settings: Settings,
 ) -> (ToolContext, Arc<AgentShared>) {
-    let mut kernel = Kernel::new(Settings::default()).unwrap();
+    let mut kernel = Kernel::new(settings).unwrap();
     loopal_agent::tools::register_all(&mut kernel);
     let kernel = Arc::new(kernel);
 

--- a/src/bootstrap/hub_bootstrap.rs
+++ b/src/bootstrap/hub_bootstrap.rs
@@ -78,7 +78,9 @@ pub async fn bootstrap_hub_and_agent(
             no_sandbox: cli.no_sandbox,
             resume: resume.map(String::from),
             lifecycle: lifecycle_str.map(String::from),
-            ..Default::default()
+            agent_type: None,
+            depth: None,
+            fork_context: None,
         })
         .await?;
 


### PR DESCRIPTION
## Summary
- Sub-agent processes ignored the parent's `--no-sandbox` flag because `spawn_manager` constructed `StartAgentParams` with `..Default::default()`, silently zeroing `no_sandbox`
- On macOS this caused nested `sandbox-exec` rejection (kernel blocks nested `sandbox_apply`) for any sub-agent running Bazel/SwiftPM commands
- Threads `no_sandbox` through the entire spawn chain and centralizes derivation, then removes `..Default::default()` in production callers so future field additions can't be silently dropped again

## Changes

**Plumbing (in-hub + cross-hub spawn)**
- `crates/loopal-agent/src/spawn.rs` — `SpawnParams` adds `no_sandbox`; `build_spawn_request` writes it to JSON
- `crates/loopal-agent/src/shared.rs` — new `AgentShared::no_sandbox()` SSOT
- `crates/loopal-agent/src/tools/collaboration/agent_spawn.rs` — derives via `shared.no_sandbox()`
- `crates/loopal-agent-server/src/memory_adapter.rs` + `memory_consolidation.rs` — same derivation path for internal spawns
- `crates/loopal-agent-hub/src/dispatch/spawn_routing.rs` — `spawn_local` parses, `spawn_via_manager` threads through
- `crates/loopal-agent-hub/src/dispatch/spawn_prepare.rs` — `RemoteSpawnArgs.no_sandbox` for cross-hub receiver; module-level TODO for cross-hub trust gap
- `crates/loopal-agent-hub/src/spawn_manager.rs` — `spawn_and_register` accepts `no_sandbox`; `StartAgentParams` now lists all 11 fields explicitly (drops `..Default::default()`)
- `src/bootstrap/hub_bootstrap.rs` — same explicit-fields treatment for the root agent path

**Tests (5 new)**
- `crates/loopal-agent/tests/suite/spawn_params_test.rs` — InHub true/false, CrossHub propagation
- `crates/loopal-agent-hub/src/dispatch/spawn_prepare_test.rs` — present/missing-default
- `crates/loopal-agent/tests/suite/agent_shared_test.rs` (new) — `no_sandbox()` derivation across `Disabled` / `DefaultWrite` / `ReadOnly` policies
- `crates/loopal-test-support/src/agent_ctx.rs` — adds `agent_tool_context_with_settings` variant for tests that need to inject custom Settings

## Test plan
- [x] `bazel build //... --config=clippy --config=rustfmt` — zero warnings
- [x] `bazel test //...` — 53/53 PASSED (incl. `system_ipc_test`, `loopal-meta-hub_e2e`, `loopal-runtime_test`)
- [ ] CI passes
- [ ] Manual: `make install` then verify a sub-agent spawned under `--no-sandbox` can run `sandbox-exec -p '(version 1)(allow default)' /bin/echo NESTED_OK` without `Operation not permitted`

## Known follow-ups (not in this PR)
- Cross-hub `no_sandbox` trust gap (TODO note added in `spawn_prepare.rs` module doc) — receiver-side per-hub policy gate, same arbitration story as `permission_mode` clamp
- `spawn_via_manager` / `spawn_and_register` 11 positional params — fold into struct as part of the existing "spawn_agent testability refactor" TODO