### PR TITLE
feat(goal): allow Complete → Active reopen so model can recover from premature complete

### DIFF
--- a/crates/loopal-protocol/src/control.rs
+++ b/crates/loopal-protocol/src/control.rs
@@ -49,5 +49,6 @@ pub enum ControlCommand {
     GoalUserPause,
     GoalUserResume,
     GoalUserComplete,
+    GoalUserReopen,
     GoalClear,
 }

--- a/crates/loopal-protocol/src/thread_goal.rs
+++ b/crates/loopal-protocol/src/thread_goal.rs
@@ -57,6 +57,8 @@ pub enum GoalTransitionReason {
     UserCreated,
     ModelCompleted,
     UserCompleted,
+    ModelReopened,
+    UserReopened,
     UserPaused,
     UserResumed,
     UserCleared,
@@ -76,6 +78,7 @@ impl ThreadGoalStatus {
             ) | (S::Active, S::Paused, R::UserPaused)
                 | (S::Paused, S::Active, R::UserResumed)
                 | (S::Paused, S::Complete, R::UserCompleted)
+                | (S::Complete, S::Active, R::ModelReopened | R::UserReopened)
         )
     }
 }

--- a/crates/loopal-protocol/tests/suite/thread_goal_test.rs
+++ b/crates/loopal-protocol/tests/suite/thread_goal_test.rs
@@ -6,10 +6,27 @@ const ALL_STATUSES: &[ThreadGoalStatus] = &[
     ThreadGoalStatus::Complete,
 ];
 
