### PR TITLE
refactor(git): move gitignore SSOT into .loopal/.gitignore

### DIFF
--- a/crates/loopal-git/src/gitignore.rs
+++ b/crates/loopal-git/src/gitignore.rs
@@ -1,0 +1,49 @@
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+const GITIGNORE: &str = "\
+# Auto-managed by Loopal. Do not edit.
+worktrees/
+plans/
+settings.local.json
+LOOPAL.local.md
+";
+
+pub fn ensure_loopal_gitignore(loopal_dir: &Path) {
+    if !is_in_git_worktree(loopal_dir) {
+        return;
+    }
+    let path = loopal_dir.join(".gitignore");
+    if matches!(fs::read_to_string(&path), Ok(s) if s == GITIGNORE) {
+        return;
+    }
+    let _ = atomic_write(&path, GITIGNORE);
+}
+
+fn is_in_git_worktree(start: &Path) -> bool {
+    let mut cur: &Path = start;
+    loop {
+        if cur.join(".git").exists() {
+            return true;
+        }
+        match cur.parent() {
+            Some(p) if p != cur => cur = p,
+            _ => return false,
+        }
+    }
+}
+
+fn atomic_write(path: &Path, contents: &str) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no parent")
+    })?;
+    fs::create_dir_all(parent)?;
+    let tmp = path.with_extension("gitignore.tmp");
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(contents.as_bytes())?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp, path)
+}

--- a/crates/loopal-git/src/lib.rs
+++ b/crates/loopal-git/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod cleanup;
+pub mod gitignore;
 pub mod repo;
 pub mod worktree;
 
 pub use cleanup::cleanup_stale_worktrees;
+pub use gitignore::ensure_loopal_gitignore;
 pub use repo::{current_branch, is_git_repo, repo_root};
 pub use worktree::{
     WorktreeInfo, cleanup_if_clean, create_worktree, remove_worktree, worktree_has_changes,

--- a/crates/loopal-git/src/worktree.rs
+++ b/crates/loopal-git/src/worktree.rs
@@ -1,10 +1,9 @@
 use std::collections::HashSet;
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::GitError;
+use crate::gitignore::ensure_loopal_gitignore;
 
 /// Information about a created worktree.
 #[derive(Debug, Clone)]
@@ -43,7 +42,7 @@ pub fn create_worktree(repo_root: &Path, name: &str) -> Result<WorktreeInfo, Git
         std::fs::create_dir_all(parent)?;
     }
 
-    ensure_gitignore_entry(repo_root);
+    ensure_loopal_gitignore(&repo_root.join(".loopal"));
 
     let output = Command::new("git")
         .args(["worktree", "add", "-b", &branch])
@@ -172,29 +171,4 @@ fn validate_name(name: &str) -> Result<(), GitError> {
         return Err(GitError::InvalidName(name.to_string()));
     }
     Ok(())
-}
-
-/// Append `.loopal/worktrees/` to `.gitignore` if not already present.
-fn ensure_gitignore_entry(repo_root: &Path) {
-    let gitignore = repo_root.join(".gitignore");
-    let entry = ".loopal/worktrees/";
-
-    let content = std::fs::read_to_string(&gitignore).unwrap_or_default();
-    if content.lines().any(|line| line.trim() == entry) {
-        return;
-    }
-
-    // Append-only write to avoid TOCTOU overwrite of concurrent modifications
-    if let Ok(mut file) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&gitignore)
-    {
-        let prefix = if content.is_empty() || content.ends_with('\n') {
-            ""
-        } else {
-            "\n"
-        };
-        let _ = writeln!(file, "{prefix}{entry}");
-    }
 }

--- a/crates/loopal-git/tests/suite.rs
+++ b/crates/loopal-git/tests/suite.rs
@@ -1,4 +1,6 @@
 // Single test binary — includes all test modules
+#[path = "suite/gitignore_test.rs"]
+mod gitignore_test;
 #[path = "suite/repo_test.rs"]
 mod repo_test;
 #[path = "suite/validate_test.rs"]

