### PR TITLE
fix(tool-api): ensure object schemas always include properties field

### DIFF
--- a/crates/loopal-tool-api/src/schema_normalize.rs
+++ b/crates/loopal-tool-api/src/schema_normalize.rs
@@ -16,6 +16,7 @@ pub fn normalize_schema(mut schema: Value) -> Value {
 
     inline_refs_recursive(&mut schema, &definitions);
     strip_titles_recursive(&mut schema);
+    ensure_object_properties_recursive(&mut schema);
     schema
 }
 
@@ -64,5 +65,30 @@ fn strip_titles_recursive(value: &mut Value) {
             }
         }
         _ => {}
+    }
+}
+
+fn ensure_object_properties_recursive(value: &mut Value) {
+    let Value::Object(map) = value else { return };
+
+    let is_object_type = map
+        .get("type")
+        .and_then(|v| v.as_str())
+        .is_some_and(|t| t == "object");
+
+    if is_object_type && !map.contains_key("properties") {
+        map.insert("properties".into(), Value::Object(Map::new()));
+    }
+
+    for v in map.values_mut() {
+        match v {
+            Value::Object(_) => ensure_object_properties_recursive(v),
+            Value::Array(arr) => {
+                for item in arr.iter_mut() {
+                    ensure_object_properties_recursive(item);
+                }
+            }
+            _ => {}
+        }
     }
 }

--- a/crates/loopal-tool-api/tests/suite/schema_normalize_test.rs
+++ b/crates/loopal-tool-api/tests/suite/schema_normalize_test.rs
@@ -133,3 +133,67 @@ fn handles_unresolvable_ref_gracefully() {
     let result = normalize_schema(schema);
     assert_eq!(result["properties"]["x"]["$ref"], "#/definitions/Missing");
 }
+
+#[test]
+fn adds_properties_to_empty_object_schema() {
+    let schema = json!({"type": "object"});
+    let result = normalize_schema(schema);
+    assert_eq!(result, json!({"type": "object", "properties": {}}));
+}
+
+#[test]
+fn preserves_existing_properties() {
+    let schema = json!({
+        "type": "object",
+        "properties": {"name": {"type": "string"}}
+    });
+    let result = normalize_schema(schema);
+    assert_eq!(result["properties"]["name"]["type"], "string");
+}
+
+#[test]
+fn adds_properties_to_nested_object_without_properties() {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "nested": {"type": "object"}
+        }
+    });
+    let result = normalize_schema(schema);
+    assert_eq!(
+        result["properties"]["nested"],
+        json!({"type": "object", "properties": {}})
+    );
+}
+
+#[test]
+fn adds_properties_to_object_in_array_items() {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "list": {
+                "type": "array",
+                "items": {"type": "object"}
+            }
+        }
+    });
+    let result = normalize_schema(schema);
+    assert_eq!(
+        result["properties"]["list"]["items"],
+        json!({"type": "object", "properties": {}})
+    );
+}
+
+#[test]
+fn does_not_add_properties_to_non_object_types() {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "count": {"type": "integer"},
+            "tags": {"type": "array", "items": {"type": "string"}}
+        }
+    });
+    let result = normalize_schema(schema);
+    assert!(result["properties"]["count"].get("properties").is_none());
+    assert!(result["properties"]["tags"].get("properties").is_none());
+}


### PR DESCRIPTION
## Summary
- OpenAI/Gemini APIs reject function schemas where `type=object` lacks a `properties` field
- `schemars` generates bare `{"type":"object"}` for empty structs (e.g. `EnterPlanModeParams`)
- Added recursive normalization pass in `normalize_schema()` that inserts `"properties":{}` for all object-typed nodes

## Changes
- `crates/loopal-tool-api/src/schema_normalize.rs` — new `ensure_object_properties_recursive()` function
- `crates/loopal-tool-api/tests/suite/schema_normalize_test.rs` — 5 new test cases

## Test plan
- [x] `bazel test //crates/loopal-tool-api:loopal-tool-api_test` passes
- [x] `bazel build //crates/loopal-tool-api:loopal-tool-api --config=clippy` passes
- [ ] CI passes