+const NON_REOPEN_REASONS: &[GoalTransitionReason] = &[
+    GoalTransitionReason::UserCreated,
+    GoalTransitionReason::ModelCompleted,
+    GoalTransitionReason::UserCompleted,
+    GoalTransitionReason::UserPaused,
+    GoalTransitionReason::UserResumed,
+    GoalTransitionReason::UserCleared,
+    GoalTransitionReason::BarrenContinuation,
+];
+
+const REOPEN_REASONS: &[GoalTransitionReason] = &[
+    GoalTransitionReason::ModelReopened,
+    GoalTransitionReason::UserReopened,
+];
+
 const ALL_REASONS: &[GoalTransitionReason] = &[
     GoalTransitionReason::UserCreated,
     GoalTransitionReason::ModelCompleted,
     GoalTransitionReason::UserCompleted,
+    GoalTransitionReason::ModelReopened,
+    GoalTransitionReason::UserReopened,
     GoalTransitionReason::UserPaused,
     GoalTransitionReason::UserResumed,
     GoalTransitionReason::UserCleared,
@@ -49,6 +66,16 @@ fn each_legal_transition_is_accepted() {
             ThreadGoalStatus::Complete,
             GoalTransitionReason::UserCompleted,
         ),
+        (
+            ThreadGoalStatus::Complete,
+            ThreadGoalStatus::Active,
+            GoalTransitionReason::ModelReopened,
+        ),
+        (
+            ThreadGoalStatus::Complete,
+            ThreadGoalStatus::Active,
+            GoalTransitionReason::UserReopened,
+        ),
     ];
     for (from, to, reason) in cases {
         assert!(
@@ -59,13 +86,37 @@ fn each_legal_transition_is_accepted() {
 }
 
 #[test]
-fn complete_is_terminal_for_every_reason() {
+fn complete_only_exits_to_active_via_reopen_reasons() {
     for &to in ALL_STATUSES {
-        for &reason in ALL_REASONS {
+        for &reason in NON_REOPEN_REASONS {
             assert!(
                 !ThreadGoalStatus::Complete.can_transition_to(to, reason),
-                "Complete must not transition to {to:?} via {reason:?}"
+                "Complete must not transition to {to:?} via non-reopen {reason:?}"
             );
+        }
+    }
+    for &reason in REOPEN_REASONS {
+        assert!(
+            ThreadGoalStatus::Complete.can_transition_to(ThreadGoalStatus::Active, reason),
+            "Complete -> Active via {reason:?} must be legal"
+        );
+        assert!(
+            !ThreadGoalStatus::Complete.can_transition_to(ThreadGoalStatus::Paused, reason),
+            "Complete -> Paused via {reason:?} must be illegal"
+        );
+    }
+}
+
+#[test]
+fn reopen_reasons_only_apply_from_complete() {
+    for &reason in REOPEN_REASONS {
+        for &from in &[ThreadGoalStatus::Active, ThreadGoalStatus::Paused] {
+            for &to in ALL_STATUSES {
+                assert!(
+                    !from.can_transition_to(to, reason),
+                    "{from:?} -> {to:?} via {reason:?} must be illegal (reopen only valid from Complete)"
+                );
+            }
         }
     }
 }
@@ -102,6 +153,20 @@ fn status_string_roundtrip_through_serde() {
         assert_eq!(json, format!("\"{expected}\""));
         let back: ThreadGoalStatus = serde_json::from_str(&json).unwrap();
         assert_eq!(back, status);
+    }
+}
+
+#[test]
+fn reopen_reasons_roundtrip_through_serde() {
+    let pairs = [
+        (GoalTransitionReason::ModelReopened, "model_reopened"),
+        (GoalTransitionReason::UserReopened, "user_reopened"),
+    ];
+    for (reason, expected) in pairs {
+        let json = serde_json::to_string(&reason).unwrap();
+        assert_eq!(json, format!("\"{expected}\""));
+        let back: GoalTransitionReason = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, reason);
     }
 }
 

--- a/crates/loopal-runtime/src/agent_loop/goal_control.rs
+++ b/crates/loopal-runtime/src/agent_loop/goal_control.rs
@@ -16,7 +16,9 @@ impl AgentLoopRunner {
         };
         let kickoff_eligible = matches!(
             &ctrl,
-            ControlCommand::GoalCreate { .. } | ControlCommand::GoalUserResume
+            ControlCommand::GoalCreate { .. }
+                | ControlCommand::GoalUserResume
+                | ControlCommand::GoalUserReopen
         );
         let is_clear = matches!(&ctrl, ControlCommand::GoalClear);
         let outcome: std::result::Result<Option<ThreadGoal>, GoalSessionError> = match ctrl {
@@ -42,6 +44,14 @@ impl AgentLoopRunner {
                     &session,
                     ThreadGoalStatus::Complete,
                     GoalTransitionReason::UserCompleted,
+                )
+                .await
+            }
+            ControlCommand::GoalUserReopen => {
+                transition(
+                    &session,
+                    ThreadGoalStatus::Active,
+                    GoalTransitionReason::UserReopened,
                 )
                 .await
             }

--- a/crates/loopal-runtime/src/agent_loop/input_control.rs
+++ b/crates/loopal-runtime/src/agent_loop/input_control.rs
@@ -114,6 +114,7 @@ impl AgentLoopRunner {
             | ControlCommand::GoalUserPause
             | ControlCommand::GoalUserResume
             | ControlCommand::GoalUserComplete
+            | ControlCommand::GoalUserReopen
             | ControlCommand::GoalClear) => {
                 return self.handle_goal_control(ctrl).await;
             }

--- a/crates/loopal-runtime/src/goal/tool_adapter.rs
+++ b/crates/loopal-runtime/src/goal/tool_adapter.rs
@@ -34,4 +34,13 @@ impl GoalSession for GoalSessionToolAdapter {
             )
             .await
     }
+
+    async fn reopen_by_model(&self) -> Result<ThreadGoal, GoalSessionError> {
+        self.inner
+            .transition(
+                ThreadGoalStatus::Active,
+                GoalTransitionReason::ModelReopened,
+            )
+            .await
+    }
 }

--- a/crates/loopal-runtime/tests/agent_loop/goal_kickoff_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/goal_kickoff_test.rs
@@ -67,3 +67,43 @@ async fn goal_resume_via_control_triggers_turn() {
     wait_for_goal_reason(&log, GoalTransitionReason::ModelCompleted).await;
     drop(harness.control_tx);
 }