--- a/crates/loopal-git/tests/suite/gitignore_test.rs
+++ b/crates/loopal-git/tests/suite/gitignore_test.rs
@@ -1,0 +1,97 @@
+use loopal_git::ensure_loopal_gitignore;
+use std::fs;
+
+const EXPECTED: &str = "\
+# Auto-managed by Loopal. Do not edit.
+worktrees/
+plans/
+settings.local.json
+LOOPAL.local.md
+";
+
+#[test]
+fn writes_when_inside_git_worktree() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
+    let loopal = dir.path().join(".loopal");
+    fs::create_dir(&loopal).unwrap();
+
+    ensure_loopal_gitignore(&loopal);
+
+    let content = fs::read_to_string(loopal.join(".gitignore")).unwrap();
+    assert_eq!(content, EXPECTED);
+}
+
+#[test]
+fn noop_when_not_in_git_worktree() {
+    let dir = tempfile::tempdir().unwrap();
+    let loopal = dir.path().join(".loopal");
+    fs::create_dir(&loopal).unwrap();
+
+    ensure_loopal_gitignore(&loopal);
+
+    assert!(!loopal.join(".gitignore").exists());
+}
+
+#[test]
+fn idempotent_when_content_matches() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
+    let loopal = dir.path().join(".loopal");
+    fs::create_dir(&loopal).unwrap();
+
+    ensure_loopal_gitignore(&loopal);
+    let before = fs::metadata(loopal.join(".gitignore"))
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    // Force a measurable time gap so any rewrite would show.
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    ensure_loopal_gitignore(&loopal);
+    let after = fs::metadata(loopal.join(".gitignore"))
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    assert_eq!(before, after, "matching content must not be rewritten");
+}
+
+#[test]
+fn overwrites_stale_user_edited_content() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
+    let loopal = dir.path().join(".loopal");
+    fs::create_dir(&loopal).unwrap();
+    fs::write(loopal.join(".gitignore"), "stale-user-edit\n").unwrap();
+
+    ensure_loopal_gitignore(&loopal);
+
+    let content = fs::read_to_string(loopal.join(".gitignore")).unwrap();
+    assert_eq!(content, EXPECTED);
+}
+
+#[test]
+fn detects_git_worktree_dot_git_as_file() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join(".git"), "gitdir: /elsewhere\n").unwrap();
+    let loopal = dir.path().join(".loopal");
+    fs::create_dir(&loopal).unwrap();
+
+    ensure_loopal_gitignore(&loopal);
+
+    let content = fs::read_to_string(loopal.join(".gitignore")).unwrap();
+    assert_eq!(content, EXPECTED);
+}
+
+#[test]
+fn finds_git_via_parent_traversal() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
+    let nested = dir.path().join("a").join("b").join(".loopal");
+    fs::create_dir_all(&nested).unwrap();
+
+    ensure_loopal_gitignore(&nested);
+
+    assert!(nested.join(".gitignore").exists());
+}

--- a/crates/loopal-git/tests/suite/worktree_test.rs
+++ b/crates/loopal-git/tests/suite/worktree_test.rs
@@ -52,22 +52,28 @@ fn test_worktree_has_changes_detects_modifications() {
 }
 
 #[test]
