### PR TITLE
refactor(scheduler): async save worker + test consolidation

### DIFF
--- a/crates/loopal-agent-server/src/cron_bridge.rs
+++ b/crates/loopal-agent-server/src/cron_bridge.rs
@@ -8,7 +8,7 @@
 //! scheduler's job set may have changed:
 //!   - `add` / `remove` mutations
 //!   - `switch_session` (resume) installs a new set
-//!   - `tick_loop` fired/expired any task this tick (incl. recurring's
+//!   - `tick_loop` fired any task this tick (incl. recurring's
 //!     `last_fired` updates that don't change the user-visible set)
 //!
 //! That last source makes the diff-skip useful as a final filter:

--- a/crates/loopal-agent-server/src/session_start.rs
+++ b/crates/loopal-agent-server/src/session_start.rs
@@ -102,6 +102,14 @@ pub(crate) async fn start_session(
         {
             tracing::warn!(error = %e, "failed to bind scheduler to session");
         }
+        // Wait for the previous session's flush + this session's
+        // normalization save to land on disk before the tick loop
+        // starts firing. Setup-time block is acceptable; tick-time
+        // saves remain fire-and-forget.
+        scheduler_for_bridge.wait_idle().await;
+        // Tick loop activates after switch_session so the first survey
+        // sees the loaded task set, not an empty in-memory state.
+        agent_shared_for_session.scheduler_handle.start();
 
         let session_id = agent_params.session().id.clone();
         tracing::Span::current().record("session.id", session_id.as_str());

--- a/crates/loopal-agent/src/shared.rs
+++ b/crates/loopal-agent/src/shared.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use loopal_ipc::connection::Connection;
@@ -8,7 +9,7 @@ use loopal_kernel::Kernel;
 use loopal_message::Message;
 use loopal_protocol::{AgentEvent, AgentStateSnapshot, Envelope, MessageSource};
 use loopal_runtime::GoalRuntimeSession;
-use loopal_scheduler::CronScheduler;
+use loopal_scheduler::{CronScheduler, ScheduledTrigger};
 
 use crate::state_snapshot::{cron_info_to_snapshot, task_to_snapshot};
 use crate::task_store::TaskStore;
@@ -16,32 +17,33 @@ use crate::types::TaskStatus;
 
 /// Handle to the per-agent cron scheduler.
 ///
-/// Owns the `CronScheduler` (for tool access) and the `CancellationToken`
-/// (to stop the tick loop on drop).
+/// The tick loop does NOT start at construction. Callers must invoke
+/// [`start`](SchedulerHandle::start) after binding the scheduler to a
+/// session via `switch_session` so the first survey sees the loaded
+/// task set rather than running empty.
 pub struct SchedulerHandle {
     pub scheduler: Arc<CronScheduler>,
     cancel: CancellationToken,
+    /// Trigger sender held until `start()` activates the tick loop.
+    /// `None` after `start()` returns, or when constructed via `new`
+    /// (which expects the caller to drive lifecycle manually).
+    pending: std::sync::Mutex<Option<mpsc::Sender<ScheduledTrigger>>>,
 }
 
 impl SchedulerHandle {
-    /// Create a fully wired scheduler pipeline.
-    ///
-    /// Starts the tick loop and an adapter task that converts
-    /// `ScheduledTrigger` → `Envelope` for the agent loop.
-    /// Returns the handle (for tools) and a receiver (for `AgentLoopParams`).
-    pub fn create() -> (Self, tokio::sync::mpsc::Receiver<Envelope>) {
+    pub fn create() -> (Self, mpsc::Receiver<Envelope>) {
         Self::create_with_scheduler(Arc::new(CronScheduler::new()))
     }
 
-    /// Create with a custom `CronScheduler` (e.g., one using `ManualClock`).
+    /// Build a handle wrapping `scheduler`. Spawns the trigger→Envelope
+    /// adapter so the returned receiver is wired immediately, but the
+    /// cron tick loop stays idle until `start()` is called.
     pub fn create_with_scheduler(
         scheduler: Arc<CronScheduler>,
-    ) -> (Self, tokio::sync::mpsc::Receiver<Envelope>) {
+    ) -> (Self, mpsc::Receiver<Envelope>) {
         let cancel = CancellationToken::new();
-        let (trigger_tx, mut trigger_rx) = tokio::sync::mpsc::channel(16);
-        scheduler.start(trigger_tx, cancel.clone());
-
-        let (env_tx, env_rx) = tokio::sync::mpsc::channel(16);
+        let (trigger_tx, mut trigger_rx) = mpsc::channel::<ScheduledTrigger>(16);
+        let (env_tx, env_rx) = mpsc::channel(16);
         tokio::spawn(async move {
             while let Some(t) = trigger_rx.recv().await {
                 let env = Envelope::new(MessageSource::Scheduled, "self", t.prompt);
@@ -51,13 +53,37 @@ impl SchedulerHandle {
             }
         });
 
-        (Self { scheduler, cancel }, env_rx)
+        (
+            Self {
+                scheduler,
+                cancel,
+                pending: std::sync::Mutex::new(Some(trigger_tx)),
+            },
+            env_rx,
+        )
     }
 
-    /// Create a handle without starting the pipeline (for tests that
-    /// manage the scheduler lifecycle manually).
+    /// Start the cron tick loop. Idempotent at this layer: the second
+    /// call observes `pending == None` and returns silently. The
+    /// underlying `CronScheduler::start` still asserts single-start —
+    /// this wrapper's `pending.take()` ensures that contract is only
+    /// reached once even when `start()` is invoked repeatedly.
+    pub fn start(&self) {
+        let tx = match self.pending.lock().unwrap().take() {
+            Some(tx) => tx,
+            None => return,
+        };
+        self.scheduler.start(tx, self.cancel.clone());
+    }
+
+    /// Construct without the adapter pipeline — for tests that drive
+    /// the scheduler lifecycle directly.
     pub fn new(scheduler: Arc<CronScheduler>, cancel: CancellationToken) -> Self {
-        Self { scheduler, cancel }
+        Self {
+            scheduler,
+            cancel,
+            pending: std::sync::Mutex::new(None),
+        }
     }
 }
 

--- a/crates/loopal-agent/src/tools/cron.rs
+++ b/crates/loopal-agent/src/tools/cron.rs
@@ -38,7 +38,7 @@ impl Tool for CronCreateTool {
          between a one-shot firing and the post-fire save, it may re-fire \
          exactly once on the next resume. \
          Jobs only fire while the agent is idle. \
-         Recurring jobs auto-expire after 3 days. Max 50 concurrent jobs."
+         Max 50 concurrent jobs."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/crates/loopal-agent/src/tools/cron.rs
+++ b/crates/loopal-agent/src/tools/cron.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use loopal_error::LoopalError;
-use loopal_scheduler::CronScheduler;
+use loopal_scheduler::{CronScheduler, MAX_PROMPT_CHARS};
 use loopal_tool_api::{PermissionLevel, Tool, ToolContext, ToolResult};
 use serde_json::{Value, json};
 
@@ -79,8 +79,10 @@ impl Tool for CronCreateTool {
         let prompt = input["prompt"].as_str().ok_or(LoopalError::Tool(
             loopal_error::ToolError::InvalidInput("prompt is required".into()),
         ))?;
-        if prompt.len() > 4096 {
-            return Ok(ToolResult::error("prompt exceeds 4096 character limit"));
+        if prompt.chars().count() > MAX_PROMPT_CHARS {
+            return Ok(ToolResult::error(format!(
+                "prompt exceeds {MAX_PROMPT_CHARS} character limit"
+            )));
         }
         if prompt.is_empty() {
             return Ok(ToolResult::error("prompt cannot be empty"));

--- a/crates/loopal-scheduler/src/clock.rs
+++ b/crates/loopal-scheduler/src/clock.rs
@@ -1,13 +1,9 @@
-//! Clock abstraction for deterministic time control in tests.
-
 use chrono::{DateTime, Utc};
 
-/// Provides the current time. Inject into `CronScheduler` for testability.
 pub trait Clock: Send + Sync + 'static {
     fn now(&self) -> DateTime<Utc>;
 }
 
-/// Production clock — delegates to `Utc::now()`.
 pub struct SystemClock;
 
 impl Clock for SystemClock {
@@ -16,7 +12,6 @@ impl Clock for SystemClock {
     }
 }
 
-/// Test clock with manually controlled time.
 pub struct ManualClock {
     now: std::sync::Mutex<DateTime<Utc>>,
 }
@@ -28,12 +23,10 @@ impl ManualClock {
         }
     }
 
-    /// Set the current time to an absolute value.
     pub fn set(&self, time: DateTime<Utc>) {
         *self.now.lock().unwrap() = time;
     }
 
-    /// Advance the current time by `duration`.
     pub fn advance(&self, duration: chrono::Duration) {
         let mut now = self.now.lock().unwrap();
         *now += duration;

--- a/crates/loopal-scheduler/src/error.rs
+++ b/crates/loopal-scheduler/src/error.rs
@@ -1,11 +1,8 @@
 use crate::expression::CronParseError;
 
-/// Scheduler-level errors.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SchedulerError {
-    /// Invalid cron expression.
     InvalidCron(CronParseError),
-    /// Task limit reached.
     TooManyTasks(usize),
 }
 
@@ -21,16 +18,3 @@ impl std::fmt::Display for SchedulerError {
 }
 
 impl std::error::Error for SchedulerError {}
-
-/// Generate an 8-character random alphanumeric task ID.
-pub(crate) fn generate_task_id() -> String {
-    use rand::Rng;
-    const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
-    let mut rng = rand::rng();
-    (0..8)
-        .map(|_| {
-            let idx = rng.random_range(0..CHARSET.len());
-            CHARSET[idx] as char
-        })
-        .collect()
-}

--- a/crates/loopal-scheduler/src/expression.rs
+++ b/crates/loopal-scheduler/src/expression.rs
@@ -27,14 +27,11 @@ impl CronExpression {
         if fields.len() != 5 {
             return Err(CronParseError::InvalidFieldCount(fields.len()));
         }
-        // Convert 5-field → 7-field for the `cron` crate: "sec min hour dom mon dow year"
         let seven_field = format!("0 {expr} *");
         let schedule = Schedule::from_str(&seven_field)
             .map_err(|e| CronParseError::ParseFailed(e.to_string()))?;
 
-        // Validate that at least one occurrence exists before the task expires.
-        let limit = now + chrono::Duration::seconds(crate::task::MAX_LIFETIME_SECS);
-        if schedule.after(&now).next().is_none_or(|t| t > limit) {
+        if schedule.after(&now).next().is_none() {
             return Err(CronParseError::NoOccurrence);
         }
 
@@ -68,7 +65,7 @@ pub enum CronParseError {
     InvalidFieldCount(usize),
     /// Underlying cron parser error.
     ParseFailed(String),
-    /// Expression never matches within the task lifetime (3 days).
+    /// Expression has no future occurrence (e.g. February 30).
     NoOccurrence,
 }
 
@@ -79,12 +76,7 @@ impl std::fmt::Display for CronParseError {
                 write!(f, "expected 5 fields in cron expression, got {n}")
             }
             Self::ParseFailed(msg) => write!(f, "invalid cron expression: {msg}"),
-            Self::NoOccurrence => {
-                write!(
-                    f,
-                    "expression has no occurrence within the task lifetime (3 days)"
-                )
-            }
+            Self::NoOccurrence => write!(f, "cron expression will never fire"),
         }
     }
 }

--- a/crates/loopal-scheduler/src/expression.rs
+++ b/crates/loopal-scheduler/src/expression.rs
@@ -3,25 +3,19 @@ use std::str::FromStr;
 use chrono::{DateTime, Utc};
 use cron::Schedule;
 
-/// Parsed cron expression wrapper.
-///
-/// Uses the 7-field `cron` crate format internally (seconds + 5-field + year),
-/// but accepts standard 5-field input by prepending `0` (seconds) and
-/// appending `*` (year).
+/// Standard 5-field cron expression. Stored as the 7-field form
+/// (`sec min hour dom mon dow year`) the `cron` crate expects.
 #[derive(Debug, Clone)]
 pub struct CronExpression {
     schedule: Schedule,
-    /// Original 5-field expression string for display.
     raw: String,
 }
 
 impl CronExpression {
-    /// Parse a standard 5-field cron expression (minute hour dom month dow).
     pub fn parse(expr: &str) -> Result<Self, CronParseError> {
         Self::parse_at(expr, Utc::now())
     }
 
-    /// Parse with an explicit reference time (for deterministic testing).
     pub fn parse_at(expr: &str, now: DateTime<Utc>) -> Result<Self, CronParseError> {
         let fields: Vec<&str> = expr.split_whitespace().collect();
         if fields.len() != 5 {
@@ -41,12 +35,10 @@ impl CronExpression {
         })
     }
 
-    /// Return the next occurrence strictly after `after`.
     pub fn next_after(&self, after: &DateTime<Utc>) -> Option<DateTime<Utc>> {
         self.schedule.after(after).next()
     }
 
-    /// Original 5-field expression string.
     pub fn as_str(&self) -> &str {
         &self.raw
     }
@@ -58,12 +50,9 @@ impl std::fmt::Display for CronExpression {
     }
 }
 
-/// Errors when parsing a cron expression.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CronParseError {
-    /// Expected exactly 5 fields.
     InvalidFieldCount(usize),
-    /// Underlying cron parser error.
     ParseFailed(String),
     /// Expression has no future occurrence (e.g. February 30).
     NoOccurrence,

--- a/crates/loopal-scheduler/src/id.rs
+++ b/crates/loopal-scheduler/src/id.rs
@@ -1,14 +1,17 @@
-//! Unique task-ID selection.
-//!
-//! Extracted from `scheduler.rs` for testability: the production path
-//! uses [`generate_task_id`](crate::error::generate_task_id) which returns
-//! random 8-char strings with statistically negligible collision
-//! probability. The retry loop is only exercised by injecting a
-//! deterministic generator in tests.
-
 use crate::task::ScheduledTask;
 
-/// Draw IDs from `id_source` until one is not already taken by `tasks`.
+pub(crate) fn generate_task_id() -> String {
+    use rand::Rng;
+    const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+    let mut rng = rand::rng();
+    (0..8)
+        .map(|_| {
+            let idx = rng.random_range(0..CHARSET.len());
+            CHARSET[idx] as char
+        })
+        .collect()
+}
+
 pub(crate) fn find_unique_id(
     tasks: &[ScheduledTask],
     mut id_source: impl FnMut() -> String,

--- a/crates/loopal-scheduler/src/json_file_io.rs
+++ b/crates/loopal-scheduler/src/json_file_io.rs
@@ -1,20 +1,3 @@
-//! Atomic JSON file I/O helpers shared by cron persistence stores.
-//!
-//! Centralizes three operations that every file-backed store needs:
-//!
-//! 1. [`read_or_empty`] — read a file, treating "missing" as empty bytes
-//!    so first-ever-use is not an error.
-//! 2. [`write_atomic`] — write via `<path>.tmp` + `fsync` + `rename`.
-//!    POSIX guarantees rename is atomic within a filesystem, so readers
-//!    always see either the previous or the new contents — never partial.
-//! 3. [`quarantine_path`] — rename a structurally-invalid file aside to
-//!    `<path>.bad-<unix-ms>` so the next save starts clean without
-//!    silently overwriting the user's durable state on schema upgrades.
-//!
-//! All functions are free functions (no struct state) so the same logic
-//! is reused by [`crate::persistence_file::FileDurableStore`] (single-path
-//! adapter) and the upcoming session-scoped store.
-
 use std::ffi::OsString;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -31,10 +14,9 @@ pub async fn read_or_empty(path: &Path) -> Result<Vec<u8>, PersistError> {
     }
 }
 
-/// Atomically replace `path` with `bytes`. Creates parent directories.
-///
-/// Sequence: write to `<name>.tmp` → `sync_all` → `rename` over `path`.
-/// The temp file does not linger after a successful call.
+/// Atomically replace `path` with `bytes` via `<name>.tmp` → `sync_all`
+/// → `rename`. POSIX guarantees rename is atomic within a filesystem;
+/// readers see either the previous or the new contents, never partial.
 pub async fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), PersistError> {
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
@@ -51,11 +33,8 @@ pub async fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), PersistError>
 }
 
 /// Move a corrupt or schema-incompatible file aside to `<path>.bad-<ts>`.
-///
-/// On success the original `path` no longer exists and the next save
-/// starts from empty. On rename failure the original is preserved and
-/// the error is returned — callers must refuse further writes to avoid
-/// clobbering data they cannot interpret.
+/// On rename failure the original is preserved — callers must refuse
+/// further writes to avoid clobbering data they cannot interpret.
 pub async fn quarantine_path(path: &Path, reason: &str) -> Result<(), PersistError> {
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -84,10 +63,6 @@ pub async fn quarantine_path(path: &Path, reason: &str) -> Result<(), PersistErr
     }
 }
 
-/// Build a sibling path with `<original-filename><suffix>`.
-///
-/// Falls back to `cron.json<suffix>` if `path` has no file name component
-/// (extremely unlikely in practice, but guards against panic).
 fn sibling_with_extension(path: &Path, suffix: &str) -> PathBuf {
     let mut tmp = path.to_path_buf();
     let name = tmp

--- a/crates/loopal-scheduler/src/lib.rs
+++ b/crates/loopal-scheduler/src/lib.rs
@@ -22,7 +22,7 @@ pub use persistence::{PersistError, PersistedTask};
 pub use persistence_file_scoped::FileScopedCronStore;
 pub use persistence_session::SessionScopedCronStorage;
 pub use scheduler::{BROADCAST_CAPACITY, CronScheduler};
-pub use task::{CronJobInfo, MAX_LIFETIME_SECS};
+pub use task::CronJobInfo;
 pub use trigger::ScheduledTrigger;
 
 #[cfg(test)]

--- a/crates/loopal-scheduler/src/lib.rs
+++ b/crates/loopal-scheduler/src/lib.rs
@@ -6,6 +6,7 @@ pub(crate) mod json_file_io;
 pub mod persistence;
 pub mod persistence_file_scoped;
 pub mod persistence_session;
+pub(crate) mod save_worker;
 pub mod scheduler;
 pub(crate) mod scheduler_crud;
 pub(crate) mod scheduler_persistence;
@@ -21,10 +22,14 @@ pub use expression::{CronExpression, CronParseError};
 pub use persistence::{PersistError, PersistedTask};
 pub use persistence_file_scoped::FileScopedCronStore;
 pub use persistence_session::SessionScopedCronStorage;
-pub use scheduler::{BROADCAST_CAPACITY, CronScheduler};
+pub use scheduler::{BROADCAST_CAPACITY, CronScheduler, MAX_PROMPT_CHARS};
 pub use task::CronJobInfo;
 pub use trigger::ScheduledTrigger;
 
 #[cfg(test)]
 #[path = "task_tests.rs"]
 mod task_tests;
+
+#[cfg(test)]
+#[path = "save_worker_tests.rs"]
+mod save_worker_tests;

--- a/crates/loopal-scheduler/src/persistence.rs
+++ b/crates/loopal-scheduler/src/persistence.rs
@@ -79,11 +79,9 @@ impl PersistedTask {
     /// entries coming off disk.
     ///
     /// `parse_reference` is the clock value used when revalidating the
-    /// cron expression. It must be "now" (not the persisted
-    /// `created_at`), otherwise an expression like `"0 9 * * *"` saved
-    /// 2.9 days ago would fail to parse as "no occurrence within the
-    /// 3-day lifetime from created_at" even though it has many
-    /// occurrences going forward.
+    /// cron expression — must be "now", not the persisted `created_at`,
+    /// so the `NoOccurrence` check sees the same forward window the
+    /// live `add()` path does.
     pub(crate) fn into_task(
         self,
         parse_reference: DateTime<Utc>,

--- a/crates/loopal-scheduler/src/persistence.rs
+++ b/crates/loopal-scheduler/src/persistence.rs
@@ -1,19 +1,6 @@
-//! Cron-task storage types — schema, persisted form, codec, errors.
-//!
-//! Each cron task marked with `durable = true` is persisted on every
-//! mutation (add / remove / tick-fired / expired), so the on-disk file
-//! always reflects the latest in-memory state. Rewriting a small JSON
-//! document (≤50 tasks) per mutation is acceptable for a feature that
-//! fires at most ~50 times a day.
-//!
 //! A crash window between an in-memory mutation and a successful
 //! `save_all` can cause a one-shot durable task to re-fire **exactly
-//! once** after restart — see [`CronScheduler`](crate::CronScheduler) docs.
-//!
-//! Session-scoped trait + impl live in [`crate::persistence_session`]
-//! and [`crate::persistence_file_scoped`]. Scheduler integration
-//! (persist_locked / load_persisted) lives in
-//! [`crate::scheduler_persistence`].
+//! once** after restart — see `CronScheduler` docs.
 
 use chrono::{DateTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
@@ -22,13 +9,10 @@ use std::io;
 use crate::expression::CronExpression;
 use crate::task::ScheduledTask;
 
-/// Current on-disk schema version. Bump if the layout changes
-/// incompatibly; `load` tolerates unknown future versions by refusing
-/// rather than silently misreading.
+/// On-disk schema version. Bump if the layout changes incompatibly;
+/// `load` refuses unknown future versions rather than misreading.
 pub const SCHEMA_VERSION: u32 = 1;
 
-/// Errors surfaced from a [`SessionScopedCronStorage`](crate::SessionScopedCronStorage)
-/// implementation.
 #[derive(Debug, thiserror::Error)]
 pub enum PersistError {
     #[error("cron storage i/o: {0}")]
@@ -39,20 +23,14 @@ pub enum PersistError {
     BadCron(String),
 }
 
-// ---------------------------------------------------------------------------
-// On-disk shape
-// ---------------------------------------------------------------------------
-
-/// Serializable form of a [`ScheduledTask`]. Uses Unix ms timestamps to
-/// avoid requiring chrono's serde feature.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(default)]
 pub struct PersistedTask {
     pub id: String,
     pub cron: String,
     pub prompt: String,
     pub recurring: bool,
     pub created_at_unix_ms: i64,
-    #[serde(default)]
     pub last_fired_unix_ms: Option<i64>,
 }
 
@@ -63,7 +41,7 @@ pub(crate) struct PersistedFile {
 }
 
 impl PersistedTask {
-    /// Build from an in-memory task. Caller ensures `durable == true`.
+    /// Caller ensures `durable == true`.
     pub(crate) fn from_task(task: &ScheduledTask) -> Self {
         Self {
             id: task.id.clone(),
@@ -75,17 +53,18 @@ impl PersistedTask {
         }
     }
 
-    /// Reconstruct an in-memory task. `durable` is always `true` for
-    /// entries coming off disk.
-    ///
-    /// `parse_reference` is the clock value used when revalidating the
-    /// cron expression — must be "now", not the persisted `created_at`,
+    /// `parse_reference` must be "now", not the persisted `created_at`,
     /// so the `NoOccurrence` check sees the same forward window the
-    /// live `add()` path does.
+    /// live `add()` path does. Rejects entries with an empty `id` so
+    /// missing-required-field cases land in the drop-on-load filter
+    /// rather than silently surfacing as a zero-id task.
     pub(crate) fn into_task(
         self,
         parse_reference: DateTime<Utc>,
     ) -> Result<ScheduledTask, PersistError> {
+        if self.id.is_empty() {
+            return Err(PersistError::BadCron("missing task id".into()));
+        }
         let created_at = unix_ms_to_utc(self.created_at_unix_ms);
         let cron = CronExpression::parse_at(&self.cron, parse_reference)
             .map_err(|e| PersistError::BadCron(format!("{e}")))?;
@@ -107,7 +86,6 @@ fn unix_ms_to_utc(ms: i64) -> DateTime<Utc> {
         .unwrap_or_else(Utc::now)
 }
 
-/// Build the durable subset of `tasks` as [`PersistedTask`] entries.
 pub(crate) fn durable_snapshot(tasks: &[ScheduledTask]) -> Vec<PersistedTask> {
     tasks
         .iter()
@@ -116,25 +94,15 @@ pub(crate) fn durable_snapshot(tasks: &[ScheduledTask]) -> Vec<PersistedTask> {
         .collect()
 }
 
-// ---------------------------------------------------------------------------
-// On-disk codec — used by `FileScopedCronStore`
-// ---------------------------------------------------------------------------
-
-/// Result of classifying raw bytes against the [`PersistedFile`] schema.
-///
-/// The store layer translates each variant into either a returned task
-/// list or a quarantine + empty result.
 pub(crate) enum LoadedPayload {
     Empty,
     Tasks(Vec<PersistedTask>),
     Quarantine(String),
 }
 
-/// Decode raw bytes into a [`LoadedPayload`].
-///
 /// Empty input is treated as a valid empty list (first-ever-use). Bad
-/// JSON or unsupported schema versions yield [`LoadedPayload::Quarantine`]
-/// with a human-readable reason for the audit log.
+/// JSON or unsupported schema versions yield `Quarantine` with a
+/// human-readable reason.
 pub(crate) fn classify_payload(bytes: &[u8]) -> LoadedPayload {
     if bytes.is_empty() {
         return LoadedPayload::Empty;
@@ -148,7 +116,6 @@ pub(crate) fn classify_payload(bytes: &[u8]) -> LoadedPayload {
     }
 }
 
-/// Encode `tasks` as pretty JSON wrapped in a current-version [`PersistedFile`].
 pub(crate) fn encode_payload(tasks: &[PersistedTask]) -> Result<Vec<u8>, serde_json::Error> {
     let file = PersistedFile {
         version: SCHEMA_VERSION,

--- a/crates/loopal-scheduler/src/persistence_file_scoped.rs
+++ b/crates/loopal-scheduler/src/persistence_file_scoped.rs
@@ -1,15 +1,3 @@
-//! `FileScopedCronStore` — session-scoped file backend implementing
-//! [`SessionScopedCronStorage`](crate::persistence_session::SessionScopedCronStorage).
-//!
-//! Stores each session's cron tasks at `<sessions_root>/<id>/cron.json`.
-//! One store instance serves all sessions under the root; the `session_id`
-//! is supplied per call rather than baked into construction.
-//!
-//! Atomic writes and quarantine on corruption use the same helpers as
-//! [`crate::persistence_file::FileDurableStore`], so on-disk format and
-//! crash semantics are identical between the two implementations. Existing
-//! `cron.json` files written by `FileDurableStore` load unchanged here.
-
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
 
@@ -19,22 +7,17 @@ use crate::persistence::{
 };
 use crate::persistence_session::SessionScopedCronStorage;
 
-/// File-backed session-scoped cron storage rooted at `sessions_root`.
-///
-/// Path layout: `<sessions_root>/<session_id>/cron.json`. The session
-/// directory is created on first `save_all` for that session; reads of
-/// missing data return an empty list so fresh sessions start cleanly.
+/// Path layout: `<sessions_root>/<session_id>/cron.json`. Reads of
+/// missing data return an empty list so fresh sessions start clean.
 pub struct FileScopedCronStore {
     sessions_root: PathBuf,
 }
 
 impl FileScopedCronStore {
-    /// Create a store rooted at `sessions_root` (typically `~/.loopal/sessions`).
     pub fn new(sessions_root: PathBuf) -> Self {
         Self { sessions_root }
     }
 
-    /// Inspect the configured root (for tests / diagnostics).
     pub fn root(&self) -> &Path {
         &self.sessions_root
     }

--- a/crates/loopal-scheduler/src/persistence_session.rs
+++ b/crates/loopal-scheduler/src/persistence_session.rs
@@ -1,33 +1,14 @@
-//! Session-scoped storage trait for cron tasks.
-//!
-//! Unlike [`DurableStore`](crate::persistence::DurableStore), which binds
-//! a store instance to a fixed path at construction, this trait treats
-//! `session_id` as a parameter — one storage instance reads and writes
-//! many sessions' data. Aligns cron persistence with the lookup pattern
-//! already used by `SessionStore` / `MessageStore` in `loopal-storage`.
-//!
-//! Concrete file-backed implementation lives in
-//! [`crate::persistence_file_scoped::FileScopedCronStore`].
-
 use async_trait::async_trait;
 
 use crate::persistence::{PersistError, PersistedTask};
 
-/// Abstract session-scoped storage for durable cron tasks.
-///
-/// Implementations must be safe to share via `Arc` and callable
-/// concurrently for distinct `session_id`s. `save_all` fully replaces
-/// the stored set for the given session.
 #[async_trait]
 pub trait SessionScopedCronStorage: Send + Sync {
-    /// Load all persisted tasks for `session_id`. Missing data
-    /// (file or directory absent) returns an empty vector — first use
-    /// of a session is not an error.
     async fn load(&self, session_id: &str) -> Result<Vec<PersistedTask>, PersistError>;
 
     /// Replace the stored set for `session_id` with `tasks`. Must be
-    /// atomic: a reader either sees the previous contents or the new
-    /// contents, never partial.
+    /// atomic — readers see either the old or the new state, never
+    /// partial.
     async fn save_all(&self, session_id: &str, tasks: &[PersistedTask])
     -> Result<(), PersistError>;
 }

--- a/crates/loopal-scheduler/src/save_worker.rs
+++ b/crates/loopal-scheduler/src/save_worker.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tokio::sync::{mpsc, oneshot};
+
+use crate::persistence::PersistedTask;
+use crate::persistence_session::SessionScopedCronStorage;
+
+/// Message sent to the save worker. `Save` carries a snapshot to write;
+/// `Barrier` signals "all prior saves have been processed" — used by
+/// `CronScheduler::wait_idle` so tests and tooling can synchronize
+/// against disk state without polling.
+pub(crate) enum SaveMessage {
+    Save(SaveRequest),
+    Barrier(oneshot::Sender<()>),
+}
+
+/// One save request handed off from a mutation path to the serial worker.
+///
+/// Worker processes requests in arrival order, which equals the order
+/// callers held `tasks.write` when they pushed the snapshot — so disk
+/// state always follows the last in-memory mutation, with no races
+/// between concurrent save sources (tick, add, remove, switch-session).
+pub(crate) struct SaveRequest {
+    pub storage: Arc<dyn SessionScopedCronStorage>,
+    pub session_id: String,
+    pub snapshot: Vec<PersistedTask>,
+    pub dirty: Arc<AtomicBool>,
+    pub store_disabled: Arc<AtomicBool>,
+}
+
+pub(crate) async fn save_worker_loop(mut rx: mpsc::Receiver<SaveMessage>) {
+    while let Some(msg) = rx.recv().await {
+        match msg {
+            SaveMessage::Save(req) => process_save(req).await,
+            SaveMessage::Barrier(tx) => {
+                let _ = tx.send(());
+            }
+        }
+    }
+}
+
+async fn process_save(req: SaveRequest) {
+    if req.store_disabled.load(Ordering::Acquire) {
+        // Quarantine latched after this request was queued — skip to
+        // avoid clobbering an unreadable on-disk file.
+        return;
+    }
+    match req.storage.save_all(&req.session_id, &req.snapshot).await {
+        Ok(()) => req.dirty.store(false, Ordering::Release),
+        Err(e) => {
+            tracing::error!(error = %e, "cron durable save failed in worker");
+            req.dirty.store(true, Ordering::Release);
+        }
+    }
+}

--- a/crates/loopal-scheduler/src/save_worker_tests.rs
+++ b/crates/loopal-scheduler/src/save_worker_tests.rs
@@ -98,7 +98,11 @@ async fn save_failure_sets_dirty() {
     ack_rx.await.unwrap();
 
     assert!(dirty.load(Ordering::Acquire), "failure must latch dirty");
-    assert_eq!(probe.save_count().await, 0, "save_all errored before recording");
+    assert_eq!(
+        probe.save_count().await,
+        0,
+        "save_all errored before recording"
+    );
     drop(tx);
 }
 
@@ -136,7 +140,11 @@ async fn store_disabled_skips_save() {
     tx.send(SaveMessage::Barrier(ack_tx)).await.unwrap();
     ack_rx.await.unwrap();
 
-    assert_eq!(probe.save_count().await, 0, "disabled store must not be hit");
+    assert_eq!(
+        probe.save_count().await,
+        0,
+        "disabled store must not be hit"
+    );
     assert!(
         dirty.load(Ordering::Acquire),
         "dirty must not be cleared when save was skipped"

--- a/crates/loopal-scheduler/src/save_worker_tests.rs
+++ b/crates/loopal-scheduler/src/save_worker_tests.rs
@@ -1,0 +1,157 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use tokio::sync::{Mutex, mpsc, oneshot};
+
+use crate::persistence::{PersistError, PersistedTask};
+use crate::persistence_session::SessionScopedCronStorage;
+use crate::save_worker::{SaveMessage, SaveRequest, save_worker_loop};
+
+struct Probe {
+    saves: Mutex<Vec<Vec<PersistedTask>>>,
+    fail_next: AtomicBool,
+}
+
+impl Probe {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            saves: Mutex::new(Vec::new()),
+            fail_next: AtomicBool::new(false),
+        })
+    }
+    fn arm_failure(&self) {
+        self.fail_next.store(true, Ordering::SeqCst);
+    }
+    async fn save_count(&self) -> usize {
+        self.saves.lock().await.len()
+    }
+}
+
+#[async_trait]
+impl SessionScopedCronStorage for Probe {
+    async fn load(&self, _session_id: &str) -> Result<Vec<PersistedTask>, PersistError> {
+        Ok(Vec::new())
+    }
+    async fn save_all(
+        &self,
+        _session_id: &str,
+        tasks: &[PersistedTask],
+    ) -> Result<(), PersistError> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(PersistError::Io(std::io::Error::other("armed failure")));
+        }
+        self.saves.lock().await.push(tasks.to_vec());
+        Ok(())
+    }
+}
+
+fn make_request(
+    storage: Arc<dyn SessionScopedCronStorage>,
+    dirty: Arc<AtomicBool>,
+    store_disabled: Arc<AtomicBool>,
+) -> SaveRequest {
+    SaveRequest {
+        storage,
+        session_id: "test".into(),
+        snapshot: Vec::new(),
+        dirty,
+        store_disabled,
+    }
+}
+
+#[tokio::test]
+async fn barrier_orders_after_pending_saves() {
+    let probe = Probe::new();
+    let (tx, rx) = mpsc::channel::<SaveMessage>(16);
+    tokio::spawn(save_worker_loop(rx));
+
+    let dirty = Arc::new(AtomicBool::new(false));
+    let store_disabled = Arc::new(AtomicBool::new(false));
+    for _ in 0..3 {
+        let req = make_request(probe.clone(), dirty.clone(), store_disabled.clone());
+        tx.send(SaveMessage::Save(req)).await.unwrap();
+    }
+    let (ack_tx, ack_rx) = oneshot::channel();
+    tx.send(SaveMessage::Barrier(ack_tx)).await.unwrap();
+    ack_rx.await.unwrap();
+
+    // All three saves are guaranteed processed before barrier acks.
+    assert_eq!(probe.save_count().await, 3);
+    drop(tx);
+}
+
+#[tokio::test]
+async fn save_failure_sets_dirty() {
+    let probe = Probe::new();
+    probe.arm_failure();
+    let (tx, rx) = mpsc::channel::<SaveMessage>(4);
+    tokio::spawn(save_worker_loop(rx));
+
+    let dirty = Arc::new(AtomicBool::new(false));
+    let store_disabled = Arc::new(AtomicBool::new(false));
+    let req = make_request(probe.clone(), dirty.clone(), store_disabled.clone());
+    tx.send(SaveMessage::Save(req)).await.unwrap();
+
+    let (ack_tx, ack_rx) = oneshot::channel();
+    tx.send(SaveMessage::Barrier(ack_tx)).await.unwrap();
+    ack_rx.await.unwrap();
+
+    assert!(dirty.load(Ordering::Acquire), "failure must latch dirty");
+    assert_eq!(probe.save_count().await, 0, "save_all errored before recording");
+    drop(tx);
+}
+
+#[tokio::test]
+async fn save_success_clears_dirty() {
+    let probe = Probe::new();
+    let (tx, rx) = mpsc::channel::<SaveMessage>(4);
+    tokio::spawn(save_worker_loop(rx));
+
+    let dirty = Arc::new(AtomicBool::new(true));
+    let store_disabled = Arc::new(AtomicBool::new(false));
+    let req = make_request(probe.clone(), dirty.clone(), store_disabled.clone());
+    tx.send(SaveMessage::Save(req)).await.unwrap();
+
+    let (ack_tx, ack_rx) = oneshot::channel();
+    tx.send(SaveMessage::Barrier(ack_tx)).await.unwrap();
+    ack_rx.await.unwrap();
+
+    assert!(!dirty.load(Ordering::Acquire), "success must clear dirty");
+    drop(tx);
+}
+
+#[tokio::test]
+async fn store_disabled_skips_save() {
+    let probe = Probe::new();
+    let (tx, rx) = mpsc::channel::<SaveMessage>(4);
+    tokio::spawn(save_worker_loop(rx));
+
+    let dirty = Arc::new(AtomicBool::new(true)); // sentinel: should not be flipped
+    let store_disabled = Arc::new(AtomicBool::new(true));
+    let req = make_request(probe.clone(), dirty.clone(), store_disabled.clone());
+    tx.send(SaveMessage::Save(req)).await.unwrap();
+
+    let (ack_tx, ack_rx) = oneshot::channel();
+    tx.send(SaveMessage::Barrier(ack_tx)).await.unwrap();
+    ack_rx.await.unwrap();
+
+    assert_eq!(probe.save_count().await, 0, "disabled store must not be hit");
+    assert!(
+        dirty.load(Ordering::Acquire),
+        "dirty must not be cleared when save was skipped"
+    );
+    drop(tx);
+}
+
+#[tokio::test]
+async fn worker_exits_when_channel_closes() {
+    let (tx, rx) = mpsc::channel::<SaveMessage>(4);
+    let handle = tokio::spawn(save_worker_loop(rx));
+    drop(tx);
+    // Worker should exit promptly once the sender drops.
+    tokio::time::timeout(std::time::Duration::from_secs(1), handle)
+        .await
+        .expect("worker did not exit after channel close")
+        .expect("worker task panicked");
+}

--- a/crates/loopal-scheduler/src/scheduler.rs
+++ b/crates/loopal-scheduler/src/scheduler.rs
@@ -1,163 +1,160 @@
-//! `CronScheduler` — central state and lifecycle.
-//!
-//! This module owns the struct definition, in-memory and session-scoped
-//! constructors, and the background tick loop entrypoint. CRUD operations
-//! (`add` / `remove` / `list`) live in [`crate::scheduler_crud`] and the
-//! legacy single-path `DurableStore` adapter is in [`crate::scheduler_legacy`].
-//!
-//! ## Lock ordering
-//!
-//! Two locks must always be acquired in the same order to prevent
-//! deadlock between [`switch_session`](crate::scheduler_session) and
-//! the persistence path:
+//! Lock ordering — both locks must always be acquired in this order to
+//! prevent deadlock between `switch_session` and the persistence path:
 //!
 //!   1. `tasks` (read or write)
 //!   2. `active`
 //!
 //! `switch_session`, `persist_locked`, and `load_persisted` all observe
 //! this order.
+//!
+//! Disk I/O ordering: all `save_all` calls are funneled through a
+//! single background worker via `save_tx`. Mutation paths snapshot
+//! durable tasks under `tasks.write`, then push the snapshot to the
+//! channel and release the lock — the worker runs `save_all` (including
+//! fsync) outside any task lock. Channel arrival order equals lock
+//! release order, so the disk state always reflects the most recent
+//! in-memory mutation without `tasks.write` ever waiting on disk I/O.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use tokio::sync::{Mutex, RwLock, broadcast};
+use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::clock::{Clock, SystemClock};
 use crate::persistence_session::SessionScopedCronStorage;
+use crate::save_worker::{SaveMessage, save_worker_loop};
 use crate::task::ScheduledTask;
 use crate::trigger::ScheduledTrigger;
 
-/// Maximum number of concurrent scheduled tasks.
+/// User-facing — `CronCreateTool::description()` in
+/// `loopal-agent/src/tools/cron.rs` mirrors this number ("Max 50
+/// concurrent jobs"). Update both together.
 pub(crate) const MAX_TASKS: usize = 50;
 
-/// Capacity for the change-notification broadcast channel.
-///
-/// Mirrors `loopal_agent::task_store::BROADCAST_CAPACITY`. Each subscriber
-/// gets an independent receiver; lagging consumers fall behind by at
-/// most this many pulses before getting `Lagged` and a forced
-/// re-snapshot, which is harmless because every pulse means
-/// "something changed — re-list".
+/// Maximum prompt length accepted by `CronScheduler::add` (counted in
+/// Unicode scalar values, not bytes). Cron tools validate against this
+/// before forwarding.
+pub const MAX_PROMPT_CHARS: usize = 4096;
+
+/// Capacity of the job-set change-notification broadcast channel.
+/// Lagging consumers fall behind by at most this many pulses before
+/// getting `Lagged` and a forced re-snapshot — harmless because every
+/// pulse means "the cron job set changed; re-list".
 pub const BROADCAST_CAPACITY: usize = 16;
 
-/// Currently bound storage and session id.
-///
+/// Save-worker channel buffer. Sized so a slow disk (fsync stalling for
+/// seconds) does not back-pressure mutation paths under bursty load.
+const SAVE_QUEUE_CAPACITY: usize = 64;
+
 /// `session_id` is `None` immediately after a session-scoped storage is
-/// attached but before [`CronScheduler::switch_session`](crate::CronScheduler::switch_session)
-/// is called — in that state persistence is a no-op (no session to save
-/// under). Once bound, it carries `Some(id)`, and all `load`/`save_all`
-/// calls flow through that id.
-///
-/// The legacy [`CronScheduler::with_store`](crate::CronScheduler::with_store)
-/// path constructs a binding with `session_id = Some(String::new())`
-/// plus a [`LegacyBindAdapter`](crate::scheduler_legacy::LegacyBindAdapter)
-/// that ignores the id, so existing single-path callers keep working.
+/// attached but before `switch_session` is called — persistence is a
+/// no-op until the binding has both `storage` and `session_id`.
 pub(crate) struct ActiveBinding {
     pub(crate) session_id: Option<String>,
     pub(crate) storage: Arc<dyn SessionScopedCronStorage>,
 }
 
-/// Cron-based scheduler that manages tasks and emits triggers.
-///
-/// Thread-safe — task list under async `RwLock`, persistence binding
-/// under async `Mutex`. See module-level docs for lock ordering rules.
-///
-/// Job-set changes (add / remove / switch_session / one-shot fire-and-
-/// remove) are advertised on a `tokio::sync::broadcast` channel
-/// `change_tx`. Subscribers re-snapshot on each pulse — the bridge
-/// layer no longer polls.
 pub struct CronScheduler {
     pub(crate) tasks: Arc<RwLock<Vec<ScheduledTask>>>,
     pub(crate) started: AtomicBool,
     pub(crate) clock: Arc<dyn Clock>,
     pub(crate) active: Arc<Mutex<Option<ActiveBinding>>>,
-    /// Set when a `save_all` call fails. The next tick (or next mutation)
-    /// retries so transient disk errors don't permanently diverge
-    /// memory from disk.
+    /// Set when a `save_all` call fails (by the save worker). The next
+    /// tick (or next mutation) retries so transient disk errors don't
+    /// permanently diverge memory from disk.
     pub(crate) dirty: Arc<AtomicBool>,
-    /// Latched when the durable store refuses to operate (e.g. a
-    /// corrupt file could not be quarantined). While set, all
-    /// `persist_locked` calls become no-ops so the scheduler never
-    /// overwrites unrecognized on-disk state. In-memory operation
-    /// continues uninterrupted.
+    /// Latched when the durable store refuses to operate (e.g. a corrupt
+    /// file could not be quarantined). While set, mutation paths skip
+    /// emitting save requests so the worker never overwrites the
+    /// unrecognized on-disk state.
     pub(crate) store_disabled: Arc<AtomicBool>,
-    /// Broadcast channel signalling job-set changes. Capacity is small
-    /// (`BROADCAST_CAPACITY`) — pulses are coalesce-able by the consumer.
     pub(crate) change_tx: broadcast::Sender<()>,
+    /// Sender side of the single-worker save queue. Cloned into every
+    /// mutation path; the worker side is owned by a background task
+    /// that lives for the lifetime of this scheduler.
+    pub(crate) save_tx: mpsc::Sender<SaveMessage>,
 }
 
 impl CronScheduler {
-    /// Create an in-memory-only scheduler with the default system clock.
     pub fn new() -> Self {
         Self::with_clock(Arc::new(SystemClock))
     }
 
-    /// Create an in-memory-only scheduler with a custom clock.
     pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
-        let (change_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
-        Self {
-            tasks: Arc::new(RwLock::new(Vec::new())),
-            started: AtomicBool::new(false),
-            clock,
-            active: Arc::new(Mutex::new(None)),
-            dirty: Arc::new(AtomicBool::new(false)),
-            store_disabled: Arc::new(AtomicBool::new(false)),
-            change_tx,
-        }
+        Self::build(clock, None)
     }
 
-    /// Create a scheduler backed by a session-scoped `storage`. The
-    /// scheduler is unbound until
-    /// [`switch_session`](crate::CronScheduler::switch_session) is called
-    /// — `add` calls before that point write to memory only.
+    /// `add` calls before `switch_session` write to memory only.
     pub fn with_session_storage(storage: Arc<dyn SessionScopedCronStorage>) -> Self {
         Self::with_session_storage_and_clock(storage, Arc::new(SystemClock))
     }
 
-    /// Like [`with_session_storage`](Self::with_session_storage) but with
-    /// a custom clock (for deterministic testing).
     pub fn with_session_storage_and_clock(
         storage: Arc<dyn SessionScopedCronStorage>,
         clock: Arc<dyn Clock>,
     ) -> Self {
+        Self::build(clock, Some(storage))
+    }
+
+    fn build(clock: Arc<dyn Clock>, storage: Option<Arc<dyn SessionScopedCronStorage>>) -> Self {
         let (change_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
+        let (save_tx, save_rx) = mpsc::channel(SAVE_QUEUE_CAPACITY);
+        // One idle tokio task per scheduler is the durability cost —
+        // multi-agent processes pay N workers worth of overhead. Each
+        // worker stays parked on `rx.recv()` until a save lands, so
+        // memory residence is small but task-count scales linearly
+        // with concurrent schedulers.
+        //
+        // Only spawn when we're already inside a tokio runtime. Outside
+        // a runtime (e.g. sync `#[test]` helpers constructing scratch
+        // schedulers) the receiver drops here, and any later
+        // `save_tx.send` returns `Closed` — handled by mutation paths.
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::spawn(save_worker_loop(save_rx));
+        }
         Self {
             tasks: Arc::new(RwLock::new(Vec::new())),
             started: AtomicBool::new(false),
             clock,
-            active: Arc::new(Mutex::new(Some(ActiveBinding {
+            active: Arc::new(Mutex::new(storage.map(|s| ActiveBinding {
                 session_id: None,
-                storage,
+                storage: s,
             }))),
             dirty: Arc::new(AtomicBool::new(false)),
             store_disabled: Arc::new(AtomicBool::new(false)),
             change_tx,
+            save_tx,
         }
     }
 
-    /// Subscribe to job-set change notifications. Each call returns an
-    /// independent `broadcast::Receiver`; multiple subscribers (the
-    /// bridge layer, future metrics observers, …) coexist without
-    /// interfering. A pulse means "the cron job set changed — re-list".
     pub fn subscribe(&self) -> broadcast::Receiver<()> {
         self.change_tx.subscribe()
     }
 
     pub(crate) fn notify_change(&self) {
-        // `send()` errors only when there are no receivers — that's
-        // expected during the windowed period between scheduler
-        // construction and any subscriber connecting. Drop the error.
+        // send() errors only when no receivers are attached yet — drop it.
         let _ = self.change_tx.send(());
     }
 
-    /// Start the background tick loop. Fires triggers on `trigger_tx`.
-    ///
+    /// Wait until every save request enqueued before this call has been
+    /// processed by the background worker. Useful for tests and tooling
+    /// that need a synchronization point against on-disk state without
+    /// polling. No-op if the worker channel has closed.
+    pub async fn wait_idle(&self) {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if self.save_tx.send(SaveMessage::Barrier(tx)).await.is_err() {
+            return;
+        }
+        let _ = rx.await;
+    }
+
     /// # Panics
     /// Panics if called more than once on the same scheduler.
     pub fn start(
         &self,
-        trigger_tx: tokio::sync::mpsc::Sender<ScheduledTrigger>,
+        trigger_tx: mpsc::Sender<ScheduledTrigger>,
         cancel: CancellationToken,
     ) -> JoinHandle<()> {
         assert!(
@@ -171,6 +168,7 @@ impl CronScheduler {
             dirty: self.dirty.clone(),
             store_disabled: self.store_disabled.clone(),
             change_tx: self.change_tx.clone(),
+            save_tx: self.save_tx.clone(),
         };
         tokio::spawn(crate::tick::tick_loop(ctx, trigger_tx, cancel))
     }

--- a/crates/loopal-scheduler/src/scheduler_crud.rs
+++ b/crates/loopal-scheduler/src/scheduler_crud.rs
@@ -1,23 +1,14 @@
-//! CRUD operations on [`CronScheduler`]: `add` / `remove` / `list`.
-//!
-//! Split out so [`crate::scheduler`] keeps its focus on lifecycle
-//! (constructors, `start`) and persistence integration lives in
-//! [`crate::scheduler_persistence`].
-
 use std::sync::atomic::Ordering;
 
-use crate::error::{SchedulerError, generate_task_id};
+use crate::error::SchedulerError;
 use crate::expression::CronExpression;
-use crate::id::find_unique_id;
+use crate::id::{find_unique_id, generate_task_id};
 use crate::scheduler::{CronScheduler, MAX_TASKS};
-use crate::task::{CronJobInfo, ScheduledTask, truncate_to_secs};
+use crate::task::{CronJobInfo, ScheduledTask};
 
 impl CronScheduler {
-    /// Add a new scheduled task. Returns the 8-char task ID.
-    ///
-    /// When `durable` is `true` and the scheduler is bound to a session
-    /// (or attached to a legacy single-path store), the new task is
-    /// persisted before this method returns.
+    /// Returns the 8-char task ID. Durable tasks are persisted before
+    /// this method returns when the scheduler is session-bound.
     pub async fn add(
         &self,
         cron_expr: &str,
@@ -49,9 +40,8 @@ impl CronScheduler {
         Ok(id)
     }
 
-    /// Remove a task by ID. Returns `true` if found and removed.
-    ///
-    /// A durable removal is written through to the store inline.
+    /// Returns `true` if found and removed. A durable removal is written
+    /// through to the store inline.
     pub async fn remove(&self, id: &str) -> bool {
         let mut tasks = self.tasks.write().await;
         let was_durable = tasks.iter().any(|t| t.id == id && t.durable);
@@ -68,15 +58,13 @@ impl CronScheduler {
         removed
     }
 
-    /// List all active tasks as read-only snapshots.
     pub async fn list(&self) -> Vec<CronJobInfo> {
         let tasks = self.tasks.read().await;
         let now = self.clock.now();
         tasks
             .iter()
             .map(|t| {
-                let reference = truncate_to_secs(t.last_fired.unwrap_or(t.created_at));
-                let next_fire = t.cron.next_after(&reference).and_then(|next| {
+                let next_fire = t.next_fire().and_then(|next| {
                     if next > now {
                         Some(next)
                     } else {

--- a/crates/loopal-scheduler/src/scheduler_persistence.rs
+++ b/crates/loopal-scheduler/src/scheduler_persistence.rs
@@ -60,8 +60,6 @@ impl CronScheduler {
     /// and silently prefers existing IDs in release builds.
     ///
     /// **Filter rules** (drop-on-load, no catch-up):
-    /// - expired (`is_expired(now)`) — past the 3-day lifetime (durable
-    ///   tasks are exempt)
     /// - one-shot already fired (`last_fired.is_some()`)
     /// - one-shot whose next fire time has passed (`next_after(created_at) ≤ now`)
     ///
@@ -112,9 +110,6 @@ impl CronScheduler {
                 tracing::warn!("dropping persisted task with unparsable cron");
                 continue;
             };
-            if task.is_expired(&now) {
-                continue;
-            }
             if !task.recurring {
                 let fired = task.last_fired.is_some();
                 let next = task.cron.next_after(&task.created_at);

--- a/crates/loopal-scheduler/src/scheduler_persistence.rs
+++ b/crates/loopal-scheduler/src/scheduler_persistence.rs
@@ -1,84 +1,78 @@
-//! `CronScheduler` methods that touch the [`SessionScopedCronStorage`].
-//!
-//! Split out so `scheduler.rs` stays focused on the in-memory CRUD path
-//! and persistence integration has room to grow (loading, retry, schema
-//! evolution).
-//!
-//! Both `persist_locked` and `load_persisted` consult
-//! [`crate::scheduler::ActiveBinding`] under the `active` mutex to fetch
-//! the current `(session_id, storage)`. Lock order is always
-//! `tasks` → `active` (see [`crate::scheduler`] module docs).
-
 use std::sync::atomic::Ordering;
 
 use crate::persistence::{PersistError, durable_snapshot};
+use crate::save_worker::{SaveMessage, SaveRequest};
 use crate::scheduler::{CronScheduler, MAX_TASKS};
 use crate::task::ScheduledTask;
 
 impl CronScheduler {
-    /// Write the current durable-task snapshot to the attached storage.
+    /// Called with `tasks` write lock held. Snapshots the durable
+    /// subset and enqueues the save on the background worker — the
+    /// actual fsync runs without holding any task lock. Failure to
+    /// enqueue (full or closed channel) sets `dirty` so the next tick
+    /// retries.
     ///
-    /// Callers must hold the `tasks` write lock so concurrent mutations
-    /// don't interleave saves. A `None` binding (no storage attached, or
-    /// session not yet bound) is a no-op. Failure is logged and sets the
-    /// `dirty` flag so the next tick or mutation retries.
-    ///
-    /// If `store_disabled` is latched (e.g. quarantine failed at load
-    /// time), this becomes a silent no-op — preventing clobbering an
-    /// unrecognized on-disk file with an empty in-memory set.
+    /// No-op when no binding, `store_disabled` is latched, or there's
+    /// no session yet (the latter prevents clobbering on-disk state
+    /// during the brief window between session storage attach and
+    /// `switch_session`).
     pub(crate) async fn persist_locked(&self, tasks: &[ScheduledTask]) {
         if self.store_disabled.load(Ordering::Acquire) {
             return;
         }
-        let active = self.active.lock().await;
-        let Some(binding) = active.as_ref() else {
-            return;
-        };
-        let Some(session_id) = binding.session_id.as_ref() else {
-            return;
+        let (storage, session_id) = {
+            let active = self.active.lock().await;
+            let Some(binding) = active.as_ref() else {
+                return;
+            };
+            let Some(sid) = binding.session_id.as_ref() else {
+                return;
+            };
+            (binding.storage.clone(), sid.clone())
         };
         let snapshot = durable_snapshot(tasks);
-        match binding.storage.save_all(session_id, &snapshot).await {
-            Ok(()) => {
-                self.dirty.store(false, Ordering::Release);
-            }
-            Err(e) => {
-                tracing::error!(error = %e, "cron durable save failed; will retry");
+        let req = SaveRequest {
+            storage,
+            session_id,
+            snapshot,
+            dirty: self.dirty.clone(),
+            store_disabled: self.store_disabled.clone(),
+        };
+        // try_send so a full channel doesn't block the caller (which
+        // still holds tasks.write). Worst case: dirty=true → next tick
+        // retries after the worker drains.
+        match self.save_tx.try_send(SaveMessage::Save(req)) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                tracing::warn!("cron save worker queue full; deferring to next tick");
                 self.dirty.store(true, Ordering::Release);
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                tracing::error!(
+                    "cron save worker channel closed; latching store_disabled to stop retries"
+                );
+                self.store_disabled.store(true, Ordering::Release);
             }
         }
     }
 
-    /// Load persisted tasks from the storage into memory.
-    ///
-    /// Internal helper invoked by [`switch_session`](crate::CronScheduler::switch_session).
-    /// External callers should use `switch_session(id)` instead — it
+    /// Internal — external callers use `switch_session(id)` which
     /// performs flush + clear + load atomically.
     ///
-    /// **Preconditions**: assumes the in-memory task list is empty —
-    /// calling this on a populated scheduler panics in debug builds
-    /// and silently prefers existing IDs in release builds.
-    ///
-    /// **Filter rules** (drop-on-load, no catch-up):
+    /// Filter rules (drop-on-load, no catch-up):
     /// - one-shot already fired (`last_fired.is_some()`)
-    /// - one-shot whose next fire time has passed (`next_after(created_at) ≤ now`)
+    /// - one-shot whose next fire time has passed
     ///
-    /// **Normalization**: for recurring tasks whose scheduled reference
-    /// (`last_fired` or `created_at`) is in the past — which would
-    /// otherwise cause an immediate "catch-up" fire on the next tick —
-    /// the `last_fired` field is clamped to `now`.
+    /// Normalization: for recurring tasks whose `next_after(reference)`
+    /// is already in the past, `last_fired` is clamped to `now` to
+    /// prevent an immediate catch-up fire on the next tick.
     ///
-    /// **Capacity**: if the on-disk set exceeds [`MAX_TASKS`], the
-    /// extras are dropped with a warning so subsequent `add` calls can
-    /// still succeed.
-    ///
-    /// **Side effect**: rewrites the storage only when the loaded set
-    /// was actually filtered / truncated / clamped, to keep mtime
-    /// stable on clean loads.
+    /// Capacity: if the on-disk set exceeds `MAX_TASKS`, extras are
+    /// dropped with a warning. Rewrites the storage only when the
+    /// loaded set was actually filtered, truncated, or clamped — so
+    /// clean loads keep mtime stable.
     pub(crate) async fn load_persisted(&self) -> Result<usize, PersistError> {
-        // Lock order: tasks → active. Acquire `tasks` first to keep
-        // ordering symmetric with `persist_locked` callers (add/remove)
-        // and `switch_session`.
+        // Lock order: tasks → active.
         let mut guard = self.tasks.write().await;
         let (storage, session_id) = {
             let active = self.active.lock().await;

--- a/crates/loopal-scheduler/src/scheduler_session.rs
+++ b/crates/loopal-scheduler/src/scheduler_session.rs
@@ -1,47 +1,35 @@
-//! `CronScheduler::switch_session` — atomic active-session swap.
-//!
-//! `switch_session(new_id)` is the single point where session-scoped
-//! storage is re-bound at runtime. It:
-//!
-//! 1. Acquires `tasks` write + `active` mutex (lock order: tasks → active,
-//!    matching [`crate::scheduler_persistence`]).
-//! 2. No-op if the binding already names `new_id`.
-//! 3. If a previous session was bound, flushes the current in-memory
-//!    durable subset to its `cron.json`. Flush failure is logged + sets
-//!    `dirty`; the call **does not abort** — resume is already
-//!    semantically committed at the message-history layer, and bouncing
-//!    here would leave the user with no cron at all.
-//! 4. Clears in-memory tasks, resets `store_disabled` (the new session's
-//!    file may be perfectly readable even if the old one was quarantined),
-//!    sets `active.session_id = Some(new_id)`.
-//! 5. Loads the new session's persisted set (filter rules in
-//!    [`crate::scheduler_persistence`]).
-//!
-//! No-op when the scheduler has no storage attached
-//! ([`CronScheduler::new`](crate::CronScheduler::new) /
-//! [`with_clock`](crate::CronScheduler::with_clock) paths) — those
-//! schedulers are in-memory-only by design.
-
 use std::sync::atomic::Ordering;
 
 use crate::persistence::{PersistError, durable_snapshot};
+use crate::save_worker::{SaveMessage, SaveRequest};
 use crate::scheduler::CronScheduler;
 
 impl CronScheduler {
-    /// Re-bind the scheduler to a different session, flushing the current
-    /// in-memory durable set to the previous session's storage and
-    /// loading the new session's persisted tasks.
+    /// Flush old session's durable subset to its storage, then load the
+    /// new session's set. Returns the number of tasks loaded.
     ///
-    /// Returns the number of tasks loaded for the new session.
+    /// Lock order: tasks → active (see `scheduler.rs` module docs).
     ///
-    /// See module-level docs for the algorithm and failure semantics.
+    /// Flush failure does NOT abort: resume is already committed at the
+    /// message-history layer, and bouncing here would leave the user
+    /// with no cron at all. The save worker emits the error
+    /// asynchronously; `dirty` is set so the next tick retries the
+    /// (new) session's state.
+    ///
+    /// `store_disabled` is reset before loading so a previous session's
+    /// quarantine state doesn't block the new session's I/O.
+    ///
+    /// On `Err`: the new session is already bound (`active.session_id`
+    /// set, in-memory tasks cleared) and `store_disabled` is latched by
+    /// `load_persisted`. Subsequent `add`/`remove` succeed in memory
+    /// but do not reach the store — preventing clobbering of the
+    /// unreadable on-disk file. Calling `switch_session` again with a
+    /// different id resets the latch.
     pub async fn switch_session(&self, new_id: &str) -> Result<usize, PersistError> {
-        // --- Phase 1: flush old + swap binding (under tasks + active locks).
         let mut guard = self.tasks.write().await;
         let flush_target = {
             let mut active = self.active.lock().await;
             let Some(binding) = active.as_mut() else {
-                // No storage attached at all — purely in-memory scheduler.
                 return Ok(0);
             };
             if binding.session_id.as_deref() == Some(new_id) {
@@ -59,43 +47,32 @@ impl CronScheduler {
             && !self.store_disabled.load(Ordering::Acquire)
         {
             let snapshot = durable_snapshot(&guard);
-            if let Err(e) = storage.save_all(&old_id, &snapshot).await {
-                tracing::error!(
-                    error = %e,
-                    old_session = %old_id,
-                    "flush on session switch failed; setting dirty for retry"
-                );
-                self.dirty.store(true, Ordering::Release);
-            } else {
-                self.dirty.store(false, Ordering::Release);
+            let req = SaveRequest {
+                storage,
+                session_id: old_id,
+                snapshot,
+                dirty: self.dirty.clone(),
+                store_disabled: self.store_disabled.clone(),
+            };
+            match self.save_tx.try_send(SaveMessage::Save(req)) {
+                Ok(()) => self.dirty.store(false, Ordering::Release),
+                Err(_) => {
+                    tracing::error!("flush on session switch could not enqueue; dirty set");
+                    self.dirty.store(true, Ordering::Release);
+                }
             }
         }
 
-        // Reset both latches: the new session starts on a clean slate.
-        //
-        // - `store_disabled`: the previous session's quarantine state
-        //   must not block the new session's storage I/O.
-        // - `dirty`: any "old session needs retry" signal is meaningless
-        //   now that the in-memory task list belongs to a different
-        //   session. Phase 2 (`load_persisted`) sets `dirty` itself if
-        //   the new session's load triggers a follow-up `persist_locked`
-        //   that fails, so the new session's retry semantics still work.
         self.store_disabled.store(false, Ordering::Release);
         self.dirty.store(false, Ordering::Release);
 
-        // Drop in-memory tasks before phase 2's empty-list precondition.
         guard.clear();
         drop(guard);
 
-        // --- Phase 2: load the new session's persisted state. The load
-        // path re-acquires `tasks` write + `active` mutex internally;
-        // since we've dropped both above, no nested locking conflict.
         let loaded = self.load_persisted().await?;
 
-        // Notify subscribers exactly once per swap, *after* the new
-        // session's tasks are visible. Doing it after `load_persisted`
-        // means the bridge re-snapshots and sees the new session's job
-        // set, not an empty intermediate state.
+        // Notify after load so subscribers see the new session's set,
+        // not the empty intermediate state.
         self.notify_change();
         Ok(loaded)
     }

--- a/crates/loopal-scheduler/src/task.rs
+++ b/crates/loopal-scheduler/src/task.rs
@@ -3,7 +3,6 @@ use serde::Serialize;
 
 use crate::expression::CronExpression;
 
-/// A scheduled task managed by [`CronScheduler`](crate::CronScheduler).
 pub(crate) struct ScheduledTask {
     pub id: String,
     pub cron: CronExpression,
@@ -12,32 +11,25 @@ pub(crate) struct ScheduledTask {
     pub created_at: DateTime<Utc>,
     pub last_fired: Option<DateTime<Utc>>,
     /// When `true`, mutations to this task are persisted via the
-    /// scheduler's [`DurableStore`](crate::persistence::DurableStore)
-    /// so it survives across process restarts. Non-durable tasks live
-    /// only in memory.
+    /// session-scoped store and survive process restarts.
     pub durable: bool,
 }
 
-/// Truncate a timestamp to whole seconds to avoid sub-second precision issues
-/// with the `cron` crate, which operates at second-level granularity.
 pub(crate) fn truncate_to_secs(dt: DateTime<Utc>) -> DateTime<Utc> {
     dt.with_nanosecond(0).unwrap_or(dt)
 }
 
 impl ScheduledTask {
-    /// Check whether the task should fire at `now`.
-    ///
-    /// Returns `true` when the next cron occurrence after `last_fired`
-    /// (or `created_at` if never fired) is at or before `now`.
-    pub fn should_fire(&self, now: &DateTime<Utc>) -> bool {
+    pub fn next_fire(&self) -> Option<DateTime<Utc>> {
         let reference = truncate_to_secs(self.last_fired.unwrap_or(self.created_at));
-        self.cron
-            .next_after(&reference)
-            .is_some_and(|next| next <= *now)
+        self.cron.next_after(&reference)
+    }
+
+    pub fn should_fire(&self, now: &DateTime<Utc>) -> bool {
+        self.next_fire().is_some_and(|next| next <= *now)
     }
 }
 
-/// Read-only snapshot of a scheduled cron job for listing.
 #[derive(Debug, Clone, Serialize)]
 pub struct CronJobInfo {
     pub id: String,
@@ -46,7 +38,5 @@ pub struct CronJobInfo {
     pub recurring: bool,
     pub created_at: DateTime<Utc>,
     pub next_fire: Option<DateTime<Utc>>,
-    /// Whether this task's state is backed by a [`DurableStore`](crate::persistence::DurableStore)
-    /// and therefore persists across session restarts.
     pub durable: bool,
 }

--- a/crates/loopal-scheduler/src/task.rs
+++ b/crates/loopal-scheduler/src/task.rs
@@ -3,9 +3,6 @@ use serde::Serialize;
 
 use crate::expression::CronExpression;
 
-/// Maximum lifetime of a scheduled task (3 days).
-pub const MAX_LIFETIME_SECS: i64 = 3 * 24 * 60 * 60;
-
 /// A scheduled task managed by [`CronScheduler`](crate::CronScheduler).
 pub(crate) struct ScheduledTask {
     pub id: String,
@@ -37,20 +34,6 @@ impl ScheduledTask {
         self.cron
             .next_after(&reference)
             .is_some_and(|next| next <= *now)
-    }
-
-    /// Whether this task has aged past its maximum lifetime.
-    ///
-    /// Durable tasks (backed by a `DurableStore`) are exempt from the
-    /// lifetime cap: users who explicitly opt into persistence expect
-    /// their schedules to survive indefinitely across restarts.
-    /// Non-durable (in-memory) tasks still expire after
-    /// [`MAX_LIFETIME_SECS`] to keep ephemeral entries from piling up.
-    pub fn is_expired(&self, now: &DateTime<Utc>) -> bool {
-        if self.durable {
-            return false;
-        }
-        now.signed_duration_since(self.created_at).num_seconds() > MAX_LIFETIME_SECS
     }
 }
 

--- a/crates/loopal-scheduler/src/task_tests.rs
+++ b/crates/loopal-scheduler/src/task_tests.rs
@@ -1,4 +1,4 @@
-//! Unit tests for ScheduledTask, should_fire, is_expired, truncate_to_secs.
+//! Unit tests for ScheduledTask, should_fire, truncate_to_secs.
 
 use chrono::{TimeZone, Timelike, Utc};
 
@@ -71,31 +71,11 @@ fn should_fire_no_double_fire_same_minute() {
 }
 
 #[test]
-fn is_expired_after_max_lifetime() {
-    let created = Utc.with_ymd_and_hms(2026, 3, 25, 10, 0, 0).unwrap();
-    let task = make_task("* * * * *", created);
-    // 4 days later → expired (> 3 days)
-    let now = Utc.with_ymd_and_hms(2026, 3, 29, 10, 0, 0).unwrap();
-    assert!(task.is_expired(&now));
-}
-
-#[test]
-fn is_expired_false_within_lifetime() {
-    let created = Utc.with_ymd_and_hms(2026, 3, 29, 10, 0, 0).unwrap();
-    let task = make_task("* * * * *", created);
-    // 1 hour later → not expired
-    let now = Utc.with_ymd_and_hms(2026, 3, 29, 11, 0, 0).unwrap();
-    assert!(!task.is_expired(&now));
-}
-
-#[test]
-fn durable_task_never_expires() {
-    // R5: durable tasks bypass the 3-day lifetime cap so persisted
-    // schedules survive indefinitely across restarts.
+fn should_fire_after_long_idle_period() {
+    // Tasks created days ago must still fire when their cadence comes
+    // around — there's no more lifetime cap to silently drop them.
     let created = Utc.with_ymd_and_hms(2026, 3, 20, 10, 0, 0).unwrap();
-    let mut task = make_task("* * * * *", created);
-    task.durable = true;
-    // 30 days later — non-durable would be expired, durable is not.
-    let now = Utc.with_ymd_and_hms(2026, 4, 19, 10, 0, 0).unwrap();
-    assert!(!task.is_expired(&now));
+    let task = make_task("* * * * *", created);
+    let now = Utc.with_ymd_and_hms(2026, 3, 29, 10, 0, 5).unwrap();
+    assert!(task.should_fire(&now));
 }

--- a/crates/loopal-scheduler/src/task_tests.rs
+++ b/crates/loopal-scheduler/src/task_tests.rs
@@ -1,5 +1,3 @@
-//! Unit tests for ScheduledTask, should_fire, truncate_to_secs.
-
 use chrono::{TimeZone, Timelike, Utc};
 
 use crate::expression::CronExpression;
@@ -71,11 +69,30 @@ fn should_fire_no_double_fire_same_minute() {
 }
 
 #[test]
-fn should_fire_after_long_idle_period() {
-    // Tasks created days ago must still fire when their cadence comes
-    // around — there's no more lifetime cap to silently drop them.
-    let created = Utc.with_ymd_and_hms(2026, 3, 20, 10, 0, 0).unwrap();
+fn next_fire_starts_from_created_at_when_not_fired() {
+    let created = Utc.with_ymd_and_hms(2026, 3, 29, 10, 0, 0).unwrap();
+    let task = make_task("0 12 * * *", created);
+    // Daily at 12:00 — next after 10:00 created_at is same day 12:00.
+    let expected = Utc.with_ymd_and_hms(2026, 3, 29, 12, 0, 0).unwrap();
+    assert_eq!(task.next_fire(), Some(expected));
+}
+
+#[test]
+fn next_fire_advances_after_last_fired() {
+    let created = Utc.with_ymd_and_hms(2026, 3, 29, 10, 0, 0).unwrap();
+    let mut task = make_task("0 12 * * *", created);
+    task.last_fired = Some(Utc.with_ymd_and_hms(2026, 3, 29, 12, 0, 0).unwrap());
+    // Already fired today's 12:00 — next is tomorrow's 12:00.
+    let expected = Utc.with_ymd_and_hms(2026, 3, 30, 12, 0, 0).unwrap();
+    assert_eq!(task.next_fire(), Some(expected));
+}
+
+#[test]
+fn next_fire_truncates_sub_second_reference() {
+    let created = Utc.with_ymd_and_hms(2026, 3, 29, 10, 0, 30).unwrap()
+        + chrono::Duration::nanoseconds(999_999);
     let task = make_task("* * * * *", created);
-    let now = Utc.with_ymd_and_hms(2026, 3, 29, 10, 0, 5).unwrap();
-    assert!(task.should_fire(&now));
+    // Truncated reference 10:00:30 → next at 10:01:00.
+    let expected = Utc.with_ymd_and_hms(2026, 3, 29, 10, 1, 0).unwrap();
+    assert_eq!(task.next_fire(), Some(expected));
 }

--- a/crates/loopal-scheduler/src/tick.rs
+++ b/crates/loopal-scheduler/src/tick.rs
@@ -1,31 +1,34 @@
-//! Background tick loop — runs every second, checks tasks, sends triggers.
-
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::persistence::durable_snapshot;
+use crate::save_worker::{SaveMessage, SaveRequest};
 use crate::scheduler::ActiveBinding;
 use crate::task::ScheduledTask;
 use crate::tick_context::TickContext;
 use crate::trigger::ScheduledTrigger;
 
-/// Core tick loop — every second, surveys + mutates tasks, sends triggers.
+/// Two-phase locking (intentional): read survey → write mutate.
+/// Concurrent `add` / `remove` between phases is safe — the id-set
+/// snapshot taken in survey is matched against ids in mutate, so a
+/// task removed between phases is simply skipped.
 ///
-/// Stops on `cancel`, dropped `trigger_tx` receiver, or send-cancellation race.
+/// Persistence: post-mutation snapshot of durable tasks is pushed to
+/// the save-worker channel while still under `tasks.write`. The worker
+/// runs `save_all` (fsync) outside any task lock, so concurrent
+/// `list`/`add`/`remove` never wait on disk I/O. At most one save
+/// request per tick. Retries fire on `dirty == true` even when no
+/// mutations occurred.
 ///
-/// **Two-phase locking** (intentional): read survey → write mutate. Concurrent
-/// `add` / `remove` between phases is safe (see helper docs).
-///
-/// **Persistence**: post-mutation snapshot of durable tasks is saved while the
-/// write lock is still held — at most one save per tick. Retries fire on
-/// `dirty == true` even when no mutations occurred this tick.
+/// Stops on `cancel`, dropped `trigger_tx` receiver, or send-cancel race.
 pub(crate) async fn tick_loop(
     ctx: TickContext,
-    trigger_tx: tokio::sync::mpsc::Sender<ScheduledTrigger>,
+    trigger_tx: mpsc::Sender<ScheduledTrigger>,
     cancel: CancellationToken,
 ) {
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
@@ -43,21 +46,24 @@ pub(crate) async fn tick_loop(
             continue;
         }
 
-        // Treat a disabled store as "no binding" for this tick so the
-        // retry path doesn't thrash trying to save into a file that
-        // `load_persisted` already refused to normalize.
+        // Treat a disabled store as "no binding" so the retry path
+        // doesn't thrash against a file `load_persisted` already refused.
         let resolved_binding = if ctx.store_disabled.load(Ordering::Acquire) {
             None
         } else {
             resolve_active(&ctx.active).await
         };
-        let triggers =
-            mutate_tasks(&ctx.tasks, &now, &firing_ids, resolved_binding, &ctx.dirty).await;
+        let triggers = mutate_tasks(
+            &ctx.tasks,
+            &now,
+            &firing_ids,
+            resolved_binding,
+            &ctx.dirty,
+            &ctx.store_disabled,
+            &ctx.save_tx,
+        )
+        .await;
 
-        // If anything fired (a recurring task's `last_fired` advanced,
-        // or a one-shot was removed after firing), the job set's
-        // user-visible state changed — broadcast so observers re-snapshot.
-        // No-op when no receivers are attached.
         if needs_write {
             let _ = ctx.change_tx.send(());
         }
@@ -75,9 +81,6 @@ pub(crate) async fn tick_loop(
     }
 }
 
-/// Snapshot the current `(storage, session_id)` from `active`, or `None`
-/// if either is unset. Cloning out lets `mutate_tasks` await the save
-/// without holding the active mutex while the storage I/O runs.
 async fn resolve_active(active: &Arc<Mutex<Option<ActiveBinding>>>) -> Option<ResolvedBinding> {
     let guard = active.lock().await;
     let binding = guard.as_ref()?;
@@ -93,31 +96,30 @@ struct ResolvedBinding {
     session_id: String,
 }
 
-/// Read-only survey: identify task ids that need firing.
 async fn survey_tasks(
     tasks: &Arc<RwLock<Vec<ScheduledTask>>>,
     now: &chrono::DateTime<chrono::Utc>,
-) -> (bool, Vec<String>) {
+) -> (bool, HashSet<String>) {
     let guard = tasks.read().await;
-    let mut firing = Vec::new();
+    let mut firing = HashSet::new();
     for task in guard.iter() {
         if task.should_fire(now) {
-            firing.push(task.id.clone());
+            firing.insert(task.id.clone());
         }
     }
     let needs_write = !firing.is_empty();
     (needs_write, firing)
 }
 
-/// Exclusive mutation: stamp `last_fired`, build triggers, remove
-/// one-shot tasks after firing, then persist if any durable task changed
-/// (or if the previous save failed). Returns the triggers to dispatch.
+#[allow(clippy::too_many_arguments)]
 async fn mutate_tasks(
     tasks: &Arc<RwLock<Vec<ScheduledTask>>>,
     now: &chrono::DateTime<chrono::Utc>,
-    firing_ids: &[String],
+    firing_ids: &HashSet<String>,
     binding: Option<ResolvedBinding>,
     dirty: &Arc<AtomicBool>,
+    store_disabled: &Arc<AtomicBool>,
+    save_tx: &mpsc::Sender<SaveMessage>,
 ) -> Vec<ScheduledTrigger> {
     let mut guard = tasks.write().await;
     let mut triggers = Vec::new();
@@ -154,11 +156,31 @@ async fn mutate_tasks(
         let retry_pending = dirty.load(Ordering::Acquire);
         if durable_touched || retry_pending {
             let snapshot = durable_snapshot(&guard);
-            match b.storage.save_all(&b.session_id, &snapshot).await {
-                Ok(()) => dirty.store(false, Ordering::Release),
-                Err(e) => {
-                    tracing::error!(error = %e, "cron durable save failed in tick");
+            // Drop the tasks write lock before queuing the save so the
+            // worker's I/O cannot block other mutations.
+            drop(guard);
+            let req = SaveRequest {
+                storage: b.storage,
+                session_id: b.session_id,
+                snapshot,
+                dirty: dirty.clone(),
+                store_disabled: store_disabled.clone(),
+            };
+            // try_send (not send().await) mirrors `persist_locked` — a
+            // backed-up worker shouldn't extend the tick interval; the
+            // dirty flag will trigger a retry on the next tick once the
+            // worker drains.
+            match save_tx.try_send(SaveMessage::Save(req)) {
+                Ok(()) => {}
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                    tracing::warn!("cron save worker queue full; deferring to next tick");
                     dirty.store(true, Ordering::Release);
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    tracing::error!(
+                        "cron save worker channel closed; latching store_disabled to stop retries"
+                    );
+                    store_disabled.store(true, Ordering::Release);
                 }
             }
         }

--- a/crates/loopal-scheduler/src/tick.rs
+++ b/crates/loopal-scheduler/src/tick.rs
@@ -37,7 +37,7 @@ pub(crate) async fn tick_loop(
         }
 
         let now = ctx.clock.now();
-        let (needs_write, expiring_ids, firing_ids) = survey_tasks(&ctx.tasks, &now).await;
+        let (needs_write, firing_ids) = survey_tasks(&ctx.tasks, &now).await;
         let should_retry = ctx.dirty.load(Ordering::Acquire);
         if !needs_write && !should_retry {
             continue;
@@ -51,18 +51,11 @@ pub(crate) async fn tick_loop(
         } else {
             resolve_active(&ctx.active).await
         };
-        let triggers = mutate_tasks(
-            &ctx.tasks,
-            &now,
-            &expiring_ids,
-            &firing_ids,
-            resolved_binding,
-            &ctx.dirty,
-        )
-        .await;
+        let triggers =
+            mutate_tasks(&ctx.tasks, &now, &firing_ids, resolved_binding, &ctx.dirty).await;
 
-        // If anything was removed (one-shot fire, expiry) or fired (a
-        // recurring task's `last_fired` advanced), the job set's
+        // If anything fired (a recurring task's `last_fired` advanced,
+        // or a one-shot was removed after firing), the job set's
         // user-visible state changed — broadcast so observers re-snapshot.
         // No-op when no receivers are attached.
         if needs_write {
@@ -100,32 +93,28 @@ struct ResolvedBinding {
     session_id: String,
 }
 
-/// Read-only survey: identify task ids that need expiring or firing.
+/// Read-only survey: identify task ids that need firing.
 async fn survey_tasks(
     tasks: &Arc<RwLock<Vec<ScheduledTask>>>,
     now: &chrono::DateTime<chrono::Utc>,
-) -> (bool, Vec<String>, Vec<String>) {
+) -> (bool, Vec<String>) {
     let guard = tasks.read().await;
-    let mut expiring = Vec::new();
     let mut firing = Vec::new();
     for task in guard.iter() {
-        if task.is_expired(now) {
-            expiring.push(task.id.clone());
-        } else if task.should_fire(now) {
+        if task.should_fire(now) {
             firing.push(task.id.clone());
         }
     }
-    let needs_write = !expiring.is_empty() || !firing.is_empty();
-    (needs_write, expiring, firing)
+    let needs_write = !firing.is_empty();
+    (needs_write, firing)
 }
 
 /// Exclusive mutation: stamp `last_fired`, build triggers, remove
-/// expired/one-shot tasks, then persist if any durable task changed
+/// one-shot tasks after firing, then persist if any durable task changed
 /// (or if the previous save failed). Returns the triggers to dispatch.
 async fn mutate_tasks(
     tasks: &Arc<RwLock<Vec<ScheduledTask>>>,
     now: &chrono::DateTime<chrono::Utc>,
-    expiring_ids: &[String],
     firing_ids: &[String],
     binding: Option<ResolvedBinding>,
     dirty: &Arc<AtomicBool>,
@@ -136,13 +125,7 @@ async fn mutate_tasks(
     let mut durable_touched = false;
 
     for (i, task) in guard.iter_mut().enumerate() {
-        if expiring_ids.contains(&task.id) {
-            info!(task_id = %task.id, "cron job expired");
-            if task.durable {
-                durable_touched = true;
-            }
-            to_remove.push(i);
-        } else if firing_ids.contains(&task.id) {
+        if firing_ids.contains(&task.id) {
             info!(task_id = %task.id, "cron job fired");
             triggers.push(ScheduledTrigger {
                 task_id: task.id.clone(),

--- a/crates/loopal-scheduler/src/tick_context.rs
+++ b/crates/loopal-scheduler/src/tick_context.rs
@@ -1,15 +1,10 @@
-//! Per-scheduler state bundled for `tick_loop`.
-//!
-//! Extracted from `tick.rs` so that file stays focused on the loop body
-//! and stays within the project's 200-LOC budget. Every field here is
-//! cloned from the corresponding `Arc` on `CronScheduler`.
-
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-use tokio::sync::{Mutex, RwLock, broadcast};
+use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
 
 use crate::clock::Clock;
+use crate::save_worker::SaveMessage;
 use crate::scheduler::ActiveBinding;
 use crate::task::ScheduledTask;
 
@@ -20,4 +15,5 @@ pub(crate) struct TickContext {
     pub dirty: Arc<AtomicBool>,
     pub store_disabled: Arc<AtomicBool>,
     pub change_tx: broadcast::Sender<()>,
+    pub save_tx: mpsc::Sender<SaveMessage>,
 }

--- a/crates/loopal-scheduler/src/trigger.rs
+++ b/crates/loopal-scheduler/src/trigger.rs
@@ -1,13 +1,9 @@
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 
-/// Payload emitted when a scheduled task fires.
 #[derive(Debug, Clone, Serialize)]
 pub struct ScheduledTrigger {
-    /// ID of the task that fired.
     pub task_id: String,
-    /// Prompt to inject into the agent loop.
     pub prompt: String,
-    /// Timestamp when the trigger actually fired.
     pub fired_at: DateTime<Utc>,
 }

--- a/crates/loopal-scheduler/tests/suite.rs
+++ b/crates/loopal-scheduler/tests/suite.rs
@@ -4,6 +4,8 @@ mod end_to_end_persistence_test;
 mod expression_test;
 #[path = "suite/file_scoped_cron_test.rs"]
 mod file_scoped_cron_test;
+#[path = "suite/mock_storage.rs"]
+mod mock_storage;
 #[path = "suite/persistence_load_clamp_test.rs"]
 mod persistence_load_clamp_test;
 #[path = "suite/persistence_load_filter_test.rs"]
@@ -12,12 +14,16 @@ mod persistence_load_filter_test;
 mod scheduler_persistence_test;
 #[path = "suite/scheduler_store_disabled_test.rs"]
 mod scheduler_store_disabled_test;
+#[path = "suite/scheduler_switch_session_edge_test.rs"]
+mod scheduler_switch_session_edge_test;
 #[path = "suite/scheduler_switch_session_test.rs"]
 mod scheduler_switch_session_test;
 #[path = "suite/scheduler_test.rs"]
 mod scheduler_test;
 #[path = "suite/tick_exit_test.rs"]
 mod tick_exit_test;
+#[path = "suite/tick_persistence_retry_test.rs"]
+mod tick_persistence_retry_test;
 #[path = "suite/tick_persistence_test.rs"]
 mod tick_persistence_test;
 #[path = "suite/tick_test.rs"]

--- a/crates/loopal-scheduler/tests/suite/end_to_end_persistence_test.rs
+++ b/crates/loopal-scheduler/tests/suite/end_to_end_persistence_test.rs
@@ -30,6 +30,7 @@ async fn durable_tasks_survive_scheduler_restart() {
         .add("*/7 * * * *", "vanish", true, false)
         .await
         .expect("transient add");
+    writer.wait_idle().await;
 
     drop(writer);
 
@@ -65,6 +66,7 @@ async fn load_persisted_cleans_up_missed_one_shot() {
         .add("5 10 * * *", "once", false, true)
         .await
         .expect("add");
+    sched.wait_idle().await;
     drop(sched);
 
     // Reload at 11:00 — one-shot time is in the past → dropped.
@@ -75,6 +77,7 @@ async fn load_persisted_cleans_up_missed_one_shot() {
     ));
     let reader = CronScheduler::with_session_storage_and_clock(store_b, clock_b);
     let count = reader.switch_session(SESSION).await.expect("load");
+    reader.wait_idle().await;
     assert_eq!(count, 0);
     assert!(reader.list().await.is_empty());
 

--- a/crates/loopal-scheduler/tests/suite/expression_test.rs
+++ b/crates/loopal-scheduler/tests/suite/expression_test.rs
@@ -60,11 +60,29 @@ fn parse_at_with_fixed_time() {
 }
 
 #[test]
-fn parse_at_rejects_no_occurrence_within_lifetime() {
-    // Use February 30 which never exists — no valid occurrence ever.
+fn parse_at_rejects_never_firing_expression() {
+    // February 30 never exists — the expression has no future occurrence ever.
     let now = Utc.with_ymd_and_hms(2026, 3, 29, 10, 0, 0).unwrap();
     let err = CronExpression::parse_at("0 0 30 2 *", now).unwrap_err();
     assert_eq!(err, CronParseError::NoOccurrence);
+    assert_eq!(err.to_string(), "cron expression will never fire");
+}
+
+#[test]
+fn parse_at_accepts_weekly_past_this_weeks_fire() {
+    // Monday 2026-03-30 10:00 — `0 9 * * 1` next fires the following
+    // Monday 09:00, ~6d 23h away. The old 3-day lifetime gate would
+    // reject this; the new rule accepts.
+    let monday_after_fire = Utc.with_ymd_and_hms(2026, 3, 30, 10, 0, 0).unwrap();
+    let expr = CronExpression::parse_at("0 9 * * 1", monday_after_fire).unwrap();
+    let next = expr.next_after(&monday_after_fire).unwrap();
+    let delta = next - monday_after_fire;
+    // Must be strictly more than 3 days — proves the lifetime cap is gone.
+    assert!(
+        delta > chrono::Duration::days(3),
+        "delta was {delta:?}, next={next}"
+    );
+    assert!(delta <= chrono::Duration::days(7));
 }
 
 #[test]

--- a/crates/loopal-scheduler/tests/suite/file_scoped_cron_test.rs
+++ b/crates/loopal-scheduler/tests/suite/file_scoped_cron_test.rs
@@ -87,8 +87,8 @@ async fn load_quarantines_corrupt_session_file() {
 
 #[tokio::test]
 async fn legacy_cron_json_loads_unchanged() {
-    // Backward-compat: a fixture matching the v1 schema written by the
-    // legacy `FileDurableStore` must decode identically here.
+    // Backward-compat: a fixture matching the v1 schema must decode
+    // identically here.
     let dir = tempdir().unwrap();
     let session_dir = dir.path().join("legacy");
     tokio::fs::create_dir_all(&session_dir).await.unwrap();
@@ -101,6 +101,44 @@ async fn legacy_cron_json_loads_unchanged() {
     assert_eq!(out.len(), 1);
     assert_eq!(out[0].id, "abc12345");
     assert_eq!(out[0].prompt, "hello");
+    assert!(out[0].last_fired_unix_ms.is_none());
+}
+
+#[tokio::test]
+async fn future_schema_extra_fields_are_ignored() {
+    // Forward-compat: a future writer adding extra fields must still
+    // decode here (extras silently dropped), not quarantine the file.
+    let dir = tempdir().unwrap();
+    let session_dir = dir.path().join("future");
+    tokio::fs::create_dir_all(&session_dir).await.unwrap();
+    let payload = br#"{"version":1,"tasks":[{"id":"future01","cron":"*/5 * * * *","prompt":"hi","recurring":true,"created_at_unix_ms":1700000000000,"future_field":"ignored","priority":42}]}"#;
+    tokio::fs::write(session_dir.join("cron.json"), payload)
+        .await
+        .unwrap();
+    let store = FileScopedCronStore::new(dir.path().to_path_buf());
+    let out = store.load("future").await.unwrap();
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].id, "future01");
+}
+
+#[tokio::test]
+async fn missing_optional_fields_load_with_defaults() {
+    // Forward-compat: a task missing every optional field must still
+    // load — `id` and `cron` provide hard floors via into_task validation.
+    let dir = tempdir().unwrap();
+    let session_dir = dir.path().join("sparse");
+    tokio::fs::create_dir_all(&session_dir).await.unwrap();
+    let payload = br#"{"version":1,"tasks":[{"id":"sparse01","cron":"*/5 * * * *"}]}"#;
+    tokio::fs::write(session_dir.join("cron.json"), payload)
+        .await
+        .unwrap();
+    let store = FileScopedCronStore::new(dir.path().to_path_buf());
+    let out = store.load("sparse").await.unwrap();
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].id, "sparse01");
+    assert_eq!(out[0].prompt, "");
+    assert!(!out[0].recurring);
+    assert_eq!(out[0].created_at_unix_ms, 0);
     assert!(out[0].last_fired_unix_ms.is_none());
 }
 

--- a/crates/loopal-scheduler/tests/suite/mock_storage.rs
+++ b/crates/loopal-scheduler/tests/suite/mock_storage.rs
@@ -1,0 +1,141 @@
+//! Shared mock `SessionScopedCronStorage` for scheduler tests.
+//!
+//! One `MockStorage` covers every test-time fault-injection axis:
+//! - seed per-session preset for `load`
+//! - record save calls (per-session + chronological)
+//! - arm a single save failure (any session or specific session)
+//! - arm load failure (permanent or once for a specific session)
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use loopal_scheduler::{PersistError, PersistedTask, SessionScopedCronStorage};
+
+pub struct MockStorage {
+    state: Mutex<HashMap<String, Vec<PersistedTask>>>,
+    saves: Mutex<Vec<(String, Vec<PersistedTask>)>>,
+    fail_save_next: AtomicBool,
+    fail_save_attempts: AtomicUsize,
+    fail_save_for: Mutex<Option<String>>,
+    fail_load_always: AtomicBool,
+    fail_load_once_for: Mutex<Option<String>>,
+}
+
+impl MockStorage {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(HashMap::new()),
+            saves: Mutex::new(Vec::new()),
+            fail_save_next: AtomicBool::new(false),
+            fail_save_attempts: AtomicUsize::new(0),
+            fail_save_for: Mutex::new(None),
+            fail_load_always: AtomicBool::new(false),
+            fail_load_once_for: Mutex::new(None),
+        })
+    }
+
+    pub async fn seed(&self, session_id: &str, tasks: Vec<PersistedTask>) {
+        self.state.lock().await.insert(session_id.into(), tasks);
+    }
+
+    pub fn arm_save_failure(&self) {
+        self.fail_save_next.store(true, Ordering::SeqCst);
+    }
+
+    pub async fn arm_save_failure_for(&self, session_id: &str) {
+        *self.fail_save_for.lock().await = Some(session_id.into());
+    }
+
+    pub fn arm_load_failure_always(&self) {
+        self.fail_load_always.store(true, Ordering::SeqCst);
+    }
+
+    pub async fn arm_load_failure_once_for(&self, session_id: &str) {
+        *self.fail_load_once_for.lock().await = Some(session_id.into());
+    }
+
+    pub async fn save_count(&self) -> usize {
+        self.saves.lock().await.len()
+    }
+
+    pub fn fail_save_attempts(&self) -> usize {
+        self.fail_save_attempts.load(Ordering::SeqCst)
+    }
+
+    pub async fn saves_for(&self, session_id: &str) -> usize {
+        self.saves
+            .lock()
+            .await
+            .iter()
+            .filter(|(s, _)| s == session_id)
+            .count()
+    }
+
+    pub async fn last_save(&self) -> Vec<PersistedTask> {
+        self.saves
+            .lock()
+            .await
+            .last()
+            .map(|(_, t)| t.clone())
+            .unwrap_or_default()
+    }
+
+    pub async fn last_ids(&self) -> Vec<String> {
+        self.last_save().await.into_iter().map(|t| t.id).collect()
+    }
+}
+
+#[async_trait]
+impl SessionScopedCronStorage for MockStorage {
+    async fn load(&self, session_id: &str) -> Result<Vec<PersistedTask>, PersistError> {
+        if self.fail_load_always.load(Ordering::SeqCst) {
+            return Err(PersistError::Io(std::io::Error::other("unreadable")));
+        }
+        let armed = self.fail_load_once_for.lock().await.clone();
+        if let Some(target) = armed
+            && target == session_id
+        {
+            *self.fail_load_once_for.lock().await = None;
+            return Err(PersistError::BadCron("forced".into()));
+        }
+        Ok(self
+            .state
+            .lock()
+            .await
+            .get(session_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    async fn save_all(
+        &self,
+        session_id: &str,
+        tasks: &[PersistedTask],
+    ) -> Result<(), PersistError> {
+        if self.fail_save_next.swap(false, Ordering::SeqCst) {
+            self.fail_save_attempts.fetch_add(1, Ordering::SeqCst);
+            return Err(PersistError::Io(std::io::Error::other("armed failure")));
+        }
+        let armed = self.fail_save_for.lock().await.clone();
+        if let Some(target) = armed
+            && target == session_id
+        {
+            *self.fail_save_for.lock().await = None;
+            self.fail_save_attempts.fetch_add(1, Ordering::SeqCst);
+            return Err(PersistError::Io(std::io::Error::other("forced")));
+        }
+        self.saves
+            .lock()
+            .await
+            .push((session_id.into(), tasks.to_vec()));
+        self.state
+            .lock()
+            .await
+            .insert(session_id.into(), tasks.to_vec());
+        Ok(())
+    }
+}

--- a/crates/loopal-scheduler/tests/suite/persistence_load_clamp_test.rs
+++ b/crates/loopal-scheduler/tests/suite/persistence_load_clamp_test.rs
@@ -1,5 +1,5 @@
-//! Tests for R1 (clamp), R5 (durable lifetime), capacity & clean-load
-//! rewrite behavior in `load_persisted`.
+//! Tests for R1 (clamp), capacity & clean-load rewrite behavior in
+//! `load_persisted`.
 
 use std::sync::Arc;
 
@@ -104,10 +104,11 @@ async fn recurring_none_last_fired_with_old_created_at_is_clamped() {
 }
 
 #[tokio::test]
-async fn durable_recurring_bypasses_three_day_lifetime() {
-    // R5: durable tasks are exempt from the 3-day lifetime cap.
+async fn task_with_old_created_at_survives_load() {
+    // Tasks persisted days ago must come back on load — there is no
+    // longer a lifetime cap on durable cron jobs.
     let store = MockStore::new(vec![persisted(
-        "old_but_durable",
+        "old_durable",
         "*/5 * * * *",
         true,
         -5 * 24 * 60 * 60,
@@ -115,25 +116,23 @@ async fn durable_recurring_bypasses_three_day_lifetime() {
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     let count = sched.switch_session("test").await.unwrap();
-    assert_eq!(count, 1, "durable old task must survive lifetime cap");
-    assert_eq!(sched.list().await[0].id, "old_but_durable");
+    assert_eq!(count, 1, "old task must survive load");
+    assert_eq!(sched.list().await[0].id, "old_durable");
 }
 
 #[tokio::test]
-async fn durable_task_ignores_lifetime_cap() {
-    // R5 alternate phrasing — ensures the load path mirrors the
-    // underlying `ScheduledTask::is_expired` exemption.
+async fn very_old_task_still_loads() {
     let store = MockStore::new(vec![persisted(
-        "old1",
+        "ancient",
         "*/5 * * * *",
         true,
-        -4 * 24 * 60 * 60,
+        -30 * 24 * 60 * 60,
     )]);
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     let count = sched.switch_session("test").await.unwrap();
     assert_eq!(count, 1);
-    assert_eq!(sched.list().await[0].id, "old1");
+    assert_eq!(sched.list().await[0].id, "ancient");
 }
 
 #[tokio::test]

--- a/crates/loopal-scheduler/tests/suite/persistence_load_clamp_test.rs
+++ b/crates/loopal-scheduler/tests/suite/persistence_load_clamp_test.rs
@@ -1,50 +1,12 @@
-//! Tests for R1 (clamp), capacity & clean-load rewrite behavior in
-//! `load_persisted`.
-
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
-use tokio::sync::Mutex;
 
 use loopal_scheduler::{
-    Clock, CronScheduler, ManualClock, PersistError, PersistedTask, SessionScopedCronStorage,
+    Clock, CronScheduler, ManualClock, PersistedTask, SessionScopedCronStorage,
 };
 
-struct MockStore {
-    preset: Mutex<Vec<PersistedTask>>,
-    saved: Mutex<Vec<Vec<PersistedTask>>>,
-}
-
-impl MockStore {
-    fn new(preset: Vec<PersistedTask>) -> Arc<Self> {
-        Arc::new(Self {
-            preset: Mutex::new(preset),
-            saved: Mutex::new(Vec::new()),
-        })
-    }
-    async fn save_count(&self) -> usize {
-        self.saved.lock().await.len()
-    }
-    async fn last_saved(&self) -> Vec<PersistedTask> {
-        self.saved.lock().await.last().cloned().unwrap_or_default()
-    }
-}
-
-#[async_trait]
-impl SessionScopedCronStorage for MockStore {
-    async fn load(&self, _session_id: &str) -> Result<Vec<PersistedTask>, PersistError> {
-        Ok(self.preset.lock().await.clone())
-    }
-    async fn save_all(
-        &self,
-        _session_id: &str,
-        tasks: &[PersistedTask],
-    ) -> Result<(), PersistError> {
-        self.saved.lock().await.push(tasks.to_vec());
-        Ok(())
-    }
-}
+use crate::mock_storage::MockStorage;
 
 fn base_time() -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2026, 4, 10, 12, 0, 0).unwrap()
@@ -62,19 +24,26 @@ fn persisted(id: &str, cron: &str, recurring: bool, created_shift: i64) -> Persi
     }
 }
 
-async fn scheduler_with(store: Arc<MockStore>, clock: Arc<dyn Clock>) -> CronScheduler {
+async fn scheduler_with(store: Arc<MockStorage>, clock: Arc<dyn Clock>) -> CronScheduler {
     let store_dyn: Arc<dyn SessionScopedCronStorage> = store;
     CronScheduler::with_session_storage_and_clock(store_dyn, clock)
+}
+
+async fn store_with_preset(preset: Vec<PersistedTask>) -> Arc<MockStorage> {
+    let store = MockStorage::new();
+    store.seed("test", preset).await;
+    store
 }
 
 #[tokio::test]
 async fn recurring_last_fired_is_clamped_to_now_on_load() {
     let mut p = persisted("recur", "*/5 * * * *", true, -10 * 60);
     p.last_fired_unix_ms = Some((base_time() - chrono::Duration::minutes(5)).timestamp_millis());
-    let store = MockStore::new(vec![p]);
+    let store = store_with_preset(vec![p]).await;
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     let count = sched.switch_session("test").await.unwrap();
+    sched.wait_idle().await;
     assert_eq!(count, 1);
     let tasks = sched.list().await;
     let next = tasks[0].next_fire.expect("has next fire");
@@ -90,10 +59,11 @@ async fn recurring_last_fired_is_clamped_to_now_on_load() {
 async fn recurring_none_last_fired_with_old_created_at_is_clamped() {
     // R1 regression: `last_fired = None` + old `created_at` previously
     // slipped past the clamp.
-    let store = MockStore::new(vec![persisted("recur", "*/5 * * * *", true, -10 * 60)]);
+    let store = store_with_preset(vec![persisted("recur", "*/5 * * * *", true, -10 * 60)]).await;
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     sched.switch_session("test").await.unwrap();
+    sched.wait_idle().await;
     let tasks = sched.list().await;
     let next = tasks[0].next_fire.expect("has next fire");
     assert!(
@@ -107,12 +77,13 @@ async fn recurring_none_last_fired_with_old_created_at_is_clamped() {
 async fn task_with_old_created_at_survives_load() {
     // Tasks persisted days ago must come back on load — there is no
     // longer a lifetime cap on durable cron jobs.
-    let store = MockStore::new(vec![persisted(
+    let store = store_with_preset(vec![persisted(
         "old_durable",
         "*/5 * * * *",
         true,
         -5 * 24 * 60 * 60,
-    )]);
+    )])
+    .await;
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     let count = sched.switch_session("test").await.unwrap();
@@ -122,12 +93,13 @@ async fn task_with_old_created_at_survives_load() {
 
 #[tokio::test]
 async fn very_old_task_still_loads() {
-    let store = MockStore::new(vec![persisted(
+    let store = store_with_preset(vec![persisted(
         "ancient",
         "*/5 * * * *",
         true,
         -30 * 24 * 60 * 60,
-    )]);
+    )])
+    .await;
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     let count = sched.switch_session("test").await.unwrap();
@@ -146,13 +118,15 @@ async fn load_exceeding_max_tasks_is_truncated() {
             -60,
         ));
     }
-    let store = MockStore::new(payload);
+    let store = store_with_preset(payload).await;
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     let count = sched.switch_session("test").await.unwrap();
+    sched.wait_idle().await;
     assert_eq!(count, 50);
+    // 1 save from the truncate rewrite.
     assert_eq!(store.save_count().await, 1);
-    assert_eq!(store.last_saved().await.len(), 50);
+    assert_eq!(store.last_save().await.len(), 50);
 }
 
 #[tokio::test]
@@ -160,17 +134,19 @@ async fn clean_load_does_not_rewrite_file() {
     // Crons are chosen so `next_after(created_at)` lies strictly in
     // the future relative to `base_time`, avoiding the R1 clamp that
     // would otherwise dirty a "clean" load.
-    let store = MockStore::new(vec![
+    let store = store_with_preset(vec![
         persisted("a", "0 13 * * *", true, -60),
         persisted("b", "0 14 * * *", true, -60),
-    ]);
+    ])
+    .await;
+    let baseline = store.save_count().await;
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     let count = sched.switch_session("test").await.unwrap();
     assert_eq!(count, 2);
     assert_eq!(
         store.save_count().await,
-        0,
+        baseline,
         "untouched set must not trigger a cleanup save"
     );
 }

--- a/crates/loopal-scheduler/tests/suite/persistence_load_filter_test.rs
+++ b/crates/loopal-scheduler/tests/suite/persistence_load_filter_test.rs
@@ -1,53 +1,12 @@
-//! `load_persisted` filter tests — expired / missed-one-shot dropped;
-//! clean entries rehydrated into memory; survivors are re-saved once
-//! so the on-disk set stays consistent.
-//!
-//! Clamp / lifetime / capacity / clean-load behavior lives in the
-//! sibling `persistence_load_clamp_test` module.
-
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
-use tokio::sync::Mutex;
 
 use loopal_scheduler::{
-    Clock, CronScheduler, ManualClock, PersistError, PersistedTask, SessionScopedCronStorage,
+    Clock, CronScheduler, ManualClock, PersistedTask, SessionScopedCronStorage,
 };
 
-/// In-memory mock store — captures save calls, returns a preset load.
-struct MockStore {
-    preset: Mutex<Vec<PersistedTask>>,
-    saved: Mutex<Vec<Vec<PersistedTask>>>,
-}
-
-impl MockStore {
-    fn new(preset: Vec<PersistedTask>) -> Arc<Self> {
-        Arc::new(Self {
-            preset: Mutex::new(preset),
-            saved: Mutex::new(Vec::new()),
-        })
-    }
-
-    async fn save_count(&self) -> usize {
-        self.saved.lock().await.len()
-    }
-}
-
-#[async_trait]
-impl SessionScopedCronStorage for MockStore {
-    async fn load(&self, _session_id: &str) -> Result<Vec<PersistedTask>, PersistError> {
-        Ok(self.preset.lock().await.clone())
-    }
-    async fn save_all(
-        &self,
-        _session_id: &str,
-        tasks: &[PersistedTask],
-    ) -> Result<(), PersistError> {
-        self.saved.lock().await.push(tasks.to_vec());
-        Ok(())
-    }
-}
+use crate::mock_storage::MockStorage;
 
 fn base_time() -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2026, 4, 10, 12, 0, 0).unwrap()
@@ -65,9 +24,15 @@ fn persisted(id: &str, cron: &str, recurring: bool, created_shift: i64) -> Persi
     }
 }
 
-async fn scheduler_with(store: Arc<MockStore>, clock: Arc<dyn Clock>) -> CronScheduler {
+async fn scheduler_with(store: Arc<MockStorage>, clock: Arc<dyn Clock>) -> CronScheduler {
     let store_dyn: Arc<dyn SessionScopedCronStorage> = store;
     CronScheduler::with_session_storage_and_clock(store_dyn, clock)
+}
+
+async fn store_with_preset(preset: Vec<PersistedTask>) -> Arc<MockStorage> {
+    let store = MockStorage::new();
+    store.seed("test", preset).await;
+    store
 }
 
 #[tokio::test]
@@ -79,22 +44,24 @@ async fn load_persisted_without_store_returns_zero() {
 #[tokio::test]
 async fn missed_one_shot_is_dropped() {
     // Created 1h ago; one-shot at +5min would have fired 55 min ago.
-    let store = MockStore::new(vec![persisted(
+    let store = store_with_preset(vec![persisted(
         "miss",
         "5 11 * * *", // 11:05 — before the 12:00 base_time
         false,
         -60 * 60,
-    )]);
+    )])
+    .await;
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     let count = sched.switch_session("test").await.unwrap();
+    sched.wait_idle().await;
     assert_eq!(count, 0);
     assert_eq!(store.save_count().await, 1);
 }
 
 #[tokio::test]
 async fn recurring_task_is_rehydrated() {
-    let store = MockStore::new(vec![persisted("keep", "*/5 * * * *", true, -60)]);
+    let store = store_with_preset(vec![persisted("keep", "*/5 * * * *", true, -60)]).await;
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     let count = sched.switch_session("test").await.unwrap();
@@ -108,7 +75,7 @@ async fn recurring_task_is_rehydrated() {
 #[tokio::test]
 async fn future_one_shot_is_kept() {
     // Created "just now" (-5s) with a cron that fires in the future.
-    let store = MockStore::new(vec![persisted("once", "5 13 * * *", false, -5)]);
+    let store = store_with_preset(vec![persisted("once", "5 13 * * *", false, -5)]).await;
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     let count = sched.switch_session("test").await.unwrap();
@@ -122,7 +89,7 @@ async fn future_one_shot_is_kept() {
 async fn fired_one_shot_is_dropped() {
     let mut p = persisted("fired", "*/5 * * * *", false, -10);
     p.last_fired_unix_ms = Some(base_time().timestamp_millis() - 30_000);
-    let store = MockStore::new(vec![p]);
+    let store = store_with_preset(vec![p]).await;
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     let count = sched.switch_session("test").await.unwrap();
@@ -131,7 +98,20 @@ async fn fired_one_shot_is_dropped() {
 
 #[tokio::test]
 async fn unparsable_cron_is_dropped_with_warning() {
-    let store = MockStore::new(vec![persisted("bad", "not a cron", true, -60)]);
+    let store = store_with_preset(vec![persisted("bad", "not a cron", true, -60)]).await;
+    let clock = Arc::new(ManualClock::new(base_time()));
+    let sched = scheduler_with(store.clone(), clock).await;
+    let count = sched.switch_session("test").await.unwrap();
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn missing_id_is_dropped() {
+    // Forward-compat: a task with a default (empty) id must be filtered
+    // rather than silently joining the in-memory set.
+    let mut p = persisted("placeholder", "*/5 * * * *", true, -60);
+    p.id = String::new();
+    let store = store_with_preset(vec![p]).await;
     let clock = Arc::new(ManualClock::new(base_time()));
     let sched = scheduler_with(store.clone(), clock).await;
     let count = sched.switch_session("test").await.unwrap();

--- a/crates/loopal-scheduler/tests/suite/scheduler_persistence_test.rs
+++ b/crates/loopal-scheduler/tests/suite/scheduler_persistence_test.rs
@@ -1,66 +1,12 @@
-//! Tests for `CronScheduler` durable add / remove persistence hooks.
-
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
-use async_trait::async_trait;
 use chrono::Utc;
-use tokio::sync::Mutex;
 
-use loopal_scheduler::{
-    CronScheduler, ManualClock, PersistError, PersistedTask, SessionScopedCronStorage,
-};
+use loopal_scheduler::{CronScheduler, ManualClock, SessionScopedCronStorage};
 
-struct CountingStore {
-    saved: Mutex<Vec<Vec<PersistedTask>>>,
-    fail_next: AtomicBool,
-}
+use crate::mock_storage::MockStorage;
 
-impl CountingStore {
-    fn new() -> Arc<Self> {
-        Arc::new(Self {
-            saved: Mutex::new(Vec::new()),
-            fail_next: AtomicBool::new(false),
-        })
-    }
-    fn arm_failure(&self) {
-        self.fail_next.store(true, Ordering::SeqCst);
-    }
-    async fn save_count(&self) -> usize {
-        self.saved.lock().await.len()
-    }
-    async fn last_ids(&self) -> Vec<String> {
-        self.saved
-            .lock()
-            .await
-            .last()
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .map(|t| t.id)
-            .collect()
-    }
-}
-
-#[async_trait]
-impl SessionScopedCronStorage for CountingStore {
-    async fn load(&self, _session_id: &str) -> Result<Vec<PersistedTask>, PersistError> {
-        Ok(Vec::new())
-    }
-    async fn save_all(
-        &self,
-        _session_id: &str,
-        tasks: &[PersistedTask],
-    ) -> Result<(), PersistError> {
-        if self.fail_next.swap(false, Ordering::SeqCst) {
-            return Err(PersistError::Io(std::io::Error::other("armed failure")));
-        }
-        self.saved.lock().await.push(tasks.to_vec());
-        Ok(())
-    }
-}
-
-async fn build_scheduler(store: Arc<CountingStore>) -> CronScheduler {
+async fn build_scheduler(store: Arc<MockStorage>) -> CronScheduler {
     let store_dyn: Arc<dyn SessionScopedCronStorage> = store;
     let sched = CronScheduler::with_session_storage_and_clock(
         store_dyn,
@@ -72,7 +18,7 @@ async fn build_scheduler(store: Arc<CountingStore>) -> CronScheduler {
 
 #[tokio::test]
 async fn add_non_durable_does_not_persist() {
-    let store = CountingStore::new();
+    let store = MockStorage::new();
     let sched = build_scheduler(store.clone()).await;
     sched
         .add("*/5 * * * *", "p", true, false)
@@ -83,25 +29,27 @@ async fn add_non_durable_does_not_persist() {
 
 #[tokio::test]
 async fn add_durable_triggers_one_save() {
-    let store = CountingStore::new();
+    let store = MockStorage::new();
     let sched = build_scheduler(store.clone()).await;
     let id = sched
         .add("*/5 * * * *", "p", true, true)
         .await
         .expect("add");
+    sched.wait_idle().await;
     assert_eq!(store.save_count().await, 1);
     assert_eq!(store.last_ids().await, vec![id]);
 }
 
 #[tokio::test]
 async fn remove_durable_persists_new_set() {
-    let store = CountingStore::new();
+    let store = MockStorage::new();
     let sched = build_scheduler(store.clone()).await;
     let id = sched
         .add("*/5 * * * *", "p", true, true)
         .await
         .expect("add");
     assert!(sched.remove(&id).await);
+    sched.wait_idle().await;
     // One save on add, one on remove.
     assert_eq!(store.save_count().await, 2);
     assert!(store.last_ids().await.is_empty());
@@ -109,19 +57,20 @@ async fn remove_durable_persists_new_set() {
 
 #[tokio::test]
 async fn remove_non_durable_does_not_persist() {
-    let store = CountingStore::new();
+    let store = MockStorage::new();
     let sched = build_scheduler(store.clone()).await;
     let id = sched
         .add("*/5 * * * *", "p", true, false)
         .await
         .expect("add");
     assert!(sched.remove(&id).await);
+    sched.wait_idle().await;
     assert_eq!(store.save_count().await, 0);
 }
 
 #[tokio::test]
 async fn snapshot_includes_only_durable_tasks() {
-    let store = CountingStore::new();
+    let store = MockStorage::new();
     let sched = build_scheduler(store.clone()).await;
     let _a = sched
         .add("*/5 * * * *", "non", true, false)
@@ -131,7 +80,7 @@ async fn snapshot_includes_only_durable_tasks() {
         .add("*/7 * * * *", "dur", true, true)
         .await
         .expect("add");
-    // The durable save must only carry `b`.
+    sched.wait_idle().await;
     let ids = store.last_ids().await;
     assert_eq!(ids, vec![b]);
 }
@@ -166,22 +115,22 @@ async fn subsequent_add_retries_after_save_failure() {
     // First durable save fails → dirty flag latches. A later
     // non-durable add must still retry the save so memory and disk
     // don't diverge indefinitely.
-    let store = CountingStore::new();
+    let store = MockStorage::new();
     let sched = build_scheduler(store.clone()).await;
-    store.arm_failure();
+    store.arm_save_failure();
     let durable_id = sched
         .add("*/5 * * * *", "persist", true, true)
         .await
         .expect("add durable");
-    // Armed failure was consumed; no successful save yet.
+    sched.wait_idle().await;
     assert_eq!(store.save_count().await, 0);
+    assert_eq!(store.fail_save_attempts(), 1);
 
-    // A non-durable add should still trigger a retry because dirty=true.
     let _transient = sched
         .add("*/7 * * * *", "transient", true, false)
         .await
         .expect("add transient");
+    sched.wait_idle().await;
     assert_eq!(store.save_count().await, 1);
-    // The persisted set still contains only the durable task.
     assert_eq!(store.last_ids().await, vec![durable_id]);
 }

--- a/crates/loopal-scheduler/tests/suite/scheduler_store_disabled_test.rs
+++ b/crates/loopal-scheduler/tests/suite/scheduler_store_disabled_test.rs
@@ -1,56 +1,19 @@
-//! R2: tests for `store_disabled` — when `load_persisted` fails, the
-//! scheduler must refuse to persist afterwards so later writes don't
-//! clobber an unrecognized on-disk file.
-
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use chrono::Utc;
-use tokio::sync::Mutex;
 
-use loopal_scheduler::{
-    CronScheduler, ManualClock, PersistError, PersistedTask, SessionScopedCronStorage,
-};
+use loopal_scheduler::{CronScheduler, ManualClock, PersistError, SessionScopedCronStorage};
 
-/// A store whose `load` always fails — simulates quarantine-failed
-/// or unreadable on-disk state.
-struct FailingLoadStore {
-    saves: Mutex<usize>,
-}
-
-impl FailingLoadStore {
-    fn new() -> Arc<Self> {
-        Arc::new(Self {
-            saves: Mutex::new(0),
-        })
-    }
-    async fn save_count(&self) -> usize {
-        *self.saves.lock().await
-    }
-}
-
-#[async_trait]
-impl SessionScopedCronStorage for FailingLoadStore {
-    async fn load(&self, _session_id: &str) -> Result<Vec<PersistedTask>, PersistError> {
-        Err(PersistError::Io(std::io::Error::other("unreadable")))
-    }
-    async fn save_all(
-        &self,
-        _session_id: &str,
-        _tasks: &[PersistedTask],
-    ) -> Result<(), PersistError> {
-        *self.saves.lock().await += 1;
-        Ok(())
-    }
-}
+use crate::mock_storage::MockStorage;
 
 #[tokio::test]
 async fn load_failure_latches_store_disabled_and_skips_subsequent_saves() {
     // If the storage `load` fails (e.g. quarantine could not move a
-    // corrupt file aside), the scheduler must **refuse** to persist
+    // corrupt file aside), the scheduler must refuse to persist
     // afterwards, otherwise a later `add` atomically overwrites the
     // user's unrecognized on-disk state with an empty snapshot.
-    let store = FailingLoadStore::new();
+    let store = MockStorage::new();
+    store.arm_load_failure_always();
     let store_dyn: Arc<dyn SessionScopedCronStorage> = store.clone();
     let sched = CronScheduler::with_session_storage_and_clock(
         store_dyn,
@@ -62,8 +25,6 @@ async fn load_failure_latches_store_disabled_and_skips_subsequent_saves() {
         "expected Io error, got {err:?}"
     );
 
-    // Further durable adds must succeed in memory but MUST NOT reach
-    // the store — otherwise the corrupt file gets clobbered.
     let _id = sched
         .add("*/5 * * * *", "after-disable", true, true)
         .await
@@ -78,9 +39,8 @@ async fn load_failure_latches_store_disabled_and_skips_subsequent_saves() {
 
 #[tokio::test]
 async fn remove_after_load_failure_also_skips_store() {
-    // Same guarantee on the `remove` path — once the store is
-    // disabled, neither add nor remove should clobber on-disk data.
-    let store = FailingLoadStore::new();
+    let store = MockStorage::new();
+    store.arm_load_failure_always();
     let store_dyn: Arc<dyn SessionScopedCronStorage> = store.clone();
     let sched = CronScheduler::with_session_storage_and_clock(
         store_dyn,

--- a/crates/loopal-scheduler/tests/suite/scheduler_switch_session_edge_test.rs
+++ b/crates/loopal-scheduler/tests/suite/scheduler_switch_session_edge_test.rs
@@ -1,0 +1,35 @@
+use std::sync::Arc;
+
+use chrono::{TimeZone, Utc};
+
+use loopal_scheduler::{CronScheduler, ManualClock, PersistedTask, SessionScopedCronStorage};
+
+use crate::mock_storage::MockStorage;
+
+#[tokio::test]
+async fn switch_resets_store_disabled_for_new_session() {
+    // After a corrupt-load on session A latches store_disabled,
+    // switching to B must clear the latch so B's I/O works normally.
+    let now = Utc.with_ymd_and_hms(2026, 4, 10, 12, 0, 0).unwrap();
+    let clock = Arc::new(ManualClock::new(now));
+    let storage = MockStorage::new();
+    storage
+        .seed(
+            "beta",
+            vec![PersistedTask {
+                id: "b1".into(),
+                cron: "*/5 * * * *".into(),
+                prompt: "hi".into(),
+                recurring: true,
+                created_at_unix_ms: now.timestamp_millis(),
+                last_fired_unix_ms: Some(now.timestamp_millis()),
+            }],
+        )
+        .await;
+    storage.arm_load_failure_once_for("alpha").await;
+    let store_dyn: Arc<dyn SessionScopedCronStorage> = storage.clone();
+    let scheduler = CronScheduler::with_session_storage_and_clock(store_dyn, clock);
+    let _ = scheduler.switch_session("alpha").await;
+    let n = scheduler.switch_session("beta").await.expect("beta loads");
+    assert_eq!(n, 1);
+}

--- a/crates/loopal-scheduler/tests/suite/scheduler_switch_session_test.rs
+++ b/crates/loopal-scheduler/tests/suite/scheduler_switch_session_test.rs
@@ -1,95 +1,10 @@
-//! Tests for `CronScheduler::switch_session` — atomic active-session swap.
-//!
-//! Covers four state transitions:
-//! - None → Some(A): no flush, loads A
-//! - Some(A) → Some(B): A flushed, B loaded
-//! - Some(A) → Some(A): no-op (verify by counting save_all calls)
-//! - Flush failure: returns Ok, dirty=true, doesn't block load
-
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use tokio::sync::Mutex;
 
-use loopal_scheduler::{
-    CronScheduler, ManualClock, PersistError, PersistedTask, SessionScopedCronStorage,
-};
+use loopal_scheduler::{CronScheduler, ManualClock, PersistedTask, SessionScopedCronStorage};
 
-/// In-memory session-scoped storage with call recording for assertions.
-struct RecordingStorage {
-    state: Mutex<std::collections::HashMap<String, Vec<PersistedTask>>>,
-    saves: Mutex<Vec<(String, Vec<PersistedTask>)>>,
-    fail_save_for: Mutex<Option<String>>,
-}
-
-impl RecordingStorage {
-    fn new() -> Arc<Self> {
-        Arc::new(Self {
-            state: Mutex::new(Default::default()),
-            saves: Mutex::new(Vec::new()),
-            fail_save_for: Mutex::new(None),
-        })
-    }
-
-    async fn seed(&self, session_id: &str, tasks: Vec<PersistedTask>) {
-        self.state.lock().await.insert(session_id.into(), tasks);
-    }
-
-    async fn arm_save_failure(&self, session_id: &str) {
-        *self.fail_save_for.lock().await = Some(session_id.into());
-    }
-
-    async fn save_count(&self) -> usize {
-        self.saves.lock().await.len()
-    }
-
-    async fn saves_for(&self, session_id: &str) -> usize {
-        self.saves
-            .lock()
-            .await
-            .iter()
-            .filter(|(s, _)| s == session_id)
-            .count()
-    }
-}
-
-#[async_trait]
-impl SessionScopedCronStorage for RecordingStorage {
-    async fn load(&self, session_id: &str) -> Result<Vec<PersistedTask>, PersistError> {
-        Ok(self
-            .state
-            .lock()
-            .await
-            .get(session_id)
-            .cloned()
-            .unwrap_or_default())
-    }
-
-    async fn save_all(
-        &self,
-        session_id: &str,
-        tasks: &[PersistedTask],
-    ) -> Result<(), PersistError> {
-        let arm = self.fail_save_for.lock().await.clone();
-        if let Some(target) = arm
-            && target == session_id
-        {
-            *self.fail_save_for.lock().await = None;
-            return Err(PersistError::Io(std::io::Error::other("forced")));
-        }
-        self.saves
-            .lock()
-            .await
-            .push((session_id.into(), tasks.to_vec()));
-        self.state
-            .lock()
-            .await
-            .insert(session_id.into(), tasks.to_vec());
-        Ok(())
-    }
-}
+use crate::mock_storage::MockStorage;
 
 fn frozen_clock() -> (Arc<ManualClock>, DateTime<Utc>) {
     let now = Utc::now();
@@ -110,38 +25,40 @@ fn task(id: &str, cron: &str, prompt: &str, created: DateTime<Utc>) -> Persisted
 #[tokio::test]
 async fn unbound_to_session_loads_without_flushing() {
     let (clock, now) = frozen_clock();
-    let storage = RecordingStorage::new();
+    let storage = MockStorage::new();
     storage
         .seed("alpha", vec![task("a1", "*/5 * * * *", "hi", now)])
         .await;
-    let scheduler = CronScheduler::with_session_storage_and_clock(storage.clone(), clock);
+    let store_dyn: Arc<dyn SessionScopedCronStorage> = storage.clone();
+    let scheduler = CronScheduler::with_session_storage_and_clock(store_dyn, clock);
     assert_eq!(storage.save_count().await, 0);
     let n = scheduler.switch_session("alpha").await.expect("switch");
     assert_eq!(n, 1);
     assert_eq!(scheduler.list().await.len(), 1);
-    // No save fired during the switch — only a load.
     assert_eq!(storage.save_count().await, 0);
 }
 
 #[tokio::test]
 async fn switch_between_sessions_flushes_old_and_loads_new() {
     let (clock, now) = frozen_clock();
-    let storage = RecordingStorage::new();
+    let storage = MockStorage::new();
     storage
         .seed("alpha", vec![task("a1", "*/5 * * * *", "in alpha", now)])
         .await;
     storage
         .seed("beta", vec![task("b1", "0 9 * * *", "in beta", now)])
         .await;
-    let scheduler = CronScheduler::with_session_storage_and_clock(storage.clone(), clock);
+    let store_dyn: Arc<dyn SessionScopedCronStorage> = storage.clone();
+    let scheduler = CronScheduler::with_session_storage_and_clock(store_dyn, clock);
     scheduler.switch_session("alpha").await.unwrap();
+    scheduler.wait_idle().await;
     assert_eq!(scheduler.list().await[0].id, "a1");
     let baseline = storage.save_count().await;
     scheduler.switch_session("beta").await.unwrap();
+    scheduler.wait_idle().await;
     let listed = scheduler.list().await;
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].id, "b1");
-    // A flush against alpha must have happened during the swap.
     assert!(storage.saves_for("alpha").await >= 1);
     assert!(storage.save_count().await > baseline);
 }
@@ -149,11 +66,12 @@ async fn switch_between_sessions_flushes_old_and_loads_new() {
 #[tokio::test]
 async fn switch_to_same_session_is_noop() {
     let (clock, now) = frozen_clock();
-    let storage = RecordingStorage::new();
+    let storage = MockStorage::new();
     storage
         .seed("s", vec![task("s1", "*/5 * * * *", "hi", now)])
         .await;
-    let scheduler = CronScheduler::with_session_storage_and_clock(storage.clone(), clock);
+    let store_dyn: Arc<dyn SessionScopedCronStorage> = storage.clone();
+    let scheduler = CronScheduler::with_session_storage_and_clock(store_dyn, clock);
     scheduler.switch_session("s").await.unwrap();
     let baseline = storage.save_count().await;
     let n = scheduler.switch_session("s").await.unwrap();
@@ -164,17 +82,17 @@ async fn switch_to_same_session_is_noop() {
 #[tokio::test]
 async fn flush_failure_does_not_block_switch() {
     let (clock, now) = frozen_clock();
-    let storage = RecordingStorage::new();
+    let storage = MockStorage::new();
     storage
         .seed("alpha", vec![task("a1", "*/5 * * * *", "hi", now)])
         .await;
     storage
         .seed("beta", vec![task("b1", "0 9 * * *", "hi", now)])
         .await;
-    let scheduler = CronScheduler::with_session_storage_and_clock(storage.clone(), clock);
+    let store_dyn: Arc<dyn SessionScopedCronStorage> = storage.clone();
+    let scheduler = CronScheduler::with_session_storage_and_clock(store_dyn, clock);
     scheduler.switch_session("alpha").await.unwrap();
-    storage.arm_save_failure("alpha").await;
-    // Flush against alpha will fail; switch must still load beta.
+    storage.arm_save_failure_for("alpha").await;
     let n = scheduler.switch_session("beta").await.unwrap();
     assert_eq!(n, 1);
     assert_eq!(scheduler.list().await[0].id, "b1");
@@ -183,50 +101,7 @@ async fn flush_failure_does_not_block_switch() {
 #[tokio::test]
 async fn unbound_scheduler_switch_is_noop() {
     let (clock, _) = frozen_clock();
-    // No storage attached.
     let scheduler = CronScheduler::with_clock(clock);
     let n = scheduler.switch_session("any").await.unwrap();
     assert_eq!(n, 0);
-}
-
-#[tokio::test]
-async fn switch_resets_store_disabled_for_new_session() {
-    // After a corrupt-load on session A, store_disabled latches; switching
-    // to B must clear it so saves/loads against B work normally.
-    let (clock, now) = frozen_clock();
-    struct FailingLoadOnce {
-        target: Mutex<Option<String>>,
-        inner: Arc<RecordingStorage>,
-    }
-    #[async_trait]
-    impl SessionScopedCronStorage for FailingLoadOnce {
-        async fn load(&self, session_id: &str) -> Result<Vec<PersistedTask>, PersistError> {
-            if self.target.lock().await.as_deref() == Some(session_id) {
-                *self.target.lock().await = None;
-                return Err(PersistError::BadCron("forced".into()));
-            }
-            self.inner.load(session_id).await
-        }
-        async fn save_all(
-            &self,
-            session_id: &str,
-            tasks: &[PersistedTask],
-        ) -> Result<(), PersistError> {
-            self.inner.save_all(session_id, tasks).await
-        }
-    }
-    let inner = RecordingStorage::new();
-    inner
-        .seed("beta", vec![task("b1", "*/5 * * * *", "hi", now)])
-        .await;
-    let storage: Arc<FailingLoadOnce> = Arc::new(FailingLoadOnce {
-        target: Mutex::new(Some("alpha".into())),
-        inner,
-    });
-    let scheduler = CronScheduler::with_session_storage_and_clock(storage.clone(), clock);
-    let _ = scheduler.switch_session("alpha").await;
-    let n = scheduler.switch_session("beta").await.expect("beta loads");
-    assert_eq!(n, 1);
-    let _ = std::any::type_name::<RecordingStorage>();
-    let _ = AtomicBool::new(false).load(Ordering::SeqCst);
 }

--- a/crates/loopal-scheduler/tests/suite/tick_persistence_retry_test.rs
+++ b/crates/loopal-scheduler/tests/suite/tick_persistence_retry_test.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{TimeZone, Utc};
+use tokio_util::sync::CancellationToken;
+
+use loopal_scheduler::{CronScheduler, ManualClock, SessionScopedCronStorage};
+
+use crate::mock_storage::MockStorage;
+
+#[tokio::test(start_paused = true)]
+async fn save_failure_retries_on_next_tick() {
+    let t0 = Utc.with_ymd_and_hms(2026, 4, 10, 10, 0, 30).unwrap();
+    let clock = Arc::new(ManualClock::new(t0));
+    let store = MockStorage::new();
+    let store_dyn: Arc<dyn SessionScopedCronStorage> = store.clone();
+    let sched = Arc::new(CronScheduler::with_session_storage_and_clock(
+        store_dyn,
+        clock.clone(),
+    ));
+    sched.switch_session("retry-test").await.unwrap();
+
+    store.arm_save_failure();
+    sched.add("* * * * *", "p", true, true).await.expect("add");
+    sched.wait_idle().await;
+    assert_eq!(store.fail_save_attempts(), 1);
+    assert_eq!(store.save_count().await, 0);
+
+    let (tx, _rx) = tokio::sync::mpsc::channel(16);
+    let cancel = CancellationToken::new();
+    sched.start(tx, cancel.clone());
+
+    clock.set(Utc.with_ymd_and_hms(2026, 4, 10, 10, 0, 45).unwrap());
+    for _ in 0..3 {
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+    }
+    sched.wait_idle().await;
+
+    assert!(
+        store.save_count().await >= 1,
+        "dirty flag must trigger retry"
+    );
+    cancel.cancel();
+}

--- a/crates/loopal-scheduler/tests/suite/tick_persistence_test.rs
+++ b/crates/loopal-scheduler/tests/suite/tick_persistence_test.rs
@@ -1,65 +1,14 @@
-//! Tick loop persistence tests — durable save on fire/expire, single
-//! save per tick, dirty-flag retry on failure.
-
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
-use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
-use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
-use loopal_scheduler::{
-    CronScheduler, ManualClock, PersistError, PersistedTask, SessionScopedCronStorage,
-};
+use loopal_scheduler::{CronScheduler, ManualClock, SessionScopedCronStorage};
 
-/// Mock store tracking save order + optional first-call failure.
-struct TickStore {
-    saves: Mutex<Vec<Vec<PersistedTask>>>,
-    fail_next: AtomicBool,
-    fail_count: AtomicUsize,
-}
+use crate::mock_storage::MockStorage;
 
-impl TickStore {
-    fn new() -> Arc<Self> {
-        Arc::new(Self {
-            saves: Mutex::new(Vec::new()),
-            fail_next: AtomicBool::new(false),
-            fail_count: AtomicUsize::new(0),
-        })
-    }
-    fn arm_failure(&self) {
-        self.fail_next.store(true, Ordering::SeqCst);
-    }
-    async fn save_count(&self) -> usize {
-        self.saves.lock().await.len()
-    }
-    async fn last_save(&self) -> Vec<PersistedTask> {
-        self.saves.lock().await.last().cloned().unwrap_or_default()
-    }
-}
-
-#[async_trait]
-impl SessionScopedCronStorage for TickStore {
-    async fn load(&self, _session_id: &str) -> Result<Vec<PersistedTask>, PersistError> {
-        Ok(Vec::new())
-    }
-    async fn save_all(
-        &self,
-        _session_id: &str,
-        tasks: &[PersistedTask],
-    ) -> Result<(), PersistError> {
-        if self.fail_next.swap(false, Ordering::SeqCst) {
-            self.fail_count.fetch_add(1, Ordering::SeqCst);
-            return Err(PersistError::Io(std::io::Error::other("armed failure")));
-        }
-        self.saves.lock().await.push(tasks.to_vec());
-        Ok(())
-    }
-}
-
-async fn build(store: Arc<TickStore>, clock: Arc<ManualClock>) -> Arc<CronScheduler> {
+async fn build(store: Arc<MockStorage>, clock: Arc<ManualClock>) -> Arc<CronScheduler> {
     let store_dyn: Arc<dyn SessionScopedCronStorage> = store;
     let sched = Arc::new(CronScheduler::with_session_storage_and_clock(
         store_dyn, clock,
@@ -80,10 +29,10 @@ async fn pump_ticks(clock: &ManualClock, to: chrono::DateTime<chrono::Utc>, roun
 async fn recurring_durable_fire_persists_last_fired() {
     let t0 = Utc.with_ymd_and_hms(2026, 4, 10, 10, 0, 30).unwrap();
     let clock = Arc::new(ManualClock::new(t0));
-    let store = TickStore::new();
+    let store = MockStorage::new();
     let sched = build(store.clone(), clock.clone()).await;
     sched.add("* * * * *", "p", true, true).await.expect("add");
-    // `add` with durable=true issues one initial save.
+    sched.wait_idle().await;
     let initial_saves = store.save_count().await;
     assert_eq!(initial_saves, 1);
 
@@ -101,6 +50,7 @@ async fn recurring_durable_fire_persists_last_fired() {
         .await
         .expect("fire")
         .expect("open");
+    sched.wait_idle().await;
 
     assert!(store.save_count().await > initial_saves, "fire must save");
     let last = store.last_save().await;
@@ -116,7 +66,7 @@ async fn recurring_durable_fire_persists_last_fired() {
 async fn oneshot_durable_fire_removes_from_store() {
     let t0 = Utc.with_ymd_and_hms(2026, 4, 10, 10, 0, 30).unwrap();
     let clock = Arc::new(ManualClock::new(t0));
-    let store = TickStore::new();
+    let store = MockStorage::new();
     let sched = build(store.clone(), clock.clone()).await;
     sched
         .add("* * * * *", "once", false, true)
@@ -146,12 +96,12 @@ async fn oneshot_durable_fire_removes_from_store() {
 async fn multiple_fires_in_one_tick_save_once() {
     let t0 = Utc.with_ymd_and_hms(2026, 4, 10, 10, 0, 30).unwrap();
     let clock = Arc::new(ManualClock::new(t0));
-    let store = TickStore::new();
+    let store = MockStorage::new();
     let sched = build(store.clone(), clock.clone()).await;
-    // Three durable tasks all firing at the same minute.
     sched.add("* * * * *", "a", true, true).await.expect("add");
     sched.add("* * * * *", "b", true, true).await.expect("add");
     sched.add("* * * * *", "c", true, true).await.expect("add");
+    sched.wait_idle().await;
     let baseline = store.save_count().await;
 
     let (tx, mut rx) = tokio::sync::mpsc::channel(16);
@@ -164,45 +114,12 @@ async fn multiple_fires_in_one_tick_save_once() {
         3,
     )
     .await;
-    // Drain triggers.
     for _ in 0..3 {
         let _ = tokio::time::timeout(Duration::from_secs(2), rx.recv()).await;
     }
+    sched.wait_idle().await;
 
-    // Exactly one additional save for this tick — not three.
     let after = store.save_count().await;
     assert_eq!(after - baseline, 1, "batched fires must save once");
-    cancel.cancel();
-}
-
-#[tokio::test(start_paused = true)]
-async fn save_failure_retries_on_next_tick() {
-    let t0 = Utc.with_ymd_and_hms(2026, 4, 10, 10, 0, 30).unwrap();
-    let clock = Arc::new(ManualClock::new(t0));
-    let store = TickStore::new();
-    let sched = build(store.clone(), clock.clone()).await;
-    // First save (from add) will fail.
-    store.arm_failure();
-    sched.add("* * * * *", "p", true, true).await.expect("add");
-    assert_eq!(store.fail_count.load(Ordering::SeqCst), 1);
-    // No successful save yet.
-    assert_eq!(store.save_count().await, 0);
-
-    let (tx, _rx) = tokio::sync::mpsc::channel(16);
-    let cancel = CancellationToken::new();
-    sched.start(tx, cancel.clone());
-
-    // One tick with no firing task still retries because dirty=true.
-    pump_ticks(
-        &clock,
-        Utc.with_ymd_and_hms(2026, 4, 10, 10, 0, 45).unwrap(),
-        3,
-    )
-    .await;
-
-    assert!(
-        store.save_count().await >= 1,
-        "dirty flag must trigger retry"
-    );
     cancel.cancel();
 }

--- a/crates/loopal-scheduler/tests/suite/tick_test.rs
+++ b/crates/loopal-scheduler/tests/suite/tick_test.rs
@@ -73,7 +73,7 @@ async fn tick_removes_oneshot_after_fire() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn tick_expires_after_3_days() {
+async fn tick_keeps_recurring_task_beyond_three_days() {
     let t0 = Utc.with_ymd_and_hms(2026, 3, 29, 10, 0, 0).unwrap();
     let clock = Arc::new(ManualClock::new(t0));
 
@@ -86,7 +86,11 @@ async fn tick_expires_after_3_days() {
         tokio::task::yield_now().await;
     }
 
-    assert!(sched.list().await.is_empty(), "task should have expired");
+    assert_eq!(
+        sched.list().await.len(),
+        1,
+        "recurring task must survive past the old 3-day lifetime cap"
+    );
     cancel.cancel();
 }
 

--- a/crates/loopal-test-support/src/wiring.rs
+++ b/crates/loopal-test-support/src/wiring.rs
@@ -103,6 +103,8 @@ pub(crate) async fn wire(builder: HarnessBuilder) -> (SpawnedHarness, AgentLoopR
     } else {
         loopal_agent::shared::SchedulerHandle::create()
     };
+    // Test fixtures don't switch sessions; activate the tick loop now.
+    scheduler_handle.start();
     let shared = Arc::new(AgentShared {
         kernel: kernel.clone(),
         task_store: Arc::new(TaskStore::with_sessions_root(tasks_dir)),


### PR DESCRIPTION
## Summary
- Extract disk I/O from mutation paths into a dedicated save worker with message queue
- Add `wait_idle()` barrier API for test synchronization
- Consolidate test infrastructure with shared `MockStorage`

## Changes
- `crates/loopal-scheduler/src/save_worker.rs` — new async save worker
- `crates/loopal-scheduler/src/scheduler.rs` — integrate save worker channel
- `crates/loopal-scheduler/src/tick.rs` — use save worker instead of inline I/O
- `crates/loopal-scheduler/tests/suite/mock_storage.rs` — shared test helper
- Various test files — deduplicate helpers, use shared mock

## Test plan
- [x] `bazel test //crates/loopal-scheduler:suite` passes
- [x] `bazel build //... --config=clippy` passes
- [ ] CI passes