### PR TITLE
feat(provider): add OPENAI_BASE_URL env var and GPT-5.5 model

### DIFF
--- a/crates/loopal-kernel/src/provider_registry.rs
+++ b/crates/loopal-kernel/src/provider_registry.rs
@@ -61,10 +61,17 @@ pub fn register_providers(settings: &Settings, registry: &mut ProviderRegistry) 
 
     if let Some(api_key) = openai_key {
         let mut provider = OpenAiProvider::new(api_key);
-        if let Some(ref config) = providers.openai
-            && let Some(ref base_url) = config.base_url
-        {
-            provider = provider.with_base_url(base_url.clone());
+        let base_url = providers
+            .openai
+            .as_ref()
+            .and_then(|c| c.base_url.clone())
+            .or_else(|| {
+                std::env::var("OPENAI_BASE_URL")
+                    .ok()
+                    .filter(|u| !u.is_empty())
+            });
+        if let Some(url) = base_url {
+            provider = provider.with_base_url(url);
         }
         registry.register(Arc::new(provider));
         info!("registered openai provider");

--- a/crates/loopal-provider/src/model_info/catalog_openai.rs
+++ b/crates/loopal-provider/src/model_info/catalog_openai.rs
@@ -115,4 +115,18 @@ pub(super) static OPENAI_MODELS: &[ModelEntry] = &[
         supports_vision: true,
         supports_prefill: true,
     },
+    ModelEntry {
+        id: "gpt-5.5",
+        provider: "openai",
+        display_name: "GPT-5.5",
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        thinking: ThinkingCapability::None,
+        speed: SpeedTier::Medium,
+        cost: CostTier::High,
+        quality: QualityTier::Premium,
+        supports_tools: true,
+        supports_vision: true,
+        supports_prefill: true,
+    },
 ];


### PR DESCRIPTION
## Summary
- Add `OPENAI_BASE_URL` environment variable support for OpenAI provider (consistent with `ANTHROPIC_BASE_URL`)
- Add GPT-5.5 to model catalog with correct specs (1M context, 128K output, vision support)

## Changes
- `crates/loopal-kernel/src/provider_registry.rs` — env var fallback for base_url
- `crates/loopal-provider/src/model_info/catalog_openai.rs` — GPT-5.5 model entry

## Test plan
- [ ] CI passes