+
+#[tokio::test]
+async fn goal_reopen_via_control_triggers_turn() {
+    let fixture = TestFixture::new();
+    let (_tmp, session, log) = make_goal_session(&fixture.test_session("kickoff-reopen").id);
+    session.create("ship work".into()).await.expect("create");
+    session
+        .transition(
+            ThreadGoalStatus::Complete,
+            GoalTransitionReason::UserCompleted,
+        )
+        .await
+        .expect("complete");
+
+    let calls = vec![chunks::tool_turn(
+        "ureopen1",
+        "update_goal",
+        json!({"status": "complete"}),
+    )];
+    let harness = HarnessBuilder::new()
+        .calls(calls)
+        .messages(vec![])
+        .goal_session(session.clone())
+        .build_spawned()
+        .await;
+
+    harness
+        .control_tx
+        .send(ControlCommand::GoalUserReopen)
+        .await
+        .unwrap();
+
+    wait_for_goal_reason(&log, GoalTransitionReason::UserReopened).await;
+    wait_for_goal_reason(&log, GoalTransitionReason::ModelCompleted).await;
+
+    let goal = session.snapshot().await.unwrap().expect("goal persisted");
+    assert_eq!(goal.objective, "ship work");
+    assert_eq!(goal.status, ThreadGoalStatus::Complete);
+    drop(harness.control_tx);
+}

--- a/crates/loopal-runtime/tests/suite.rs
+++ b/crates/loopal-runtime/tests/suite.rs
@@ -35,6 +35,8 @@ mod frontend_unified_test;
 mod goal_continuation_test;
 #[path = "suite/goal_session_lifecycle_test.rs"]
 mod goal_session_lifecycle_test;
+#[path = "suite/goal_session_reopen_test.rs"]
+mod goal_session_reopen_test;
 #[path = "suite/goal_session_support.rs"]
 mod goal_session_support;
 #[path = "suite/goal_session_test.rs"]

