### PR TITLE
fix(provider): flush each OpenAI reasoning item as independent Thinking block

### DIFF
--- a/crates/loopal-provider/tests/suite/openai_reasoning_test.rs
+++ b/crates/loopal-provider/tests/suite/openai_reasoning_test.rs
@@ -102,6 +102,67 @@ fn thinking_with_empty_signature_skipped() {
 }
 
 #[test]
+fn multiple_reasoning_items_paired_with_web_search_calls() {
+    let provider = make_provider();
+    let params = make_params(
+        vec![
+            Message::user("search for rust and python"),
+            Message {
+                id: None,
+                role: MessageRole::Assistant,
+                content: vec![
+                    ContentBlock::Thinking {
+                        thinking: "Search rust".to_string(),
+                        signature: Some("rs_001".to_string()),
+                    },
+                    ContentBlock::ServerToolUse {
+                        id: "ws_001".to_string(),
+                        name: "web_search".to_string(),
+                        input: json!({"query": "rust"}),
+                    },
+                    ContentBlock::ServerToolResult {
+                        block_type: "web_search_tool_result".to_string(),
+                        tool_use_id: "ws_001".to_string(),
+                        content: json!({"status": "completed"}),
+                    },
+                    ContentBlock::Thinking {
+                        thinking: "Search python".to_string(),
+                        signature: Some("rs_002".to_string()),
+                    },
+                    ContentBlock::ServerToolUse {
+                        id: "ws_002".to_string(),
+                        name: "web_search".to_string(),
+                        input: json!({"query": "python"}),
+                    },
+                    ContentBlock::ServerToolResult {
+                        block_type: "web_search_tool_result".to_string(),
+                        tool_use_id: "ws_002".to_string(),
+                        content: json!({"status": "completed"}),
+                    },
+                    ContentBlock::Text {
+                        text: "Here are the results.".to_string(),
+                    },
+                ],
+            },
+        ],
+        "",
+    );
+    let input = provider.build_input(&params);
+    assert_eq!(input[0]["type"], "message");
+    assert_eq!(input[0]["role"], "user");
+    assert_eq!(input[1]["type"], "reasoning");
+    assert_eq!(input[1]["id"], "rs_001");
+    assert_eq!(input[2]["type"], "web_search_call");
+    assert_eq!(input[2]["id"], "ws_001");
+    assert_eq!(input[3]["type"], "reasoning");
+    assert_eq!(input[3]["id"], "rs_002");
+    assert_eq!(input[4]["type"], "web_search_call");
+    assert_eq!(input[4]["id"], "ws_002");
+    assert_eq!(input[5]["type"], "message");
+    assert_eq!(input[5]["role"], "assistant");
+}
+
+#[test]
 fn multi_turn_reasoning_before_web_search() {
     let provider = make_provider();
     let params = make_params(

--- a/crates/loopal-runtime/src/agent_loop/llm_chunk.rs
+++ b/crates/loopal-runtime/src/agent_loop/llm_chunk.rs
@@ -29,12 +29,10 @@ impl AgentLoopRunner {
             Ok(StreamChunk::ThinkingSignature { signature }) => {
                 // reason: OpenAI emits multiple reasoning items (one per web_search_call);
                 // flush each as a Thinking block in stream order so replay has correct pairing
-                result
-                    .server_blocks
-                    .push(ContentBlock::Thinking {
-                        thinking: std::mem::take(&mut result.thinking_text),
-                        signature: Some(signature),
-                    });
+                result.server_blocks.push(ContentBlock::Thinking {
+                    thinking: std::mem::take(&mut result.thinking_text),
+                    signature: Some(signature),
+                });
             }
             Ok(StreamChunk::ToolUse { id, name, input }) => {
                 self.emit_in_turn(AgentEventPayload::ToolCall {

--- a/crates/loopal-runtime/src/agent_loop/llm_chunk.rs
+++ b/crates/loopal-runtime/src/agent_loop/llm_chunk.rs
@@ -27,7 +27,14 @@ impl AgentLoopRunner {
                     .await?;
             }
             Ok(StreamChunk::ThinkingSignature { signature }) => {
-                result.thinking_signature = Some(signature);
+                // reason: OpenAI emits multiple reasoning items (one per web_search_call);
+                // flush each as a Thinking block in stream order so replay has correct pairing
+                result
+                    .server_blocks
+                    .push(ContentBlock::Thinking {
+                        thinking: std::mem::take(&mut result.thinking_text),
+                        signature: Some(signature),
+                    });
             }
             Ok(StreamChunk::ToolUse { id, name, input }) => {
                 self.emit_in_turn(AgentEventPayload::ToolCall {


### PR DESCRIPTION
## Summary
- OpenAI emits one reasoning item per web_search_call in a single response, but the old code overwrote `thinking_signature` on each ThinkingSignature chunk, keeping only the last ID
- On multi-turn replay, N-1 web_search_call items lacked their required reasoning predecessor, causing API 400 errors
- Fix: on each ThinkingSignature, immediately flush accumulated thinking text + signature as a ContentBlock::Thinking into server_blocks, preserving the 1:1 pairing

## Changes
- `crates/loopal-runtime/src/agent_loop/llm_chunk.rs` — flush ThinkingSignature into server_blocks instead of overwriting single field
- `crates/loopal-provider/tests/suite/openai_reasoning_test.rs` — add multi-reasoning pairing test

## Test plan
- [x] `bazel test //crates/loopal-provider:loopal-provider_test` passes
- [x] `bazel test //crates/loopal-runtime:loopal-runtime_test` passes
- [x] `bazel test //crates/loopal-context:loopal-context_test` passes
- [x] `bazel build //crates/loopal-runtime:loopal-runtime --config=clippy` zero warnings
- [ ] CI passes