### PR TITLE
fix(provider): preserve OpenAI reasoning item for web_search_call multi-turn

### DIFF
--- a/crates/loopal-provider/src/openai/input_builder.rs
+++ b/crates/loopal-provider/src/openai/input_builder.rs
@@ -127,8 +127,22 @@ fn build_assistant_items(blocks: &[ContentBlock], input: &mut Vec<Value>) {
                     "action": {"type": "search", "query": args.get("query").and_then(|v| v.as_str()).unwrap_or("")}
                 }));
             }
-            ContentBlock::Thinking { .. }
-            | ContentBlock::ServerToolResult { .. }
+            ContentBlock::Thinking {
+                thinking,
+                signature,
+            } => {
+                flush_assistant_text(&mut text_parts, input);
+                // reason: OpenAI requires reasoning item before web_search_call in multi-turn
+                let id = signature.clone().unwrap_or_default();
+                if !id.is_empty() {
+                    input.push(json!({
+                        "type": "reasoning",
+                        "id": id,
+                        "summary": [{"type": "summary_text", "text": thinking}]
+                    }));
+                }
+            }
+            ContentBlock::ServerToolResult { .. }
             | ContentBlock::Image { .. }
             | ContentBlock::ToolResult { .. } => {}
         }

--- a/crates/loopal-provider/src/openai/stream.rs
+++ b/crates/loopal-provider/src/openai/stream.rs
@@ -162,6 +162,13 @@ fn parse_output_item_done(item: &Value, chunks: &mut Vec<Result<StreamChunk, Loo
                 content: json!({"status": "completed"}),
             }));
         }
+        "reasoning" => {
+            // reason: OpenAI requires the reasoning item ID when replaying web_search_call
+            let id = item["id"].as_str().unwrap_or("").to_string();
+            if !id.is_empty() {
+                chunks.push(Ok(StreamChunk::ThinkingSignature { signature: id }));
+            }
+        }
         _ => {}
     }
 }

--- a/crates/loopal-provider/tests/suite.rs
+++ b/crates/loopal-provider/tests/suite.rs
@@ -23,6 +23,10 @@ mod model_info_overlay_test;
 mod model_info_test;
 #[path = "suite/model_supports_prefill_test.rs"]
 mod model_supports_prefill_test;
+#[path = "suite/openai_reasoning_e2e_test.rs"]
+mod openai_reasoning_e2e_test;
+#[path = "suite/openai_reasoning_test.rs"]
+mod openai_reasoning_test;
 #[path = "suite/openai_request_test.rs"]
 mod openai_request_test;
 #[path = "suite/openai_stream_edge_test.rs"]

--- a/crates/loopal-provider/tests/suite/openai_reasoning_e2e_test.rs
+++ b/crates/loopal-provider/tests/suite/openai_reasoning_e2e_test.rs
@@ -59,9 +59,18 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"usage\"
             _ => {}
         }
     }
-    assert!(got_thinking, "expected Thinking chunk from reasoning_summary_text.delta");
-    assert!(got_signature, "expected ThinkingSignature from reasoning output_item.done");
-    assert!(got_server_tool_use, "expected ServerToolUse from web_search_call");
+    assert!(
+        got_thinking,
+        "expected Thinking chunk from reasoning_summary_text.delta"
+    );
+    assert!(
+        got_signature,
+        "expected ThinkingSignature from reasoning output_item.done"
+    );
+    assert!(
+        got_server_tool_use,
+        "expected ServerToolUse from web_search_call"
+    );
     assert!(got_text, "expected Text chunk");
 }
 

