### PR TITLE
fix(tui): guard render paths against tiny terminals

### DIFF
--- a/crates/loopal-tui/src/views/picker.rs
+++ b/crates/loopal-tui/src/views/picker.rs
@@ -120,8 +120,9 @@ fn render_thinking_indicator(f: &mut Frame, picker: &PickerState, area: Rect) {
         Span::styled(" ▶ ", Style::default().fg(Color::Magenta)),
     ]);
     // Estimate width: " Thinking: ◀ {label} ▶ " ~ 18 + label.len()
-    let w = (18 + label.len()).min(area.width as usize - 2) as u16;
-    let x = area.x + area.width - w - 1; // -1 for right border
+    let budget = area.width.saturating_sub(2) as usize;
+    let w = (18 + label.len()).min(budget) as u16;
+    let x = area.x + area.width.saturating_sub(w + 1); // -1 for right border
     let indicator_area = Rect::new(x, area.y, w, 1);
     f.render_widget(Paragraph::new(indicator), indicator_area);
 }

--- a/crates/loopal-tui/src/views/topology_overlay/layout.rs
+++ b/crates/loopal-tui/src/views/topology_overlay/layout.rs
@@ -111,13 +111,26 @@ pub fn compute_overlay_width(placed: &[PlacedNode], max_w: u16) -> u16 {
         .max()
         .unwrap_or(12);
     let span = ((x_max - x_min) / 4.0).ceil() as u16 + 1;
-    (span.max(max_label as u16) + 4).clamp(24, max_w * 60 / 100)
+    let desired = span.max(max_label as u16) + 4;
+    let upper = max_w.saturating_mul(60) / 100;
+    safe_clamp(desired, 24, upper)
 }
 
 pub fn compute_overlay_height(placed: &[PlacedNode], max_h: u16) -> u16 {
     let (_, _, y_min, y_max) = canvas_bounds(placed);
     let depth = ((y_max - y_min) / 4.0).ceil() as u16 + 1;
-    (depth * 3 + 2).clamp(8, max_h / 2)
+    let desired = depth.saturating_mul(3) + 2;
+    safe_clamp(desired, 8, max_h / 2)
+}
+
+// reason: u16::clamp panics if lower > upper; in TUI render paths the upper
+// bound is derived from a runtime area size that can drop below the lower
+// constant on tiny terminals. Collapse the lower bound onto the upper so the
+// invariant holds, then expand the upper to never sit below the lower.
+fn safe_clamp(value: u16, lower: u16, upper: u16) -> u16 {
+    let lo = lower.min(upper);
+    let hi = upper.max(lo);
+    value.clamp(lo, hi)
 }
 
 #[cfg(test)]
@@ -180,5 +193,37 @@ mod tests {
         // Check they are evenly spaced
         assert_eq!(xs.len(), 3);
         assert!((xs[1] - xs[0] - H_SPACING).abs() < 0.01);
+    }
+
+    #[test]
+    fn overlay_width_does_not_panic_on_tiny_terminal() {
+        let placed = compute_layout(&[
+            make_node("root", None, &["a"]),
+            make_node("a", Some("root"), &[]),
+        ]);
+        for w in [0u16, 1, 10, 20, 39, 40, 80, 200] {
+            let _ = compute_overlay_width(&placed, w);
+        }
+    }
+
+    #[test]
+    fn overlay_height_does_not_panic_on_tiny_terminal() {
+        let placed = compute_layout(&[
+            make_node("root", None, &["a"]),
+            make_node("a", Some("root"), &[]),
+        ]);
+        for h in [0u16, 1, 7, 14, 15, 16, 24, 100] {
+            let _ = compute_overlay_height(&placed, h);
+        }
+    }
+
+    #[test]
+    fn safe_clamp_handles_inverted_bounds() {
+        assert_eq!(safe_clamp(10, 8, 4), 4);
+        assert_eq!(safe_clamp(2, 8, 4), 4);
+        assert_eq!(safe_clamp(100, 8, 0), 0);
+        assert_eq!(safe_clamp(50, 10, 80), 50);
+        assert_eq!(safe_clamp(5, 10, 80), 10);
+        assert_eq!(safe_clamp(200, 10, 80), 80);
     }
 }

--- a/crates/loopal-tui/src/views/topology_overlay/mod.rs
+++ b/crates/loopal-tui/src/views/topology_overlay/mod.rs
@@ -111,6 +111,9 @@ pub fn render_topology_overlay(f: &mut Frame, nodes: &[TopologyNode], area: Rect
     if nodes.len() <= 1 {
         return; // Only root, no sub-agents
     }
+    if area.width < 40 || area.height < 16 {
+        return; // Terminal too small to host overlay
+    }
 
     let placed = layout::compute_layout(nodes);
     if placed.is_empty() {


### PR DESCRIPTION
## Summary
- iPad mosh terminals (~14 rows) crashed loopal at boot: `compute_overlay_height` called `u16::clamp(8, max_h / 2)` and panicked on `min > max`. Same shape in `compute_overlay_width` for `max_w < 40`.
- Hardened the TUI render path so no view panics on extreme terminal sizes, plus added regression coverage.

## Changes
- `crates/loopal-tui/src/views/topology_overlay/layout.rs` — introduce `safe_clamp` that collapses inverted (lower, upper) pairs before delegating to `u16::clamp`; rewrite `compute_overlay_width` / `compute_overlay_height` to use it.
- `crates/loopal-tui/src/views/topology_overlay/mod.rs` — minimum-area guard (`area.width < 40 || area.height < 16`) at `render_topology_overlay` entry; small terminals skip the overlay rather than fight for space.
- `crates/loopal-tui/src/views/picker.rs` — `render_thinking_indicator` uses `saturating_sub`, removing the implicit reliance on the upstream `area.width < 30` early-return guard.
- Regression tests cover `max_w/max_h ∈ {0, 1, 7, 14, 15, 16, 39, 40, ...}` plus `safe_clamp` inverted-bounds cases.

## Test plan
- [x] `bazel test //crates/loopal-tui:loopal-tui_test` (local — passes)
- [x] `bazel build //crates/loopal-tui:loopal-tui --config=clippy` (local — clean)
- [ ] CI passes