-fn test_ensure_gitignore_entry() {
+fn test_worktree_creation_writes_loopal_gitignore() {
     let dir = tempfile::tempdir().unwrap();
     init_repo(dir.path());
 
     create_worktree(dir.path(), "gi-test").unwrap();
 
-    let content = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
-    assert!(content.contains(".loopal/worktrees/"));
+    let gi = dir.path().join(".loopal").join(".gitignore");
+    let content = std::fs::read_to_string(&gi).unwrap();
+    assert!(content.contains("worktrees/"));
+    assert!(content.contains("plans/"));
+    assert!(content.contains("settings.local.json"));
+    assert!(content.contains("LOOPAL.local.md"));
 
-    // Second create should not duplicate the entry
+    // Outer .gitignore must NOT be touched by the new mechanism.
+    assert!(!dir.path().join(".gitignore").exists());
+
+    // Second create remains idempotent: same content, no duplication.
+    let before = std::fs::read_to_string(&gi).unwrap();
     remove_worktree(dir.path(), "gi-test", false).unwrap();
     create_worktree(dir.path(), "gi-test2").unwrap();
-
-    let content = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
-    let count = content.matches(".loopal/worktrees/").count();
-    assert_eq!(count, 1, "gitignore entry should not be duplicated");
+    let after = std::fs::read_to_string(&gi).unwrap();
+    assert_eq!(before, after);
 
     remove_worktree(dir.path(), "gi-test2", false).unwrap();
 }

--- a/crates/loopal-runtime/src/agent_loop/tools_plan.rs
+++ b/crates/loopal-runtime/src/agent_loop/tools_plan.rs
@@ -84,6 +84,12 @@ impl AgentLoopRunner {
             ));
         }
 
+        if let Some(plans_dir) = self.plan_file.path().parent()
+            && let Some(loopal_dir) = plans_dir.parent()
+        {
+            loopal_git::ensure_loopal_gitignore(loopal_dir);
+        }
+
         let plan_path = self.plan_file.path().display();
         let file_info = if self.plan_file.exists() {
             format!("A plan file already exists at {plan_path}. Read it and edit incrementally.")


### PR DESCRIPTION
## Summary

- 把 `.loopal/` 的 gitignore 维护从「污染项目根 `.gitignore`」改为「自治的 `.loopal/.gitignore`」
- 新机制是 SSOT：一次性列出所有 ephemeral 项（worktrees、plans、settings.local.json、LOOPAL.local.md），新增子目录只改一处
- 触发点：首次创建 worktree 时 + 进入 plan mode 时；仅在 git worktree 下执行；幂等（内容比对 + atomic rename）

## Why

旧的 `ensure_gitignore_entry` 在每次 worktree 创建时往**项目根** `.gitignore` 追加 `.loopal/worktrees/`：

- 侵入用户文件，且需要为每种 ephemeral 目录单独维护"追加哪一行"
- 实证翻车：`.plans/` 加入后忘了同步追加，导致本仓库 `.gitignore` 手工补了 `.loopal/plans/`

新的 `ensure_loopal_gitignore` 写一份固定模板到 `<project>/.loopal/.gitignore`，git 嵌套 ignore 天然支持。归属在 `loopal-git`（git 关注点，保持其零 loopal deps 属性；`loopal-runtime` 已经依赖它，无需新加 dep）。

## Changes

- **新增** `crates/loopal-git/src/gitignore.rs`（49 行）—— `ensure_loopal_gitignore` + `is_in_git_worktree`（父级遍历，支持 `.git` 为文件的 worktree 场景）+ `atomic_write`
- **新增** `crates/loopal-git/tests/suite/gitignore_test.rs`（6 个 case：git 仓库下写入 / 非 git 仓库 no-op / 内容匹配幂等 / 覆盖用户编辑 / `.git` 是文件 / 父级遍历）
- **删除** `crates/loopal-git/src/worktree.rs` 中的旧 `ensure_gitignore_entry`（30 行 → 删）
- **修改** `crates/loopal-git/tests/suite/worktree_test.rs` —— 旧测试改为验证 `.loopal/.gitignore` 内容齐全且**未触碰**项目根 `.gitignore`
- **修改** `crates/loopal-runtime/src/agent_loop/tools_plan.rs` —— 进 plan mode 创建 `plans/` 目录后追加调用

## SSOT 文件内容

```
# Auto-managed by Loopal. Do not edit.
worktrees/
plans/
settings.local.json
LOOPAL.local.md
```

## Test plan

- [x] `bazel test //...` 58 个测试全过
- [x] `bazel build //... --config=clippy` 112 targets 零警告
- [x] 新增 6 个 gitignore 单测覆盖所有分支
- [x] worktree 测试改造后断言外层 `.gitignore` 未被触碰
- [ ] CI passes