### PR TITLE
refactor(view-state): silence allow-path decision echoes

### DIFF
--- a/crates/loopal-view-state/src/mutators/interactive.rs
+++ b/crates/loopal-view-state/src/mutators/interactive.rs
@@ -1,4 +1,4 @@
-use loopal_protocol::{MessageSource, ResolveSource};
+use loopal_protocol::MessageSource;
 
 use crate::SessionMessage;
 use crate::conversation::{PendingPermission, conversation_display};
@@ -112,10 +112,13 @@ pub(super) fn permission_decided(
     reason: &str,
     duration_ms: u64,
 ) -> bool {
-    let label = match decision {
-        "allow" => "permission allowed",
-        "deny" => "permission denied",
-        _ => "permission",
+    if decision == "allow" {
+        return false;
+    }
+    let label = if decision == "deny" {
+        "permission denied"
+    } else {
+        "permission"
     };
     let suffix = if duration_ms > 0 {
         format!(" ({duration_ms}ms)")
@@ -126,28 +129,6 @@ pub(super) fn permission_decided(
         format!("[{label}] {tool_name}{suffix}")
     } else {
         format!("[{label}] {tool_name}: {reason}{suffix}")
-    };
-    conversation_display::push_system_msg(&mut state.agent.conversation, &line);
-    true
-}
-
-pub(super) fn question_decided(
-    state: &mut SessionViewState,
-    question_count: u32,
-    reason: &str,
-    duration_ms: u64,
-    source: ResolveSource,
-) -> bool {
-    let suffix = if duration_ms > 0 {
-        format!(" ({duration_ms}ms)")
-    } else {
-        String::new()
-    };
-    let label = format!("[ask-user] {}", source.as_str());
-    let line = if reason.is_empty() {
-        format!("{label}: {question_count} question(s){suffix}")
-    } else {
-        format!("{label}: {reason}{suffix}")
     };
     conversation_display::push_system_msg(&mut state.agent.conversation, &line);
     true

--- a/crates/loopal-view-state/src/mutators/mod.rs
+++ b/crates/loopal-view-state/src/mutators/mod.rs
@@ -117,12 +117,6 @@ pub(crate) fn mutate(state: &mut SessionViewState, event: &AgentEventPayload) ->
             reason,
             duration_ms,
         } => interactive::permission_decided(state, tool_name, decision, reason, *duration_ms),
-        QuestionDecided {
-            question_count,
-            duration_ms,
-            reason,
-            source,
-        } => interactive::question_decided(state, *question_count, reason, *duration_ms, *source),
         ModeChanged { mode } => lifecycle::mode_changed(state, mode),
         ModelChanged { model } => lifecycle::model_changed(state, model),
         ThinkingChanged { thinking_config } => lifecycle::thinking_changed(state, thinking_config),
@@ -145,6 +139,7 @@ pub(crate) fn mutate(state: &mut SessionViewState, event: &AgentEventPayload) ->
         MessageRouted { .. }
         | InboxConsumed { .. }
         | TurnDiffSummary { .. }
-        | SessionResumeWarnings { .. } => false,
+        | SessionResumeWarnings { .. }
+        | QuestionDecided { .. } => false,
     }
 }

--- a/crates/loopal-view-state/tests/suite/decided_mutators_test.rs
+++ b/crates/loopal-view-state/tests/suite/decided_mutators_test.rs
@@ -12,38 +12,59 @@ fn last_message_content(r: &ViewStateReducer) -> String {
         .clone()
 }
 
+fn message_count(r: &ViewStateReducer) -> usize {
+    r.state().agent.conversation.messages.len()
+}
+
 #[test]
