### PR TITLE
fix(goals): unblock /goal pipeline and unify command reply channel

### DIFF
--- a/crates/loopal-agent-server/src/agent_setup.rs
+++ b/crates/loopal-agent-server/src/agent_setup.rs
@@ -70,7 +70,7 @@ pub async fn build_with_frontend(ctx: AgentSetupContext<'_>) -> anyhow::Result<A
     let (scheduler_handle, scheduled_rx) =
         SchedulerHandle::create_with_scheduler(scheduler.clone());
     let message_snapshot = Arc::new(std::sync::RwLock::new(Vec::new()));
-    let goal_session = if config.settings.goals.enabled && depth == 0 {
+    let goal_session = if depth == 0 {
         let goal_store = session_manager.goal_store();
         Some(std::sync::Arc::new(
             loopal_runtime::GoalRuntimeSession::new(

--- a/crates/loopal-agent-server/src/params.rs
+++ b/crates/loopal-agent-server/src/params.rs
@@ -41,11 +41,16 @@ pub struct StartParams {
 
 /// Build a Kernel from config (production path: MCP, tools).
 /// Caller should apply start overrides to config.settings before calling.
+/// `depth` controls role-scoped tool registration (root only registers goal tools).
 pub(crate) async fn build_kernel_from_config(
     config: &ResolvedConfig,
     production: bool,
+    depth: u32,
 ) -> anyhow::Result<Arc<Kernel>> {
     let mut kernel = Kernel::new(config.settings.clone())?;
+    if depth == 0 {
+        kernel.register_goal_tools();
+    }
     if production {
         // Wire up MCP sampling: resolve the default model's provider and inject.
         if let Ok(provider) = kernel.resolve_provider(&config.settings.model) {
@@ -88,9 +93,5 @@ pub(crate) fn apply_start_overrides(settings: &mut loopal_config::Settings, star
     }
     if start.no_sandbox {
         settings.sandbox.policy = loopal_config::SandboxPolicy::Disabled;
-    }
-    if start.depth.unwrap_or(0) > 0 {
-        // sub-agents are not the goal-bearing thread
-        settings.goals.enabled = false;
     }
 }

--- a/crates/loopal-agent-server/src/session_start.rs
+++ b/crates/loopal-agent-server/src/session_start.rs
@@ -72,12 +72,13 @@ pub(crate) async fn start_session(
 
         let mut config = load_config(&cwd)?;
         crate::params::apply_start_overrides(&mut config.settings, &start);
+        let depth = start.depth.unwrap_or(0);
         let kernel = if is_production {
-            crate::params::build_kernel_from_config(&config, true).await?
+            crate::params::build_kernel_from_config(&config, true, depth).await?
         } else {
             match hub.get_test_provider().await {
                 Some(provider) => crate::params::build_kernel_with_provider(provider)?,
-                None => crate::params::build_kernel_from_config(&config, false).await?,
+                None => crate::params::build_kernel_from_config(&config, false, depth).await?,
             }
         };
 

--- a/crates/loopal-config/src/settings.rs
+++ b/crates/loopal-config/src/settings.rs
@@ -71,8 +71,6 @@ pub struct Settings {
     #[serde(default)]
     pub fetch_refiner: FetchRefinerConfig,
 
-    /// Thread goal feature: per-session long-running objective tracking with
-    /// automatic continuation between turns. Disabled by default.
     #[serde(default)]
     pub goals: GoalSettings,
 }
@@ -103,7 +101,6 @@ impl Default for Settings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct GoalSettings {
-    pub enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_token_budget: Option<u64>,
     pub barren_continuation_limit: u32,
@@ -112,7 +109,6 @@ pub struct GoalSettings {
 impl Default for GoalSettings {
     fn default() -> Self {
         Self {
-            enabled: false,
             default_token_budget: None,
             barren_continuation_limit: 2,
         }

--- a/crates/loopal-kernel/src/kernel/mod.rs
+++ b/crates/loopal-kernel/src/kernel/mod.rs
@@ -35,7 +35,7 @@ impl Kernel {
     pub fn new(settings: Settings) -> Result<Self> {
         let bg_store = BackgroundTaskStore::new();
         let tool_registry = ToolRegistry::new();
-        loopal_tools::builtin::register_all(&tool_registry, bg_store.clone(), &settings);
+        loopal_tools::builtin::register_all(&tool_registry, bg_store.clone());
 
         let mut provider_registry = ProviderRegistry::new();
         provider_registry::register_providers(&settings, &mut provider_registry);
@@ -63,6 +63,12 @@ impl Kernel {
     /// Register an additional tool (thread-safe, can be called after Arc wrapping).
     pub fn register_tool(&self, tool: Box<dyn loopal_tool_api::Tool>) {
         self.tool_registry.register(tool);
+    }
+
+    /// Register thread-goal tools — only valid for the root agent that
+    /// owns a `goal_session`. Sub-agents must not call this.
+    pub fn register_goal_tools(&self) {
+        loopal_tools::builtin::register_goal_tools(&self.tool_registry);
     }
 
     /// Register an additional provider (useful for testing with mock providers).

--- a/crates/loopal-test-support/src/harness.rs
+++ b/crates/loopal-test-support/src/harness.rs
@@ -179,6 +179,11 @@ impl IntegrationHarness {
 
 /// Harness with `agent_loop` running in a background task.
 pub struct SpawnedHarness {
+    /// Clone of the channel sender backing `event_rx`. Tests that need to
+    /// inject synthetic `AgentEvent`s (e.g. wrapping a `GoalRuntimeSession`
+    /// `EventEmitter` so its `ThreadGoalUpdated` payloads ride the same
+    /// pipe the runner uses) push through here.
+    pub event_tx: mpsc::Sender<AgentEvent>,
     pub event_rx: mpsc::Receiver<AgentEvent>,
     pub mailbox_tx: mpsc::Sender<Envelope>,
     pub control_tx: mpsc::Sender<ControlCommand>,

--- a/crates/loopal-test-support/src/wiring.rs
+++ b/crates/loopal-test-support/src/wiring.rs
@@ -63,16 +63,15 @@ pub(crate) async fn wire(builder: HarnessBuilder) -> (SpawnedHarness, AgentLoopR
     ));
 
     // Kernel: register builtin tools + agent tools + mock provider.
-    // Auto-enable goals when a goal_session is provided so the goal tools
-    // appear in the LLM tool list during e2e tests.
-    let mut settings = Settings {
+    // Goal tools are root-only — only register when the test wired a goal_session.
+    let settings = Settings {
         hooks: builder.hooks,
         ..Settings::default()
     };
-    if builder.goal_session.is_some() {
-        settings.goals.enabled = true;
-    }
     let mut kernel = Kernel::new(settings).unwrap();
+    if builder.goal_session.is_some() {
+        kernel.register_goal_tools();
+    }
     loopal_agent::tools::register_all(&mut kernel);
     kernel.register_provider(Arc::new(MultiCallProvider::new(builder.calls)) as Arc<dyn Provider>);
     if let Some(setup) = builder.kernel_setup {
@@ -106,7 +105,7 @@ pub(crate) async fn wire(builder: HarnessBuilder) -> (SpawnedHarness, AgentLoopR
         cwd,
         depth: 0,
         agent_name: "main".to_string(),
-        parent_event_tx: Some(event_tx),
+        parent_event_tx: Some(event_tx.clone()),
         cancel_token: None,
         scheduler_handle,
         message_snapshot: Arc::new(std::sync::RwLock::new(Vec::new())),
@@ -168,6 +167,7 @@ pub(crate) async fn wire(builder: HarnessBuilder) -> (SpawnedHarness, AgentLoopR
     .build();
 
     let harness = SpawnedHarness {
+        event_tx: event_tx.clone(),
         event_rx,
         mailbox_tx,
         control_tx,

--- a/crates/loopal-tui/BUILD.bazel
+++ b/crates/loopal-tui/BUILD.bazel
@@ -63,6 +63,7 @@ rust_test(
         "//crates/loopal-protocol",
         "//crates/loopal-runtime",
         "//crates/loopal-session",
+        "//crates/loopal-storage",
         "//crates/loopal-view-state",
     ],
     proc_macro_deps = ["@crates//:async-trait"],

--- a/crates/loopal-tui/src/command/agent_cmd.rs
+++ b/crates/loopal-tui/src/command/agent_cmd.rs
@@ -20,17 +20,19 @@ impl CommandHandler for AgentsCmd {
         "List agents and their connection status"
     }
 
+    fn has_arg(&self) -> bool {
+        false
+    }
+
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
         let agents = app.session.list_agents().await;
         if agents.is_empty() {
-            app.push_system_message("No sub-agents".into());
-        } else {
-            let lines: Vec<String> = agents
-                .iter()
-                .map(|(name, state)| format!("  {name}: {state}"))
-                .collect();
-            app.push_system_message(format!("Agents:\n{}", lines.join("\n")));
+            return CommandEffect::Reply("No sub-agents".into());
         }
-        CommandEffect::Done
+        let lines: Vec<String> = agents
+            .iter()
+            .map(|(name, state)| format!("  {name}: {state}"))
+            .collect();
+        CommandEffect::Reply(format!("Agents:\n{}", lines.join("\n")))
     }
 }

--- a/crates/loopal-tui/src/command/builtin.rs
+++ b/crates/loopal-tui/src/command/builtin.rs
@@ -26,6 +26,9 @@ impl CommandHandler for ClearCmd {
     fn description(&self) -> &str {
         "Clear conversation history"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
         app.pending_images.clear();
         app.session.clear().await;
@@ -43,6 +46,9 @@ impl CommandHandler for CompactCmd {
     fn description(&self) -> &str {
         "Compact old messages"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
         app.session.compact().await;
         CommandEffect::Done
@@ -59,6 +65,9 @@ impl CommandHandler for PlanCmd {
     fn description(&self) -> &str {
         "Switch to Plan mode"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, _app: &mut App, _arg: Option<&str>) -> CommandEffect {
         CommandEffect::ModeSwitch(AgentMode::Plan)
     }
@@ -74,6 +83,9 @@ impl CommandHandler for ActCmd {
     fn description(&self) -> &str {
         "Switch to Act mode"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, _app: &mut App, _arg: Option<&str>) -> CommandEffect {
         CommandEffect::ModeSwitch(AgentMode::Act)
     }
@@ -88,6 +100,9 @@ impl CommandHandler for ExitCmd {
     }
     fn description(&self) -> &str {
         "Shut down Hub and all agents, then exit"
+    }
+    fn has_arg(&self) -> bool {
+        false
     }
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
         app.shutdown_initiated = true;

--- a/crates/loopal-tui/src/command/detach_hub_cmd.rs
+++ b/crates/loopal-tui/src/command/detach_hub_cmd.rs
@@ -13,6 +13,9 @@ impl CommandHandler for DetachHubCmd {
     fn description(&self) -> &str {
         "Detach TUI from Hub (Hub & agents keep running)"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, _app: &mut App, _arg: Option<&str>) -> CommandEffect {
         CommandEffect::Detach
     }

--- a/crates/loopal-tui/src/command/goal_cmd.rs
+++ b/crates/loopal-tui/src/command/goal_cmd.rs
@@ -4,6 +4,9 @@ use loopal_protocol::ControlCommand;
 use super::{CommandEffect, CommandHandler};
 use crate::app::App;
 
+const USAGE: &str =
+    "/goal usage: <objective> [--budget=<N>] | pause | resume | complete | clear | extend <N>";
+
 pub struct GoalCmd;
 
 #[async_trait]
@@ -16,20 +19,40 @@ impl CommandHandler for GoalCmd {
         "Manage thread goal: /goal <objective> | pause | resume | complete | clear | extend <N>"
     }
 
+    fn has_arg(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, app: &mut App, arg: Option<&str>) -> CommandEffect {
         let arg = arg.unwrap_or("").trim();
         let cmd = match parse_goal_arg(arg) {
             Some(c) => c,
-            None => {
-                tracing::warn!(
-                    "/goal usage: <objective> | pause | resume | complete | clear | extend <N>"
-                );
-                return CommandEffect::Done;
-            }
+            None => return CommandEffect::Reply(USAGE.into()),
         };
+        let ack = ack_for(&cmd);
         let target = app.session.lock().active_view.clone();
         app.session.send_control(target, cmd).await;
-        CommandEffect::Done
+        CommandEffect::Reply(ack)
+    }
+}
+
+fn ack_for(cmd: &ControlCommand) -> String {
+    match cmd {
+        ControlCommand::GoalCreate {
+            objective,
+            token_budget,
+        } => match token_budget {
+            Some(b) => format!("Goal set: \"{objective}\" (budget {b} tokens)"),
+            None => format!("Goal set: \"{objective}\""),
+        },
+        ControlCommand::GoalUserPause => "Goal paused.".into(),
+        ControlCommand::GoalUserResume => "Goal resumed.".into(),
+        ControlCommand::GoalUserComplete => "Goal marked complete.".into(),
+        ControlCommand::GoalClear => "Goal cleared.".into(),
+        ControlCommand::GoalExtendBudget { additional_tokens } => {
+            format!("Goal budget extended by {additional_tokens} tokens.")
+        }
+        _ => "Goal command sent.".into(),
     }
 }
 
@@ -77,6 +100,10 @@ pub(crate) fn parse_goal_arg(arg: &str) -> Option<ControlCommand> {
 mod tests {
     use super::*;
 
+    fn dbg_variant(c: &ControlCommand) -> String {
+        format!("{c:?}")
+    }
+
     #[test]
     fn empty_arg_returns_none() {
         assert!(parse_goal_arg("").is_none());
@@ -84,60 +111,35 @@ mod tests {
 
     #[test]
     fn lifecycle_keywords_parse() {
-        assert!(matches!(
-            parse_goal_arg("pause"),
-            Some(ControlCommand::GoalUserPause)
-        ));
-        assert!(matches!(
-            parse_goal_arg("RESUME"),
-            Some(ControlCommand::GoalUserResume)
-        ));
-        assert!(matches!(
-            parse_goal_arg("Complete"),
-            Some(ControlCommand::GoalUserComplete)
-        ));
-        assert!(matches!(
-            parse_goal_arg("clear"),
-            Some(ControlCommand::GoalClear)
-        ));
-    }
-
-    #[test]
-    fn extend_parses_token_amount() {
-        match parse_goal_arg("extend 5000") {
-            Some(ControlCommand::GoalExtendBudget { additional_tokens }) => {
-                assert_eq!(additional_tokens, 5000);
-            }
-            other => panic!("expected GoalExtendBudget, got {other:?}"),
+        for (input, want) in [
+            ("pause", "GoalUserPause"),
+            ("RESUME", "GoalUserResume"),
+            ("Complete", "GoalUserComplete"),
+            ("clear", "GoalClear"),
+        ] {
+            let got = dbg_variant(&parse_goal_arg(input).unwrap());
+            assert!(got.starts_with(want), "{input} -> {got}");
         }
     }
 
     #[test]
-    fn extend_with_non_numeric_falls_through_to_objective() {
+    fn extend_parses_token_amount_else_falls_through() {
+        match parse_goal_arg("extend 5000") {
+            Some(ControlCommand::GoalExtendBudget { additional_tokens }) => {
+                assert_eq!(additional_tokens, 5000)
+            }
+            other => panic!("expected GoalExtendBudget, got {other:?}"),
+        }
         match parse_goal_arg("extend the timeout") {
-            Some(ControlCommand::GoalCreate {
-                objective,
-                token_budget,
-            }) => {
-                assert_eq!(objective, "extend the timeout");
-                assert!(token_budget.is_none());
+            Some(ControlCommand::GoalCreate { objective, .. }) => {
+                assert_eq!(objective, "extend the timeout")
             }
             other => panic!("expected GoalCreate fallthrough, got {other:?}"),
         }
     }
 
     #[test]
-    fn extend_with_only_keyword_falls_through_to_objective() {
-        match parse_goal_arg("extend") {
-            Some(ControlCommand::GoalCreate { objective, .. }) => {
-                assert_eq!(objective, "extend");
-            }
-            other => panic!("expected GoalCreate, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn plain_objective_creates_goal() {
+    fn objective_creates_goal_with_optional_budget() {
         match parse_goal_arg("ship the goal feature") {
             Some(ControlCommand::GoalCreate {
                 objective,
@@ -148,10 +150,6 @@ mod tests {
             }
             other => panic!("expected GoalCreate, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn objective_with_budget_flag_parses_both() {
         match parse_goal_arg("ship feature --budget=10000") {
             Some(ControlCommand::GoalCreate {
                 objective,
@@ -162,5 +160,33 @@ mod tests {
             }
             other => panic!("expected GoalCreate with budget, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn ack_strings_per_variant() {
+        let mk = |o: &str, b: Option<u64>| ControlCommand::GoalCreate {
+            objective: o.into(),
+            token_budget: b,
+        };
+        assert!(ack_for(&mk("x", None)).contains("\"x\""));
+        assert!(ack_for(&mk("x", Some(42))).contains("42"));
+        assert_eq!(ack_for(&ControlCommand::GoalUserPause), "Goal paused.");
+        assert_eq!(ack_for(&ControlCommand::GoalUserResume), "Goal resumed.");
+        assert_eq!(
+            ack_for(&ControlCommand::GoalUserComplete),
+            "Goal marked complete."
+        );
+        assert_eq!(ack_for(&ControlCommand::GoalClear), "Goal cleared.");
+        assert!(
+            ack_for(&ControlCommand::GoalExtendBudget {
+                additional_tokens: 99
+            })
+            .contains("99")
+        );
+    }
+
+    #[test]
+    fn handler_declares_argument() {
+        assert!(GoalCmd.has_arg());
     }
 }

--- a/crates/loopal-tui/src/command/help_cmd.rs
+++ b/crates/loopal-tui/src/command/help_cmd.rs
@@ -25,8 +25,7 @@ impl CommandHandler for HelpCmd {
         } else {
             build_full_help(&entries)
         };
-        app.push_system_message(content);
-        CommandEffect::Done
+        CommandEffect::Reply(content)
     }
 }
 

--- a/crates/loopal-tui/src/command/init_cmd/mod.rs
+++ b/crates/loopal-tui/src/command/init_cmd/mod.rs
@@ -26,6 +26,9 @@ impl CommandHandler for InitCmd {
     fn description(&self) -> &str {
         "Initialize project config (agent-powered)"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
         run_init(app)
     }
@@ -75,6 +78,11 @@ fn run_init(app: &mut App) -> CommandEffect {
     };
     lines.push(String::new());
     lines.push(action.to_string());
+    // reason: this command emits two distinct things in one shot — a
+    // user-visible scaffolding summary and a prompt fed back to the LLM.
+    // CommandEffect::Reply can only carry one message and the dispatch
+    // returns a single Effect, so we push the summary directly here and
+    // let the returned InboxPush carry the prompt.
     app.push_system_message(lines.join("\n"));
 
     // 5. Build prompt and inject into agent loop

--- a/crates/loopal-tui/src/command/kill_hub_cmd.rs
+++ b/crates/loopal-tui/src/command/kill_hub_cmd.rs
@@ -13,6 +13,9 @@ impl CommandHandler for KillHubCmd {
     fn description(&self) -> &str {
         "Shut down Hub and all agents, then exit TUI"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
         app.shutdown_initiated = true;
         app.session.shutdown_hub().await;

--- a/crates/loopal-tui/src/command/mcp_cmd.rs
+++ b/crates/loopal-tui/src/command/mcp_cmd.rs
@@ -16,6 +16,9 @@ impl CommandHandler for McpCmd {
     fn description(&self) -> &str {
         "Show MCP server status"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
         open_mcp_page(app).await;
         CommandEffect::Done

--- a/crates/loopal-tui/src/command/mod.rs
+++ b/crates/loopal-tui/src/command/mod.rs
@@ -26,8 +26,14 @@ use crate::app::App;
 /// Result of executing a slash command.
 /// `key_dispatch` maps these to concrete side-effects.
 pub enum CommandEffect {
-    /// Command completed all work internally (e.g. push_system_message, open SubPage).
+    /// Command completed all work internally (e.g. opened a SubPage).
     Done,
+    /// Show one system message in the conversation, then Done. Use this
+    /// for parameter errors, single-line acknowledgements, and short
+    /// result summaries — the dispatch layer pushes it via the canonical
+    /// `App::push_system_message` channel so the message is visible
+    /// regardless of where the handler runs.
+    Reply(String),
     /// Push expanded content to the agent for processing.
     InboxPush(UserContent),
     /// Switch agent mode (plan / act).
@@ -52,9 +58,10 @@ pub trait CommandHandler: Send + Sync {
     /// Short description for autocomplete / help display.
     fn description(&self) -> &str;
     /// Whether the command accepts an argument after the name.
-    fn has_arg(&self) -> bool {
-        false
-    }
+    /// Required (no default): forgetting to declare this is the kind of
+    /// silent UX bug that lets autocomplete dispatch a parameterised
+    /// command with no argument.
+    fn has_arg(&self) -> bool;
     /// Whether this handler originates from a skill file.
     fn is_skill(&self) -> bool {
         false

--- a/crates/loopal-tui/src/command/model_cmd.rs
+++ b/crates/loopal-tui/src/command/model_cmd.rs
@@ -15,6 +15,9 @@ impl CommandHandler for ModelCmd {
     fn description(&self) -> &str {
         "Switch model"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
         open_model_picker(app);
         CommandEffect::Done

--- a/crates/loopal-tui/src/command/resume_cmd.rs
+++ b/crates/loopal-tui/src/command/resume_cmd.rs
@@ -27,15 +27,12 @@ impl CommandHandler for ResumeCmd {
         match arg {
             Some(partial_id) => match resolve_session_id(&app.cwd, partial_id) {
                 Ok(full_id) => CommandEffect::ResumeSession(full_id),
-                Err(msg) => {
-                    app.push_system_message(msg);
-                    CommandEffect::Done
-                }
+                Err(msg) => CommandEffect::Reply(msg),
             },
-            None => {
-                open_session_picker(app);
-                CommandEffect::Done
-            }
+            None => match open_session_picker(app) {
+                Ok(()) => CommandEffect::Done,
+                Err(msg) => CommandEffect::Reply(msg),
+            },
         }
     }
 }
@@ -62,21 +59,12 @@ fn resolve_session_id(cwd: &Path, partial: &str) -> Result<String, String> {
 
 // ── Picker ─────────────────────────────────────────────────────────
 
-fn open_session_picker(app: &mut App) {
-    let sm = match loopal_runtime::SessionManager::new() {
-        Ok(sm) => sm,
-        Err(_) => {
-            app.push_system_message("Failed to access sessions.".into());
-            return;
-        }
-    };
-    let sessions = match sm.list_root_sessions_for_cwd(&app.cwd) {
-        Ok(s) => s,
-        Err(_) => {
-            app.push_system_message("Failed to list sessions.".into());
-            return;
-        }
-    };
+fn open_session_picker(app: &mut App) -> Result<(), String> {
+    let sm = loopal_runtime::SessionManager::new()
+        .map_err(|_| String::from("Failed to access sessions."))?;
+    let sessions = sm
+        .list_root_sessions_for_cwd(&app.cwd)
+        .map_err(|_| String::from("Failed to list sessions."))?;
 
     // Exclude current session
     let current_id = app.session.lock().root_session_id.clone();
@@ -100,8 +88,7 @@ fn open_session_picker(app: &mut App) {
         .collect();
 
     if items.is_empty() {
-        app.push_system_message("No previous sessions found for this project.".into());
-        return;
+        return Err("No previous sessions found for this project.".into());
     }
 
     app.sub_page = Some(SubPage::SessionPicker(PickerState {
@@ -113,4 +100,5 @@ fn open_session_picker(app: &mut App) {
         thinking_options: vec![],
         thinking_selected: 0,
     }));
+    Ok(())
 }

--- a/crates/loopal-tui/src/command/rewind_cmd.rs
+++ b/crates/loopal-tui/src/command/rewind_cmd.rs
@@ -15,16 +15,20 @@ impl CommandHandler for RewindCmd {
     fn description(&self) -> &str {
         "Rewind to a previous turn"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
-        open_rewind_picker(app);
-        CommandEffect::Done
+        match open_rewind_picker(app) {
+            Ok(()) => CommandEffect::Done,
+            Err(msg) => CommandEffect::Reply(msg),
+        }
     }
 }
 
-fn open_rewind_picker(app: &mut App) {
+fn open_rewind_picker(app: &mut App) -> Result<(), String> {
     if !app.is_active_agent_idle() {
-        app.push_system_message("Cannot rewind while the agent is busy.".into());
-        return;
+        return Err("Cannot rewind while the agent is busy.".into());
     }
     let turns: Vec<RewindTurnItem> = app.with_active_conversation(|conv| {
         conv.messages
@@ -51,12 +55,12 @@ fn open_rewind_picker(app: &mut App) {
     });
 
     if turns.is_empty() {
-        app.push_system_message("No turns to rewind to.".into());
-        return;
+        return Err("No turns to rewind to.".into());
     }
 
     app.sub_page = Some(SubPage::RewindPicker(RewindPickerState {
         turns,
         selected: 0,
     }));
+    Ok(())
 }

--- a/crates/loopal-tui/src/command/skills_cmd.rs
+++ b/crates/loopal-tui/src/command/skills_cmd.rs
@@ -15,6 +15,9 @@ impl CommandHandler for SkillsCmd {
     fn description(&self) -> &str {
         "List loaded skills and sources"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
         let state = build_skills_page_state(app);
         app.sub_page = Some(SubPage::SkillsPage(state));

--- a/crates/loopal-tui/src/command/status_cmd.rs
+++ b/crates/loopal-tui/src/command/status_cmd.rs
@@ -18,6 +18,9 @@ impl CommandHandler for StatusCmd {
     fn description(&self) -> &str {
         "Show status dashboard"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
         open_status_page(app).await;
         CommandEffect::Done

--- a/crates/loopal-tui/src/command/topology_cmd.rs
+++ b/crates/loopal-tui/src/command/topology_cmd.rs
@@ -15,6 +15,9 @@ impl CommandHandler for TopologyCmd {
     fn description(&self) -> &str {
         "Toggle agent topology graph overlay"
     }
+    fn has_arg(&self) -> bool {
+        false
+    }
     async fn execute(&self, app: &mut App, _arg: Option<&str>) -> CommandEffect {
         app.show_topology = !app.show_topology;
         CommandEffect::Done

--- a/crates/loopal-tui/src/key_dispatch_ops.rs
+++ b/crates/loopal-tui/src/key_dispatch_ops.rs
@@ -43,6 +43,10 @@ pub(crate) async fn push_to_inbox(app: &mut App, content: UserContent) {
 pub async fn handle_effect(app: &mut App, effect: CommandEffect) -> bool {
     match effect {
         CommandEffect::Done => false,
+        CommandEffect::Reply(msg) => {
+            app.push_system_message(msg);
+            false
+        }
         CommandEffect::InboxPush(content) => {
             push_to_inbox(app, content).await;
             false

--- a/crates/loopal-tui/tests/suite.rs
+++ b/crates/loopal-tui/tests/suite.rs
@@ -128,6 +128,10 @@ mod e2e_error_test;
 mod e2e_fetch_test;
 #[path = "suite/e2e_git_test.rs"]
 mod e2e_git_test;
+#[path = "suite/e2e_goal_support.rs"]
+mod e2e_goal_support;
+#[path = "suite/e2e_goal_test.rs"]
+mod e2e_goal_test;
 #[path = "suite/e2e_harness.rs"]
 mod e2e_harness;
 #[path = "suite/e2e_hooks_test.rs"]

--- a/crates/loopal-tui/tests/suite/command_edge_test.rs
+++ b/crates/loopal-tui/tests/suite/command_edge_test.rs
@@ -69,12 +69,13 @@ async fn test_help_cmd_shows_all_commands() {
     let mut app = make_app();
     let handler = app.command_registry.find("/help").unwrap();
     let effect = handler.execute(&mut app, None).await;
-    assert!(matches!(effect, loopal_tui::command::CommandEffect::Done));
-    let conv = app.snapshot_active_conversation();
-    let last = conv.messages.last().expect("expected help message");
-    assert!(last.content.contains("/clear"));
-    assert!(last.content.contains("/model"));
-    assert!(last.content.contains("Shortcuts:"));
+    let body = match effect {
+        loopal_tui::command::CommandEffect::Reply(s) => s,
+        other => panic!("expected Reply, got {:?}", std::mem::discriminant(&other)),
+    };
+    assert!(body.contains("/clear"));
+    assert!(body.contains("/model"));
+    assert!(body.contains("Shortcuts:"));
 }
 
 #[tokio::test]
@@ -116,11 +117,13 @@ async fn test_rewind_on_busy_agent_shows_error() {
         view.observable.status = AgentStatus::Running;
     });
     let handler = app.command_registry.find("/rewind").unwrap();
-    handler.execute(&mut app, None).await;
+    let effect = handler.execute(&mut app, None).await;
     assert!(app.sub_page.is_none());
-    let conv = app.snapshot_active_conversation();
-    let last = conv.messages.last().unwrap();
-    assert!(last.content.contains("Cannot rewind"));
+    let body = match effect {
+        loopal_tui::command::CommandEffect::Reply(s) => s,
+        other => panic!("expected Reply, got {:?}", std::mem::discriminant(&other)),
+    };
+    assert!(body.contains("Cannot rewind"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/loopal-tui/tests/suite/e2e_goal_support.rs
+++ b/crates/loopal-tui/tests/suite/e2e_goal_support.rs
@@ -1,0 +1,134 @@
+//! Shared helpers for `/goal` end-to-end tests.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use loopal_protocol::{AgentEvent, AgentEventPayload, ThreadGoalStatus};
+use loopal_runtime::frontend::traits::EventEmitter;
+use loopal_runtime::goal::GoalRuntimeSession;
+use loopal_storage::GoalStore;
+use loopal_test_support::HarnessBuilder;
+use loopal_tui::app::App;
+use loopal_tui::command::CommandEffect;
+use loopal_tui::dispatch_ops::handle_effect;
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use tempfile::TempDir;
+use tokio::sync::mpsc;
+
+use super::e2e_harness::TuiTestHarness;
+
+pub(super) struct ProxyEmitter {
+    pub tx: mpsc::Sender<AgentEvent>,
+}
+
+#[async_trait]
+impl EventEmitter for ProxyEmitter {
+    async fn emit(&self, payload: AgentEventPayload) -> loopal_error::Result<()> {
+        let _ = self.tx.send(AgentEvent::root(payload)).await;
+        Ok(())
+    }
+}
+
+pub(super) struct GoalScenario {
+    pub _store_dir: TempDir,
+    pub session: Arc<GoalRuntimeSession>,
+    pub proxy_rx: mpsc::Receiver<AgentEvent>,
+    pub harness: TuiTestHarness,
+}
+
+pub(super) async fn setup() -> GoalScenario {
+    let store_dir = TempDir::new().unwrap();
+    let store = Arc::new(GoalStore::with_base_dir(store_dir.path().to_path_buf()));
+    let (proxy_tx, proxy_rx) = mpsc::channel::<AgentEvent>(64);
+    let session = Arc::new(GoalRuntimeSession::new(
+        "e2e-goal-session".into(),
+        store,
+        Box::new(ProxyEmitter { tx: proxy_tx }),
+    ));
+
+    let inner = HarnessBuilder::new()
+        .messages(vec![])
+        .goal_session(session.clone())
+        .build_spawned()
+        .await;
+
+    let terminal = Terminal::new(TestBackend::new(120, 24)).unwrap();
+    let app = App::new(
+        inner.session_ctrl.clone(),
+        inner.fixture.path().to_path_buf(),
+    );
+    let harness = TuiTestHarness {
+        terminal,
+        app,
+        inner,
+    };
+
+    GoalScenario {
+        _store_dir: store_dir,
+        session,
+        proxy_rx,
+        harness,
+    }
+}
+
+pub(super) fn drain_proxy(scenario: &mut GoalScenario) {
+    while let Ok(event) = scenario.proxy_rx.try_recv() {
+        scenario.harness.app.dispatch_event(event);
+    }
+}
+
+pub(super) async fn run_goal(scenario: &mut GoalScenario, arg: Option<&str>) -> CommandEffect {
+    let handler = scenario
+        .harness
+        .app
+        .command_registry
+        .find("/goal")
+        .expect("/goal handler must be registered");
+    let effect = handler.execute(&mut scenario.harness.app, arg).await;
+    handle_effect(&mut scenario.harness.app, copy_effect(&effect)).await;
+    effect
+}
+
+fn copy_effect(effect: &CommandEffect) -> CommandEffect {
+    match effect {
+        CommandEffect::Reply(s) => CommandEffect::Reply(s.clone()),
+        CommandEffect::Done => CommandEffect::Done,
+        _ => panic!(
+            "unexpected effect for /goal: {:?}",
+            std::mem::discriminant(effect)
+        ),
+    }
+}
+
+pub(super) async fn wait_for_status(
+    scenario: &mut GoalScenario,
+    expected: ThreadGoalStatus,
+    timeout: Duration,
+) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        drain_proxy(scenario);
+        if let Some(snap) = scenario.session.snapshot().await.unwrap()
+            && snap.status == expected
+        {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            let snap = scenario.session.snapshot().await.unwrap();
+            panic!("timed out waiting for {expected:?}; current = {snap:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+pub(super) fn last_system_message(app: &App) -> String {
+    let conv = app.snapshot_active_conversation();
+    conv.messages
+        .iter()
+        .rev()
+        .find(|m| m.role == "system")
+        .map(|m| m.content.clone())
+        .unwrap_or_default()
+}

--- a/crates/loopal-tui/tests/suite/e2e_goal_test.rs
+++ b/crates/loopal-tui/tests/suite/e2e_goal_test.rs
@@ -1,0 +1,201 @@
+//! `/goal` end-to-end tests.
+//!
+//! Cover the path TUI handler -> control channel -> agent runtime ->
+//! `GoalRuntimeSession` -> `ThreadGoalUpdated` event -> ViewState
+//! mutator -> status-bar render. The runtime is real; only the LLM
+//! provider is mocked. Goal events ride a proxy `mpsc` because the goal
+//! session is constructed before the wiring channel exists; the test
+//! drains the proxy into `App::dispatch_event` to mirror what the
+//! production frontend forwarder does.
+
+use std::time::Duration;
+
+use loopal_protocol::{AgentStateSnapshot, ThreadGoalStatus};
+use loopal_tui::command::CommandEffect;
+use loopal_tui::view_client::ViewClient;
+use loopal_view_state::{SessionViewState, ViewSnapshot};
+
+use super::e2e_goal_support::{drain_proxy, last_system_message, run_goal, setup, wait_for_status};
+
+const TIMEOUT: Duration = Duration::from_secs(2);
+
+#[tokio::test]
+async fn create_command_drives_runtime_and_renders_status_bar() {
+    let mut scenario = setup().await;
+
+    let effect = run_goal(&mut scenario, Some("ship feature")).await;
+    assert!(
+        matches!(&effect, CommandEffect::Reply(s) if s.contains("ship feature")),
+        "expected Reply with objective, got {:?}",
+        std::mem::discriminant(&effect)
+    );
+    assert!(last_system_message(&scenario.harness.app).contains("ship feature"));
+
+    wait_for_status(&mut scenario, ThreadGoalStatus::Active, TIMEOUT).await;
+
+    let frame = scenario.harness.render_text();
+    assert!(
+        frame.contains("ship feature") && frame.contains("active"),
+        "status bar missing goal indicator:\n{frame}"
+    );
+}
+
+#[tokio::test]
+async fn pause_then_resume_cycle_through_runtime() {
+    let mut scenario = setup().await;
+    run_goal(&mut scenario, Some("ship feature")).await;
+    wait_for_status(&mut scenario, ThreadGoalStatus::Active, TIMEOUT).await;
+
+    run_goal(&mut scenario, Some("pause")).await;
+    wait_for_status(&mut scenario, ThreadGoalStatus::Paused, TIMEOUT).await;
+    let frame = scenario.harness.render_text();
+    assert!(
+        frame.contains("paused"),
+        "expected paused indicator, got:\n{frame}"
+    );
+
+    run_goal(&mut scenario, Some("resume")).await;
+    wait_for_status(&mut scenario, ThreadGoalStatus::Active, TIMEOUT).await;
+}
+
+#[tokio::test]
+async fn clear_command_removes_goal_from_status_bar() {
+    let mut scenario = setup().await;
+    run_goal(&mut scenario, Some("ship feature")).await;
+    wait_for_status(&mut scenario, ThreadGoalStatus::Active, TIMEOUT).await;
+    assert!(scenario.harness.render_text().contains("[active]"));
+
+    run_goal(&mut scenario, Some("clear")).await;
+    let deadline = tokio::time::Instant::now() + TIMEOUT;
+    loop {
+        drain_proxy(&mut scenario);
+        if scenario.session.snapshot().await.unwrap().is_none() {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("goal still present after clear");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // The Reply text "Goal set: ..." stays in the conversation history, so
+    // we can't ask "frame must not contain ship feature". The status bar
+    // indicator is what tracks goal state — its lifecycle bracket label
+    // (active/paused/done/budget) disappears when the goal is cleared.
+    let frame = scenario.harness.render_text();
+    assert!(
+        !frame.contains("[active]")
+            && !frame.contains("[paused]")
+            && !frame.contains("[done]")
+            && !frame.contains("[budget]"),
+        "status indicator still present:\n{frame}"
+    );
+}
+
+#[tokio::test]
+async fn empty_arg_replies_with_usage_and_does_not_create_goal() {
+    let mut scenario = setup().await;
+    let effect = run_goal(&mut scenario, None).await;
+
+    let usage = match effect {
+        CommandEffect::Reply(s) => s,
+        other => panic!(
+            "expected Reply for empty arg, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    };
+    assert!(usage.contains("/goal usage"));
+    assert!(last_system_message(&scenario.harness.app).contains("/goal usage"));
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    drain_proxy(&mut scenario);
+    assert!(
+        scenario.session.snapshot().await.unwrap().is_none(),
+        "no goal should have been created"
+    );
+}
+
+#[tokio::test]
+async fn extend_recovers_from_budget_limited_to_active() {
+    let mut scenario = setup().await;
+
+    // Create with a tiny budget so a synthetic add_usage can blow it.
+    run_goal(&mut scenario, Some("ship --budget=100")).await;
+    wait_for_status(&mut scenario, ThreadGoalStatus::Active, TIMEOUT).await;
+
+    // Side-door budget exhaustion: add_usage is the same hook the runner
+    // uses after each turn. Driving it directly avoids constructing a
+    // mock-LLM Usage chunk stream while still funnelling through the
+    // real GoalRuntimeSession state machine.
+    scenario
+        .session
+        .add_usage(150, 0)
+        .await
+        .expect("add_usage should succeed");
+    wait_for_status(&mut scenario, ThreadGoalStatus::BudgetLimited, TIMEOUT).await;
+    let frame = scenario.harness.render_text();
+    assert!(
+        frame.contains("[budget]"),
+        "expected budget indicator, got:\n{frame}"
+    );
+
+    // Extend bumps budget AND transitions back to Active in one atomic
+    // step. The full pipeline (TUI parse → control → runtime → emit →
+    // dispatch → render) must reflect both halves.
+    run_goal(&mut scenario, Some("extend 1500")).await;
+    wait_for_status(&mut scenario, ThreadGoalStatus::Active, TIMEOUT).await;
+    let snap = scenario.session.snapshot().await.unwrap().unwrap();
+    assert_eq!(snap.token_budget, Some(1600));
+    let frame = scenario.harness.render_text();
+    assert!(
+        frame.contains("[active]"),
+        "expected active indicator after extend, got:\n{frame}"
+    );
+}
+
+#[tokio::test]
+async fn reconnecting_view_client_sees_existing_goal_via_snapshot() {
+    let mut scenario = setup().await;
+
+    // Establish a live goal through the normal command path.
+    run_goal(&mut scenario, Some("ship feature")).await;
+    wait_for_status(&mut scenario, ThreadGoalStatus::Active, TIMEOUT).await;
+
+    // Reproduce the production reconnect hop:
+    //   AgentShared.snapshot_state() -> AgentStateSnapshot
+    //   SessionViewState::from_snapshot()
+    //   ViewSnapshot { state, rev }
+    //   ViewClient::from_snapshot()
+    // ThreadGoalUpdated events fired before reconnect aren't replayed,
+    // so the goal must survive purely on the snapshot wire payload.
+    let live_goal = scenario
+        .session
+        .snapshot()
+        .await
+        .unwrap()
+        .expect("goal exists");
+    let agent_snap = AgentStateSnapshot {
+        tasks: vec![],
+        crons: vec![],
+        bg_tasks: vec![],
+        thread_goal: Some(live_goal.clone()),
+    };
+    let rebuilt = SessionViewState::from_snapshot("main", agent_snap);
+    let view_snap = ViewSnapshot {
+        state: rebuilt,
+        rev: 1,
+    };
+
+    // Replace the live ViewClient with one seeded purely from the
+    // snapshot — the rendered status bar must still show the goal.
+    scenario
+        .harness
+        .app
+        .view_clients
+        .insert("main".into(), ViewClient::from_snapshot("main", view_snap));
+    let frame = scenario.harness.render_text();
+    assert!(
+        frame.contains("ship feature") && frame.contains("[active]"),
+        "reconnected client missing goal indicator:\n{frame}"
+    );
+}

--- a/crates/tools/registry/src/builtin/mod.rs
+++ b/crates/tools/registry/src/builtin/mod.rs
@@ -1,20 +1,15 @@
 use std::sync::Arc;
 
-use loopal_config::Settings;
 use loopal_tool_background::BackgroundTaskStore;
 
 use crate::registry::ToolRegistry;
 
-/// Register all built-in tools with the given registry.
+/// Register all built-in tools that every agent (root or sub) needs.
 ///
-/// `settings` gates feature-flagged tool families: when a feature is
-/// disabled the tools simply don't appear in the LLM tool list, so the
-/// model never sees an option it cannot exercise.
-pub fn register_all(
-    registry: &ToolRegistry,
-    bg_store: Arc<BackgroundTaskStore>,
-    settings: &Settings,
-) {
+/// Role-scoped tools (e.g. thread-goal tools that only make sense on
+/// the root agent that owns the goal session) live in dedicated
+/// `register_*_tools` helpers below; callers pick what to register.
+pub fn register_all(registry: &ToolRegistry, bg_store: Arc<BackgroundTaskStore>) {
     registry.register(Box::new(loopal_tool_apply_patch::ApplyPatchTool));
     registry.register(Box::new(loopal_tool_read::ReadTool));
     registry.register(Box::new(loopal_tool_write::WriteTool));
@@ -31,9 +26,13 @@ pub fn register_all(
     registry.register(Box::new(loopal_tool_file_ops::move_file::MoveFileTool));
     registry.register(Box::new(loopal_tool_file_ops::delete::DeleteTool));
     registry.register(Box::new(loopal_tool_file_ops::copy::CopyFileTool));
-    if settings.goals.enabled {
-        registry.register(Box::new(loopal_tool_goal::GetGoalTool));
-        registry.register(Box::new(loopal_tool_goal::CreateGoalTool));
-        registry.register(Box::new(loopal_tool_goal::UpdateGoalTool));
-    }
+}
+
+/// Register thread-goal tools. Only the root agent owns a `goal_session`,
+/// so sub-agents must NOT call this — registering tools they cannot back
+/// would expose dead options to the model.
+pub fn register_goal_tools(registry: &ToolRegistry) {
+    registry.register(Box::new(loopal_tool_goal::GetGoalTool));
+    registry.register(Box::new(loopal_tool_goal::CreateGoalTool));
+    registry.register(Box::new(loopal_tool_goal::UpdateGoalTool));
 }


### PR DESCRIPTION
## Summary
- `/goal` was a silent black hole: autocomplete dispatched it without an arg, errors went to `tracing::warn!` (invisible under TUI alt-screen), and `settings.goals.enabled=false` dropped every control command at runtime
- Replace the redundant feature gate with role-based registration (root agent only) and remove the hack of mutating `Settings` to signal sub-agent isolation
- Add `CommandEffect::Reply(String)` as the canonical feedback channel and remove `has_arg()` default — both were systemic gaps that let the `/goal` bug exist

## Changes
**Goal feature gate removal**
- `loopal-config/src/settings.rs` — drop `GoalSettings.enabled` field
- `loopal-kernel`, `loopal-tools::builtin` — split `register_goal_tools` from `register_all`; root agents call it explicitly
- `loopal-agent-server` — depth-driven goal session + tool registration; remove `apply_start_overrides` hack
- `loopal-test-support/wiring` — sync test path

**Command system unification**
- `loopal-tui/command/mod.rs` — `CommandEffect::Reply` variant + `has_arg()` no default
- `key_dispatch_ops::handle_effect` — central dispatch through `App::push_system_message`
- 14 handlers updated to declare `has_arg` explicitly; goal/help/agent/rewind/resume migrated to `Reply`

**End-to-end tests** (`crates/loopal-tui/tests/suite/e2e_goal_*.rs`)
- create / pause-resume / clear / empty-arg / extend (BudgetLimited→Active) / reconnect-via-snapshot
- Drives full pipeline: TUI handler → control channel → real `AgentLoopRunner` → `GoalRuntimeSession` → event → `ViewState` mutator → status-bar render
- `SpawnedHarness` exposes `event_tx` so tests can wire goal-session emitters to the same channel the runner uses

## Test plan
- [ ] `bazel test //...` — all 55 targets pass
- [ ] `bazel build //... --config=clippy` — zero warnings
- [ ] `bazel build //... --config=rustfmt` — clean