--- a/crates/loopal-runtime/tests/suite/goal_session_reopen_test.rs
+++ b/crates/loopal-runtime/tests/suite/goal_session_reopen_test.rs
@@ -1,0 +1,125 @@
+use loopal_protocol::{AgentEventPayload, GoalTransitionReason, ThreadGoalStatus};
+
+use super::goal_session_support::{fixture, last_payload};
+
+#[tokio::test]
+async fn transition_complete_to_active_via_model_reopened_succeeds() {
+    let (_tmp, store, emitter, session) = fixture();
+    session.create("ship".into()).await.unwrap();
+    session
+        .transition(
+            ThreadGoalStatus::Complete,
+            GoalTransitionReason::ModelCompleted,
+        )
+        .await
+        .unwrap();
+
+    let reopened = session
+        .transition(
+            ThreadGoalStatus::Active,
+            GoalTransitionReason::ModelReopened,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(reopened.status, ThreadGoalStatus::Active);
+    assert_eq!(reopened.objective, "ship");
+    let saved = store.load("sess").unwrap().unwrap();
+    assert_eq!(saved.status, ThreadGoalStatus::Active);
+    assert_eq!(saved.goal_id, reopened.goal_id);
+    assert!(matches!(
+        last_payload(&emitter),
+        AgentEventPayload::ThreadGoalUpdated {
+            reason: GoalTransitionReason::ModelReopened,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn transition_complete_to_active_via_user_reopened_succeeds() {
+    let (_tmp, _store, emitter, session) = fixture();
+    session.create("ship".into()).await.unwrap();
+    session
+        .transition(
+            ThreadGoalStatus::Complete,
+            GoalTransitionReason::UserCompleted,
+        )
+        .await
+        .unwrap();
+
+    let reopened = session
+        .transition(ThreadGoalStatus::Active, GoalTransitionReason::UserReopened)
+        .await
+        .unwrap();
+
+    assert_eq!(reopened.status, ThreadGoalStatus::Active);
+    assert!(matches!(
+        last_payload(&emitter),
+        AgentEventPayload::ThreadGoalUpdated {
+            reason: GoalTransitionReason::UserReopened,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn reopen_when_active_is_rejected() {
+    let (_tmp, _store, _emitter, session) = fixture();
+    session.create("ship".into()).await.unwrap();
+    let err = session
+        .transition(
+            ThreadGoalStatus::Active,
+            GoalTransitionReason::ModelReopened,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        loopal_tool_api::GoalSessionError::ModelStatusForbidden
+    ));
+}
+
+#[tokio::test]
+async fn reopen_when_no_goal_returns_not_found() {
+    let (_tmp, _store, _emitter, session) = fixture();
+    let err = session
+        .transition(
+            ThreadGoalStatus::Active,
+            GoalTransitionReason::ModelReopened,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, loopal_tool_api::GoalSessionError::NotFound));
+}
+
+#[tokio::test]
+async fn adapter_reopen_by_model_routes_through_transition() {
+    use std::sync::Arc;
+
+    use loopal_runtime::GoalSessionToolAdapter;
+    use loopal_tool_api::GoalSession;
+
+    let (_tmp, _store, emitter, session) = fixture();
+    let session = Arc::new(session);
+    session.create("ship".into()).await.unwrap();
+    session
+        .transition(
+            ThreadGoalStatus::Complete,
+            GoalTransitionReason::ModelCompleted,
+        )
+        .await
+        .unwrap();
+
+    let adapter = GoalSessionToolAdapter::new(Arc::clone(&session));
+    let reopened = adapter.reopen_by_model().await.unwrap();
+
+    assert_eq!(reopened.status, ThreadGoalStatus::Active);
+    assert!(matches!(
+        last_payload(&emitter),
+        AgentEventPayload::ThreadGoalUpdated {
+            reason: GoalTransitionReason::ModelReopened,
+            ..
+        }
+    ));
+}

--- a/crates/loopal-tool-api/src/goal_session.rs
+++ b/crates/loopal-tool-api/src/goal_session.rs
@@ -8,7 +8,7 @@ pub enum GoalSessionError {
     AlreadyExists,
     #[error("no goal exists for this session")]
     NotFound,
-    #[error("model can only mark goals complete; pause/resume are user-only")]
+    #[error("model attempted a forbidden goal status transition")]
     ModelStatusForbidden,
     #[error("objective must be non-empty and at most {max} characters; got {got}")]
     ObjectiveTooLong { max: usize, got: usize },
@@ -23,4 +23,6 @@ pub trait GoalSession: Send + Sync {
     async fn create(&self, objective: String) -> Result<ThreadGoal, GoalSessionError>;
 
     async fn complete_by_model(&self) -> Result<ThreadGoal, GoalSessionError>;
+
+    async fn reopen_by_model(&self) -> Result<ThreadGoal, GoalSessionError>;
 }

--- a/crates/loopal-tui/src/command/goal_cmd.rs
+++ b/crates/loopal-tui/src/command/goal_cmd.rs
@@ -4,7 +4,7 @@ use loopal_protocol::ControlCommand;
 use super::{CommandEffect, CommandHandler};
 use crate::app::App;
 
-const USAGE: &str = "/goal usage: <objective> | pause | resume | complete | clear";
+const USAGE: &str = "/goal usage: <objective> | pause | resume | complete | reopen | clear";
 
 pub struct GoalCmd;
 
@@ -15,7 +15,7 @@ impl CommandHandler for GoalCmd {
     }
 
     fn description(&self) -> &str {
-        "Manage thread goal: /goal <objective> | pause | resume | complete | clear"
+        "Manage thread goal: /goal <objective> | pause | resume | complete | reopen | clear"
     }
 
     fn has_arg(&self) -> bool {
@@ -41,6 +41,7 @@ fn ack_for(cmd: &ControlCommand) -> String {
         ControlCommand::GoalUserPause => "Goal paused.".into(),
         ControlCommand::GoalUserResume => "Goal resumed.".into(),
         ControlCommand::GoalUserComplete => "Goal marked complete.".into(),
+        ControlCommand::GoalUserReopen => "Goal reopened.".into(),
         ControlCommand::GoalClear => "Goal cleared.".into(),
         _ => "Goal command sent.".into(),
     }
@@ -55,6 +56,7 @@ pub(crate) fn parse_goal_arg(arg: &str) -> Option<ControlCommand> {
         "pause" => return Some(ControlCommand::GoalUserPause),
         "resume" => return Some(ControlCommand::GoalUserResume),
         "complete" => return Some(ControlCommand::GoalUserComplete),
+        "reopen" => return Some(ControlCommand::GoalUserReopen),
         "clear" => return Some(ControlCommand::GoalClear),
         _ => {}
     }
@@ -82,6 +84,7 @@ mod tests {
             ("pause", "GoalUserPause"),
             ("RESUME", "GoalUserResume"),
             ("Complete", "GoalUserComplete"),
+            ("reopen", "GoalUserReopen"),
             ("clear", "GoalClear"),
         ] {
             let got = dbg_variant(&parse_goal_arg(input).unwrap());
@@ -111,6 +114,7 @@ mod tests {
             ack_for(&ControlCommand::GoalUserComplete),
             "Goal marked complete."
         );
+        assert_eq!(ack_for(&ControlCommand::GoalUserReopen), "Goal reopened.");
         assert_eq!(ack_for(&ControlCommand::GoalClear), "Goal cleared.");
     }
 

--- a/crates/loopal-tui/tests/suite/e2e_control_completeness_test.rs
+++ b/crates/loopal-tui/tests/suite/e2e_control_completeness_test.rs
@@ -47,6 +47,7 @@ fn expected_view_effect(cmd: &ControlCommand) -> ExpectedViewEffect {
         GoalUserPause => FixtureRequired("active goal"),
         GoalUserResume => FixtureRequired("paused goal"),
         GoalUserComplete => FixtureRequired("active goal"),
+        GoalUserReopen => FixtureRequired("completed goal"),
         GoalClear => FixtureRequired("active goal"),
     }
 }
@@ -139,6 +140,7 @@ fn variant_name(cmd: &ControlCommand) -> &'static str {
         GoalUserPause => "GoalUserPause",
         GoalUserResume => "GoalUserResume",
         GoalUserComplete => "GoalUserComplete",
+        GoalUserReopen => "GoalUserReopen",
         GoalClear => "GoalClear",
     }
 }

--- a/crates/tools/agent/goal/src/create_goal.rs
+++ b/crates/tools/agent/goal/src/create_goal.rs
@@ -22,8 +22,10 @@ impl TypedTool<CreateGoalParams> for CreateGoalTool {
 
     fn description(&self) -> &str {
         "Create a goal only when explicitly requested by the user or system/developer \
-         instructions; do not infer goals from ordinary tasks. Fails if a goal already exists; \
-         use update_goal only to mark an existing goal complete."
+         instructions; do not infer goals from ordinary tasks. Fails if a non-complete goal \
+         already exists. If a previous goal was mistakenly marked complete and the same \
+         objective still applies, prefer update_goal with status `active` to reopen it rather \
+         than creating a new goal with the same objective."
     }
 
     fn permission(&self) -> PermissionLevel {

--- a/crates/tools/agent/goal/src/errors.rs
+++ b/crates/tools/agent/goal/src/errors.rs
@@ -3,12 +3,15 @@ use loopal_tool_api::GoalSessionError;
 pub fn format_session_error(err: GoalSessionError) -> String {
     match err {
         GoalSessionError::AlreadyExists => {
-            "this thread already has a goal; use update_goal only when the existing goal is complete"
+            "this thread already has an in-progress goal; if you intend to continue the same \
+             objective use update_goal with status `active`, otherwise wait for the user or \
+             system to clear the existing goal"
                 .to_string()
         }
         GoalSessionError::NotFound => "no goal exists for this thread".to_string(),
         GoalSessionError::ModelStatusForbidden => {
-            "update_goal can only mark the existing goal complete; pause and resume are user-controlled"
+            "update_goal cannot apply that status to the goal's current state; \
+             call get_goal to inspect the current status before retrying"
                 .to_string()
         }
         GoalSessionError::ObjectiveTooLong { max, got } => {

--- a/crates/tools/agent/goal/src/update_goal.rs
+++ b/crates/tools/agent/goal/src/update_goal.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use loopal_error::LoopalError;
-use loopal_tool_api::{PermissionLevel, ToolContext, ToolResult, TypedTool};
+use loopal_tool_api::{GoalSessionError, PermissionLevel, ToolContext, ToolResult, TypedTool};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -12,6 +12,7 @@ pub struct UpdateGoalTool;
 #[derive(Deserialize, JsonSchema, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum GoalStatusInput {
+    Active,
     Complete,
 }
 
@@ -27,11 +28,14 @@ impl TypedTool<UpdateGoalParams> for UpdateGoalTool {
     }
 
     fn description(&self) -> &str {
-        "Update the existing goal. Use this tool only to mark the goal achieved. Set status to \
-         `complete` only when the objective has actually been achieved and no required work \
-         remains. Do not mark a goal complete merely because you are stopping work. You cannot \
-         use this tool to pause or resume a goal; those status changes are controlled by the \
-         user or system."
+        "Update the existing goal. Use `complete` only when the objective has actually been \
+         achieved and no required work remains. Use `active` only to revert a mistaken \
+         `complete` — you previously marked the goal complete and then discovered remaining \
+         work that still falls under the same original objective; reopening preserves the \
+         goal's id and objective. To pursue a different objective, use create_goal instead. \
+         Do not mark complete merely because you are stopping work, and do not toggle between \
+         `active` and `complete` to manipulate continuation. You cannot pause or resume the \
+         goal via this tool; those status changes are controlled by the user or system."
     }
 
     fn permission(&self) -> PermissionLevel {
@@ -55,8 +59,11 @@ impl TypedTool<UpdateGoalParams> for UpdateGoalTool {
                 ));
             }
         };
-        let _ = input.status;
-        match session.complete_by_model().await {
+        let outcome: Result<_, GoalSessionError> = match input.status {
+            GoalStatusInput::Complete => session.complete_by_model().await,
+            GoalStatusInput::Active => session.reopen_by_model().await,
+        };
+        match outcome {
             Ok(goal) => Ok(ToolResult::success(render_response(&Some(goal)))),
             Err(err) => Ok(ToolResult::error(format_session_error(err))),
         }

--- a/crates/tools/agent/goal/tests/suite/create_goal_test.rs
+++ b/crates/tools/agent/goal/tests/suite/create_goal_test.rs
@@ -29,7 +29,8 @@ async fn rejects_when_goal_already_exists() {
         .await
         .unwrap();
     assert!(result.is_error);
-    assert!(result.content.contains("already has a goal"));
+    assert!(result.content.contains("in-progress goal"));
+    assert!(result.content.contains("update_goal"));
 }
 
 #[tokio::test]

--- a/crates/tools/agent/goal/tests/suite/schema_test.rs
+++ b/crates/tools/agent/goal/tests/suite/schema_test.rs
@@ -46,3 +46,28 @@ fn update_goal_description_warns_against_premature_complete() {
         "must warn against marking complete merely because work is stopping"
     );
 }
+
+#[test]
+fn update_goal_description_disambiguates_active_from_create() {
+    let desc = make_update_goal_tool().description().to_lowercase();
+    assert!(
+        desc.contains("same original objective"),
+        "active path must scope itself to the original objective so the LLM \
+         does not use it to silently swap goals"
+    );
+    assert!(
+        desc.contains("create_goal"),
+        "active path must point to create_goal as the alternative when the \
+         objective itself needs to change"
+    );
+}
+
+#[test]
+fn create_goal_description_routes_misclick_recovery_to_update_goal() {
+    let desc = make_create_goal_tool().description().to_lowercase();
+    assert!(
+        desc.contains("update_goal"),
+        "create_goal must point LLMs at update_goal `active` when the previous \
+         goal was mistakenly marked complete"
+    );
+}

--- a/crates/tools/agent/goal/tests/suite/support.rs
+++ b/crates/tools/agent/goal/tests/suite/support.rs
@@ -143,6 +143,18 @@ impl GoalSession for FakeGoalSession {
             None => Err(GoalSessionError::NotFound),
         }
     }
+
+    async fn reopen_by_model(&self) -> Result<ThreadGoal, GoalSessionError> {
+        let mut slot = self.goal.lock().unwrap();
+        match slot.as_mut() {
+            Some(g) if g.status == ThreadGoalStatus::Complete => {
+                g.status = ThreadGoalStatus::Active;
+                Ok(g.clone())
+            }
+            Some(_) => Err(GoalSessionError::ModelStatusForbidden),
+            None => Err(GoalSessionError::NotFound),
+        }
+    }
 }
 
 pub fn ctx_with_goal_session(session: Arc<dyn GoalSession>) -> ToolContext {

--- a/crates/tools/agent/goal/tests/suite/update_goal_test.rs
+++ b/crates/tools/agent/goal/tests/suite/update_goal_test.rs
@@ -44,3 +44,48 @@ async fn surfaces_disabled_when_no_goal_session() {
     assert!(result.is_error);
     assert!(result.content.contains("disabled"));
 }
+
+#[tokio::test]
+async fn reopens_completed_goal_when_status_active() {
+    let session = FakeGoalSession::with_active("ship");
+    {
+        let mut slot = session.goal.lock().unwrap();
+        slot.as_mut().unwrap().status = loopal_protocol::ThreadGoalStatus::Complete;
+    }
+    let ctx = ctx_with_goal_session(session.clone());
+    let result = make_update_goal_tool()
+        .execute(json!({"status": "active"}), &ctx)
+        .await
+        .unwrap();
+    assert!(!result.is_error);
+    let parsed: serde_json::Value = serde_json::from_str(&result.content).unwrap();
+    assert_eq!(parsed["goal"]["status"], "active");
+    assert_eq!(
+        session.goal.lock().unwrap().as_ref().unwrap().status,
+        loopal_protocol::ThreadGoalStatus::Active,
+    );
+}
+
+#[tokio::test]
+async fn rejects_reopen_when_already_active() {
+    let session = FakeGoalSession::with_active("ship");
+    let ctx = ctx_with_goal_session(session);
+    let result = make_update_goal_tool()
+        .execute(json!({"status": "active"}), &ctx)
+        .await
+        .unwrap();
+    assert!(result.is_error);
+    assert!(result.content.contains("cannot apply"));
+}
+
+#[tokio::test]
+async fn rejects_reopen_when_no_goal_exists() {
+    let session = FakeGoalSession::empty();
+    let ctx = ctx_with_goal_session(session);
+    let result = make_update_goal_tool()
+        .execute(json!({"status": "active"}), &ctx)
+        .await
+        .unwrap();
+    assert!(result.is_error);
+    assert!(result.content.contains("no goal exists"));
+}


### PR DESCRIPTION
## Summary

- New escape edge from `Complete` to `Active` in the goal state machine, with two restricted reasons (`ModelReopened`, `UserReopened`). Complete remains effectively terminal — only these two reasons can move out of it, and reopen reasons are rejected from any other state.
- Model gets `update_goal status=active` to undo a mistaken `complete`; user gets symmetric `ControlCommand::GoalUserReopen` (also wired as `/goal reopen` in the TUI). Continuation pump auto-restarts after reopen.
- Tool descriptions disambiguate reopen (keeps `goal_id` + objective) from `create_goal` (new `goal_id` + new objective) so the LLM does not silently swap goals through reopen.

## Changes

**Protocol** (`loopal-protocol`)
- `ThreadGoalStatus::can_transition_to` — two new edges
- `GoalTransitionReason` — `ModelReopened`, `UserReopened`
- `ControlCommand::GoalUserReopen`

**Tool-API** (`loopal-tool-api`)
- `GoalSession::reopen_by_model()`
- `ModelStatusForbidden` text generalized

**Runtime** (`loopal-runtime`)
- `GoalSessionToolAdapter::reopen_by_model` → `transition(Active, ModelReopened)`
- `goal_control.rs` — handles `GoalUserReopen`; `kickoff_eligible` includes it so continuation pump restarts
- `input_control.rs` — routing updated

**Tool** (`loopal-tool-goal`)
- `update_goal` — `GoalStatusInput::Active`; description disambiguates from `create_goal`
- `create_goal` description — points misclick recovery at `update_goal active`
- `errors.rs` — `AlreadyExists` / `ModelStatusForbidden` text updated to surface the new path to the LLM

**TUI** (`loopal-tui`)
- `/goal reopen` slash command
- exhaustive-match `e2e_control_completeness_test` synced

## Test plan

- [x] state-machine invariants for new edges and reasons (`thread_goal_test`)
- [x] session reopen behavior — success / forbidden / not-found / adapter wiring (`goal_session_reopen_test`)
- [x] `update_goal active` tool tests — happy path + reject when already-active + reject when no goal (`update_goal_test`)
- [x] description guards as regression invariants — `update_goal_description_disambiguates_active_from_create`, `create_goal_description_routes_misclick_recovery_to_update_goal` (`schema_test`)
- [x] runtime e2e — `GoalUserReopen` → continuation pump → `ModelCompleted` (`goal_kickoff_test::goal_reopen_via_control_triggers_turn`)
- [x] `bazel test //...` → 81/81 passed
- [x] `bazel build //... --config=clippy` → zero warnings
- [x] `bazel build //... --config=rustfmt` → clean
- [ ] CI passes