### PR TITLE
fix(tools): treat empty process_id as absent in Bash tool

### DIFF
--- a/crates/tools/process/bash/src/lib.rs
+++ b/crates/tools/process/bash/src/lib.rs
@@ -101,7 +101,7 @@ impl Tool for BashTool {
     }
 
     async fn execute(&self, input: Value, ctx: &ToolContext) -> Result<ToolResult, LoopalError> {
-        if let Some(pid) = input["process_id"].as_str() {
+        if let Some(pid) = input["process_id"].as_str().filter(|s| !s.is_empty()) {
             if input["stop"].as_bool().unwrap_or(false) {
                 return Ok(bg_ops::bg_stop(&self.store, pid));
             }


### PR DESCRIPTION
## Summary
- Filter empty `process_id` strings in Bash tool so they don't trigger background-process lookup
- Same class of bug as the Read tool `pages: ""` issue fixed in #155

## Changes
- `crates/tools/process/bash/src/lib.rs` — add `.filter(|s| !s.is_empty())` to `process_id` extraction

## Test plan
- [x] Clippy passes locally
- [ ] CI passes