--- a/crates/loopal-provider/tests/suite/openai_reasoning_e2e_test.rs
+++ b/crates/loopal-provider/tests/suite/openai_reasoning_e2e_test.rs
@@ -1,0 +1,95 @@
+use super::stream_helpers::{collect_chunks, test_chat_params};
+use loopal_provider::OpenAiProvider;
+use loopal_provider_api::{Provider, StreamChunk};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn reasoning_and_web_search_round_trip() {
+    let mock_server = MockServer::start().await;
+
+    let sse_body = "\
+event: response.reasoning_summary_text.delta\n\
+data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"Searching for info\"}\n\n\
+event: response.output_item.done\n\
+data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"reasoning\",\"id\":\"rs_abc123\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Searching for info\"}]}}\n\n\
+event: response.output_item.done\n\
+data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"web_search_call\",\"id\":\"ws_def456\",\"status\":\"completed\",\"action\":{\"type\":\"search\",\"query\":\"rust async\"}}}\n\n\
+event: response.output_text.delta\n\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"Here is what I found.\"}\n\n\
+event: response.completed\n\
+data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"usage\":{\"input_tokens\":20,\"output_tokens\":10,\"total_tokens\":30}}}\n\n";
+
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&mock_server)
+        .await;
+
+    let provider = OpenAiProvider::new("test-key".to_string()).with_base_url(mock_server.uri());
+
+    let stream = provider.stream_chat(&test_chat_params()).await.unwrap();
+    let chunks = collect_chunks(stream).await;
+
+    let mut got_thinking = false;
+    let mut got_signature = false;
+    let mut got_server_tool_use = false;
+    let mut got_text = false;
+
+    for chunk in chunks.into_iter().flatten() {
+        match chunk {
+            StreamChunk::Thinking { text } => {
+                assert_eq!(text, "Searching for info");
+                got_thinking = true;
+            }
+            StreamChunk::ThinkingSignature { signature } => {
+                assert_eq!(signature, "rs_abc123");
+                got_signature = true;
+            }
+            StreamChunk::ServerToolUse { id, name, input } => {
+                assert_eq!(id, "ws_def456");
+                assert_eq!(name, "web_search");
+                assert_eq!(input["query"], "rust async");
+                got_server_tool_use = true;
+            }
+            StreamChunk::Text { text } => {
+                assert_eq!(text, "Here is what I found.");
+                got_text = true;
+            }
+            _ => {}
+        }
+    }
+    assert!(got_thinking, "expected Thinking chunk from reasoning_summary_text.delta");
+    assert!(got_signature, "expected ThinkingSignature from reasoning output_item.done");
+    assert!(got_server_tool_use, "expected ServerToolUse from web_search_call");
+    assert!(got_text, "expected Text chunk");
+}
+
+#[tokio::test]
+async fn reasoning_id_missing_does_not_emit_signature() {
+    let mock_server = MockServer::start().await;
+
+    let sse_body = "\
+event: response.output_item.done\n\
+data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"reasoning\",\"id\":\"\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"thinking\"}]}}\n\n\
+event: response.completed\n\
+data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"usage\":{\"input_tokens\":5,\"output_tokens\":3,\"total_tokens\":8}}}\n\n";
+
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&mock_server)
+        .await;
+
+    let provider = OpenAiProvider::new("test-key".to_string()).with_base_url(mock_server.uri());
+
+    let stream = provider.stream_chat(&test_chat_params()).await.unwrap();
+    let chunks = collect_chunks(stream).await;
+
+    for chunk in chunks.into_iter().flatten() {
+        assert!(
+            !matches!(chunk, StreamChunk::ThinkingSignature { .. }),
+            "empty reasoning ID should not emit ThinkingSignature"
+        );
+    }
+}

