### PR TITLE
fix(scheduler): remove wait_idle from startup path

### DIFF
--- a/crates/loopal-agent-server/src/session_start.rs
+++ b/crates/loopal-agent-server/src/session_start.rs
@@ -102,13 +102,9 @@ pub(crate) async fn start_session(
         {
             tracing::warn!(error = %e, "failed to bind scheduler to session");
         }
-        // Wait for the previous session's flush + this session's
-        // normalization save to land on disk before the tick loop
-        // starts firing. Setup-time block is acceptable; tick-time
-        // saves remain fire-and-forget.
-        scheduler_for_bridge.wait_idle().await;
         // Tick loop activates after switch_session so the first survey
         // sees the loaded task set, not an empty in-memory state.
+        // Disk sync is fire-and-forget — failures retry via dirty flag.
         agent_shared_for_session.scheduler_handle.start();
 
         let session_id = agent_params.session().id.clone();

--- a/crates/loopal-scheduler/src/scheduler.rs
+++ b/crates/loopal-scheduler/src/scheduler.rs
@@ -142,6 +142,10 @@ impl CronScheduler {
     /// processed by the background worker. Useful for tests and tooling
     /// that need a synchronization point against on-disk state without
     /// polling. No-op if the worker channel has closed.
+    ///
+    /// **Warning**: This method blocks until all pending saves complete.
+    /// Do NOT use in production startup paths — disk I/O latency would
+    /// block handshake and cause timeouts. Use only in tests or tooling.
     pub async fn wait_idle(&self) {
         let (tx, rx) = tokio::sync::oneshot::channel();
         if self.save_tx.send(SaveMessage::Barrier(tx)).await.is_err() {


### PR DESCRIPTION
## Summary
- Remove `wait_idle()` call from session startup path that was blocking handshake on `--resume`
- Add warning documentation to `wait_idle()` clarifying it's for tests/tooling only

## Changes
- `crates/loopal-agent-server/src/session_start.rs`: Remove blocking `wait_idle()` call
- `crates/loopal-scheduler/src/scheduler.rs`: Add warning doc to `wait_idle()`

## Root Cause
`wait_idle()` blocks until all pending saves complete. On `--resume`, cron normalization triggers disk I/O via the save worker. If the save is slow, `wait_idle()` blocks the startup path, causing the 30s handshake timeout.

The tick loop only needs the in-memory task set to be correct (which `switch_session` guarantees synchronously). Disk sync is fire-and-forget with dirty-flag retry on failure.

## Test plan
- [x] All 75 tests pass
- [ ] CI passes