-fn permission_decided_allow_with_reason_and_duration() {
+fn permission_decided_allow_is_silent() {
     let mut r = ViewStateReducer::new("root");
+    let before = message_count(&r);
     let bumped = r.apply(AgentEventPayload::PermissionDecided {
         tool_name: "Bash".into(),
         decision: "allow".into(),
         reason: "normal cargo test".into(),
         duration_ms: 42,
     });
-    assert!(bumped.is_some(), "permission_decided must bump rev");
-    let msg = last_message_content(&r);
-    assert!(msg.contains("permission allowed"), "label missing: {msg}");
-    assert!(msg.contains("Bash"), "tool name missing: {msg}");
-    assert!(msg.contains("normal cargo test"), "reason missing: {msg}");
-    assert!(msg.contains("(42ms)"), "duration missing: {msg}");
+    assert!(bumped.is_none(), "allow must not bump rev");
+    assert_eq!(
+        message_count(&r),
+        before,
+        "allow must not push a system msg"
+    );
+}
+
+#[test]
+fn permission_decided_allow_empty_reason_is_silent() {
+    let mut r = ViewStateReducer::new("root");
+    let before = message_count(&r);
+    let bumped = r.apply(AgentEventPayload::PermissionDecided {
+        tool_name: "Read".into(),
+        decision: "allow".into(),
+        reason: String::new(),
+        duration_ms: 0,
+    });
+    assert!(bumped.is_none(), "allow must not bump rev");
+    assert_eq!(message_count(&r), before, "allow must not push msg");
 }
 
 #[test]
 fn permission_decided_deny_without_duration() {
     let mut r = ViewStateReducer::new("root");
-    r.apply(AgentEventPayload::PermissionDecided {
+    let bumped = r.apply(AgentEventPayload::PermissionDecided {
         tool_name: "rm -rf".into(),
         decision: "deny".into(),
         reason: "dangerous".into(),
         duration_ms: 0,
     });
+    assert!(bumped.is_some(), "deny must bump rev");
     let msg = last_message_content(&r);
     assert!(
         msg.contains("permission denied"),
         "deny label missing: {msg}"
     );
     assert!(msg.contains("rm -rf"), "tool name missing: {msg}");
+    assert!(msg.contains("dangerous"), "reason missing: {msg}");
     assert!(
         !msg.contains("(0ms)"),
         "zero duration must be omitted: {msg}"
@@ -51,105 +72,107 @@ fn permission_decided_deny_without_duration() {
 }
 
 #[test]
-fn permission_decided_empty_reason_omits_colon() {
+fn permission_decided_deny_with_duration() {
     let mut r = ViewStateReducer::new("root");
     r.apply(AgentEventPayload::PermissionDecided {
-        tool_name: "Read".into(),
-        decision: "allow".into(),
+        tool_name: "Bash".into(),
+        decision: "deny".into(),
+        reason: "policy".into(),
+        duration_ms: 1500,
+    });
+    let msg = last_message_content(&r);
+    assert!(msg.contains("permission denied"), "deny label: {msg}");
+    assert!(msg.contains("(1500ms)"), "duration must appear: {msg}");
+}
+
+#[test]
+fn permission_decided_deny_empty_reason_omits_colon() {
+    let mut r = ViewStateReducer::new("root");
+    r.apply(AgentEventPayload::PermissionDecided {
+        tool_name: "Edit".into(),
+        decision: "deny".into(),
         reason: String::new(),
-        duration_ms: 12,
+        duration_ms: 0,
     });
     let msg = last_message_content(&r);
     assert!(
         !msg.contains(": "),
         "no reason → no ': reason' segment, got: {msg}"
     );
-    assert!(
-        msg.contains("(12ms)"),
-        "duration should still appear: {msg}"
-    );
-    assert!(msg.contains("Read"));
+    assert!(msg.contains("Edit"));
 }
 
 #[test]
 fn permission_decided_unknown_decision_uses_neutral_label() {
     let mut r = ViewStateReducer::new("root");
-    r.apply(AgentEventPayload::PermissionDecided {
+    let bumped = r.apply(AgentEventPayload::PermissionDecided {
         tool_name: "Tool".into(),
         decision: "ask".into(),
         reason: "intermediate".into(),
         duration_ms: 0,
     });
+    assert!(
+        bumped.is_some(),
+        "unknown decision still pushes (diagnostic)"
+    );
     let msg = last_message_content(&r);
-    // "ask" or any unknown decision uses the bare "permission" label
     assert!(msg.contains("[permission]"), "neutral label missing: {msg}");
     assert!(!msg.contains("permission allowed"));
     assert!(!msg.contains("permission denied"));
 }
 
 #[test]
-fn question_decided_with_reason_and_duration() {
+fn question_decided_manual_is_silent() {
     let mut r = ViewStateReducer::new("root");
+    let before = message_count(&r);
     let bumped = r.apply(AgentEventPayload::QuestionDecided {
         question_count: 3,
         duration_ms: 150,
         reason: "chose conservative defaults".into(),
         source: ResolveSource::Manual,
     });
-    assert!(bumped.is_some(), "question_decided must bump rev");
-    let msg = last_message_content(&r);
-    assert!(msg.contains("[ask-user] manual"), "label missing: {msg}");
-    assert!(
-        msg.contains("chose conservative defaults"),
-        "reason missing: {msg}"
-    );
-    assert!(msg.contains("(150ms)"), "duration missing: {msg}");
+    assert!(bumped.is_none(), "question_decided must not bump rev");
+    assert_eq!(message_count(&r), before, "must not push system msg");
 }
 
 #[test]
-fn question_decided_empty_reason_falls_back_to_count() {
+fn question_decided_classifier_is_silent() {
     let mut r = ViewStateReducer::new("root");
-    r.apply(AgentEventPayload::QuestionDecided {
-        question_count: 1,
-        duration_ms: 0,
-        reason: String::new(),
-        source: ResolveSource::Manual,
-    });
-    let msg = last_message_content(&r);
-    assert!(msg.contains("1 question(s)"), "count missing: {msg}");
-    assert!(!msg.contains("(0ms)"), "zero duration must be omitted");
-}
-
-#[test]
-fn question_decided_classifier_source_in_label() {
-    let mut r = ViewStateReducer::new("root");
-    r.apply(AgentEventPayload::QuestionDecided {
+    let before = message_count(&r);
+    let bumped = r.apply(AgentEventPayload::QuestionDecided {
         question_count: 1,
         duration_ms: 8200,
         reason: "代码探索".into(),
         source: ResolveSource::Classifier,
     });
-    let msg = last_message_content(&r);
-    assert!(
-        msg.contains("[ask-user] classifier"),
-        "classifier label missing: {msg}"
-    );
-    assert!(msg.contains("代码探索"), "answer missing: {msg}");
-    assert!(msg.contains("(8200ms)"));
+    assert!(bumped.is_none(), "classifier source must not bump rev");
+    assert_eq!(message_count(&r), before);
 }
 
 #[test]
-fn question_decided_agent_source_in_label() {
+fn question_decided_agent_is_silent() {
     let mut r = ViewStateReducer::new("root");
-    r.apply(AgentEventPayload::QuestionDecided {
+    let before = message_count(&r);
+    let bumped = r.apply(AgentEventPayload::QuestionDecided {
         question_count: 1,
         duration_ms: 24500,
         reason: "looked at git status".into(),
         source: ResolveSource::Agent,
     });
-    let msg = last_message_content(&r);
-    assert!(
-        msg.contains("[ask-user] agent"),
-        "agent label missing: {msg}"
-    );
+    assert!(bumped.is_none(), "agent source must not bump rev");
+    assert_eq!(message_count(&r), before);
+}
+
+#[test]
+fn question_decided_empty_reason_is_silent() {
+    let mut r = ViewStateReducer::new("root");
+    let before = message_count(&r);
+    let bumped = r.apply(AgentEventPayload::QuestionDecided {
+        question_count: 1,
+        duration_ms: 0,
+        reason: String::new(),
+        source: ResolveSource::Manual,
+    });
+    assert!(bumped.is_none());
+    assert_eq!(message_count(&r), before);
 }

--- a/crates/loopal-view-state/tests/suite/e2e_resolve_source_propagation_test.rs
+++ b/crates/loopal-view-state/tests/suite/e2e_resolve_source_propagation_test.rs
@@ -1,74 +1,52 @@
-// E2E: ResolveSource (protocol enum) → AgentEventPayload::QuestionDecided
-// → view-state mutator → conversation system message string.
-// Locks the wire-to-UI contract for each of the three sources.
-
 use loopal_protocol::{AgentEventPayload, ResolveSource};
 use loopal_view_state::ViewStateReducer;
 
-fn last_system_line(r: &ViewStateReducer) -> String {
-    r.state()
-        .agent
-        .conversation
-        .messages
-        .last()
-        .expect("a message should have been pushed")
-        .content
-        .clone()
+fn message_count(r: &ViewStateReducer) -> usize {
+    r.state().agent.conversation.messages.len()
 }
 
-fn apply_decided(r: &mut ViewStateReducer, source: ResolveSource, reason: &str) {
+fn apply_decided(r: &mut ViewStateReducer, source: ResolveSource, reason: &str) -> Option<u64> {
     r.apply(AgentEventPayload::QuestionDecided {
         question_count: 1,
         duration_ms: 1234,
         reason: reason.into(),
         source,
-    });
+    })
 }
 
 #[test]
-fn manual_source_propagates_to_system_msg() {
+fn manual_source_does_not_emit_system_msg() {
     let mut r = ViewStateReducer::new("root");
-    apply_decided(&mut r, ResolveSource::Manual, "user picked X");
-    let msg = last_system_line(&r);
-    assert!(
-        msg.contains("[ask-user] manual"),
-        "manual label missing: {msg}"
-    );
-    assert!(msg.contains("user picked X"), "reason missing: {msg}");
-    assert!(msg.contains("(1234ms)"), "duration missing: {msg}");
+    let before = message_count(&r);
+    let bumped = apply_decided(&mut r, ResolveSource::Manual, "user picked X");
+    assert!(bumped.is_none(), "manual must not bump rev");
+    assert_eq!(message_count(&r), before);
 }
 
 #[test]
-fn classifier_source_propagates_to_system_msg() {
+fn classifier_source_does_not_emit_system_msg() {
     let mut r = ViewStateReducer::new("root");
-    apply_decided(&mut r, ResolveSource::Classifier, "classifier inferred");
-    let msg = last_system_line(&r);
-    assert!(
-        msg.contains("[ask-user] classifier"),
-        "classifier label missing: {msg}"
-    );
-    assert!(msg.contains("classifier inferred"));
+    let before = message_count(&r);
+    let bumped = apply_decided(&mut r, ResolveSource::Classifier, "classifier inferred");
+    assert!(bumped.is_none(), "classifier must not bump rev");
+    assert_eq!(message_count(&r), before);
 }
 
 #[test]
-fn agent_source_propagates_to_system_msg() {
+fn agent_source_does_not_emit_system_msg() {
     let mut r = ViewStateReducer::new("root");
-    apply_decided(
+    let before = message_count(&r);
+    let bumped = apply_decided(
         &mut r,
         ResolveSource::Agent,
         "sub-agent looked at git status",
     );
-    let msg = last_system_line(&r);
-    assert!(
-        msg.contains("[ask-user] agent"),
-        "agent label missing: {msg}"
-    );
-    assert!(msg.contains("sub-agent looked at git status"));
+    assert!(bumped.is_none(), "agent must not bump rev");
+    assert_eq!(message_count(&r), before);
 }
 
 #[test]
 fn resolve_source_serde_canonical_roundtrip() {
-    // Round-trip via JSON to lock the wire encoding for each variant.
     for (variant, expected) in [
         (ResolveSource::Manual, "\"manual\""),
         (ResolveSource::Classifier, "\"classifier\""),


### PR DESCRIPTION
## Summary
- PermissionDecided allow + QuestionDecided no longer push a system msg into the conversation; deny still renders for diagnostic value
- Drops the now-empty `question_decided` mutator and folds `QuestionDecided` into the existing non-rendering arm next to `MessageRouted | InboxConsumed | TurnDiffSummary | SessionResumeWarnings`
- Wire / IPC / telemetry / classifier `info!` log are untouched — only the view-state renderer stops echoing the success path

## Why
Every tool call in Classifier-decision mode was producing `[permission allowed] Edit: ... (2469ms)`-style lines that re-echoed the LLM's self-justification with no actionable value. Manual mode produced `(0ms)` echoes right after the user clicked allow. Deny information is still surfaced; if you want allow-path traces, look at the tracing log.

## Changes
- `crates/loopal-view-state/src/mutators/interactive.rs` — `permission_decided` early-returns `false` on `allow`; deny/unknown still push; `question_decided` removed
- `crates/loopal-view-state/src/mutators/mod.rs` — `QuestionDecided { .. }` joined the `=> false` non-rendering group
- `crates/loopal-view-state/tests/suite/decided_mutators_test.rs` — allow / all `question_decided` paths now assert `bumped.is_none()` + no msg pushed; deny + unknown coverage retained
- `crates/loopal-view-state/tests/suite/e2e_resolve_source_propagation_test.rs` — rewritten: three sources assert silence; serde wire contract preserved

## Test plan
- [x] `bazel test //crates/loopal-view-state:loopal-view-state_test` PASSED
- [x] `bazel test //...` 58/58 PASSED
- [x] `bazel build //... --config=clippy` zero warnings
- [x] `bazel build //... --config=rustfmt` clean
- [ ] CI passes