--- a/crates/loopal-provider/tests/suite/openai_reasoning_test.rs
+++ b/crates/loopal-provider/tests/suite/openai_reasoning_test.rs
@@ -1,0 +1,149 @@
+use loopal_message::{ContentBlock, Message, MessageRole};
+use loopal_provider::OpenAiProvider;
+use loopal_provider_api::ChatParams;
+use serde_json::json;
+
+fn make_provider() -> OpenAiProvider {
+    OpenAiProvider::new("test-key".to_string())
+}
+
+fn make_params(messages: Vec<Message>, system_prompt: &str) -> ChatParams {
+    ChatParams {
+        model: "gpt-5.5".to_string(),
+        messages,
+        system_prompt: system_prompt.to_string(),
+        tools: vec![],
+        max_tokens: 4096,
+        temperature: None,
+        thinking: None,
+        continuation_intent: None,
+        debug_dump_dir: None,
+    }
+}
+
+#[test]
+fn thinking_becomes_reasoning_item() {
+    let provider = make_provider();
+    let params = make_params(
+        vec![Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: vec![
+                ContentBlock::Thinking {
+                    thinking: "Let me search for that.".to_string(),
+                    signature: Some("rs_abc123".to_string()),
+                },
+                ContentBlock::ServerToolUse {
+                    id: "ws_def456".to_string(),
+                    name: "web_search".to_string(),
+                    input: json!({"query": "rust async"}),
+                },
+            ],
+        }],
+        "",
+    );
+    let input = provider.build_input(&params);
+    assert_eq!(input.len(), 2);
+    assert_eq!(input[0]["type"], "reasoning");
+    assert_eq!(input[0]["id"], "rs_abc123");
+    assert_eq!(input[0]["summary"][0]["type"], "summary_text");
+    assert_eq!(input[0]["summary"][0]["text"], "Let me search for that.");
+    assert_eq!(input[1]["type"], "web_search_call");
+    assert_eq!(input[1]["id"], "ws_def456");
+}
+
+#[test]
+fn thinking_without_signature_skipped() {
+    let provider = make_provider();
+    let params = make_params(
+        vec![Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: vec![
+                ContentBlock::Thinking {
+                    thinking: "some thought".to_string(),
+                    signature: None,
+                },
+                ContentBlock::Text {
+                    text: "Hello".to_string(),
+                },
+            ],
+        }],
+        "",
+    );
+    let input = provider.build_input(&params);
+    assert_eq!(input.len(), 1);
+    assert_eq!(input[0]["type"], "message");
+    assert_eq!(input[0]["role"], "assistant");
+}
+
+#[test]
+fn thinking_with_empty_signature_skipped() {
+    let provider = make_provider();
+    let params = make_params(
+        vec![Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: vec![
+                ContentBlock::Thinking {
+                    thinking: "some thought".to_string(),
+                    signature: Some(String::new()),
+                },
+                ContentBlock::Text {
+                    text: "Hello".to_string(),
+                },
+            ],
+        }],
+        "",
+    );
+    let input = provider.build_input(&params);
+    assert_eq!(input.len(), 1);
+    assert_eq!(input[0]["type"], "message");
+}
+
+#[test]
+fn multi_turn_reasoning_before_web_search() {
+    let provider = make_provider();
+    let params = make_params(
+        vec![
+            Message {
+                id: None,
+                role: MessageRole::Assistant,
+                content: vec![
+                    ContentBlock::Thinking {
+                        thinking: "First search".to_string(),
+                        signature: Some("rs_001".to_string()),
+                    },
+                    ContentBlock::ServerToolUse {
+                        id: "ws_001".to_string(),
+                        name: "web_search".to_string(),
+                        input: json!({"query": "first query"}),
+                    },
+                    ContentBlock::Text {
+                        text: "Found it.".to_string(),
+                    },
+                ],
+            },
+            Message::user("Tell me more"),
+            Message {
+                id: None,
+                role: MessageRole::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "Sure, here's more.".to_string(),
+                }],
+            },
+        ],
+        "",
+    );
+    let input = provider.build_input(&params);
+    assert_eq!(input[0]["type"], "reasoning");
+    assert_eq!(input[0]["id"], "rs_001");
+    assert_eq!(input[1]["type"], "web_search_call");
+    assert_eq!(input[1]["id"], "ws_001");
+    assert_eq!(input[2]["type"], "message");
+    assert_eq!(input[2]["role"], "assistant");
+    assert_eq!(input[3]["type"], "message");
+    assert_eq!(input[3]["role"], "user");
+    assert_eq!(input[4]["type"], "message");
+    assert_eq!(input[4]["role"], "assistant");
+}

--- a/crates/loopal-provider/tests/suite/openai_request_test.rs
+++ b/crates/loopal-provider/tests/suite/openai_request_test.rs
@@ -145,6 +145,5 @@ fn test_system_prompt_not_in_input() {
     let provider = make_provider();
     let params = make_params(vec![], vec![], "You are helpful");
     let input = provider.build_input(&params);
-    // System prompt goes to `instructions`, not in input array
     assert!(input.is_empty());
 }

--- a/crates/loopal-runtime/src/agent_loop/llm_record.rs
+++ b/crates/loopal-runtime/src/agent_loop/llm_record.rs
@@ -20,7 +20,9 @@ impl AgentLoopRunner {
         // Thinking block goes first (Anthropic API requires this order).
         // Skip if signature is missing — an unsigned thinking block (e.g. from
         // an interrupted stream) fails API validation on the next multi-turn call.
-        if !thinking_text.is_empty() && thinking_signature.is_some() {
+        // For OpenAI, signature stores the reasoning item ID — save even if text is empty.
+        if thinking_signature.is_some() && (!thinking_text.is_empty() || !server_blocks.is_empty())
+        {
             assistant_content.push(ContentBlock::Thinking {
                 thinking: thinking_text.to_string(),
                 signature: thinking_signature.map(String::from),


### PR DESCRIPTION
## Summary
- Fix GPT-5.5 400 error: `web_search_call` item was provided without its required `reasoning` item
- Parse `reasoning` output item from OpenAI Responses API stream, storing its ID via `ThinkingSignature`
- Convert `ContentBlock::Thinking` to OpenAI `reasoning` input item on multi-turn replay

## Changes
- `crates/loopal-provider/src/openai/stream.rs` — handle `"reasoning"` in `parse_output_item_done`
- `crates/loopal-provider/src/openai/input_builder.rs` — emit `reasoning` item from `ContentBlock::Thinking`
- `crates/loopal-runtime/src/agent_loop/llm_record.rs` — relax save condition for thinking blocks with server blocks
- New test files: `openai_reasoning_test.rs`, `openai_reasoning_e2e_test.rs`

## Test plan
- [x] `bazel test //crates/loopal-provider:loopal-provider_test` passes
- [x] `bazel test //crates/loopal-provider:loopal-provider-unit-test` passes
- [x] `bazel test //crates/loopal-runtime:loopal-runtime-unit-test` passes
- [x] `bazel build //... --config=clippy` zero warnings
- [ ] CI passes