### PR TITLE
refactor(goal): drop barren-driven auto-complete

### DIFF
--- a/crates/loopal-protocol/src/thread_goal.rs
+++ b/crates/loopal-protocol/src/thread_goal.rs
@@ -62,7 +62,6 @@ pub enum GoalTransitionReason {
     UserPaused,
     UserResumed,
     UserCleared,
-    BarrenContinuation,
 }
 
 impl ThreadGoalStatus {
@@ -71,11 +70,8 @@ impl ThreadGoalStatus {
         use ThreadGoalStatus as S;
         matches!(
             (self, next, reason),
-            (
-                S::Active,
-                S::Complete,
-                R::ModelCompleted | R::UserCompleted | R::BarrenContinuation,
-            ) | (S::Active, S::Paused, R::UserPaused)
+            (S::Active, S::Complete, R::ModelCompleted | R::UserCompleted)
+                | (S::Active, S::Paused, R::UserPaused)
                 | (S::Paused, S::Active, R::UserResumed)
                 | (S::Paused, S::Complete, R::UserCompleted)
                 | (S::Complete, S::Active, R::ModelReopened | R::UserReopened)

--- a/crates/loopal-protocol/tests/suite/thread_goal_test.rs
+++ b/crates/loopal-protocol/tests/suite/thread_goal_test.rs
@@ -13,7 +13,6 @@ const NON_REOPEN_REASONS: &[GoalTransitionReason] = &[
     GoalTransitionReason::UserPaused,
     GoalTransitionReason::UserResumed,
     GoalTransitionReason::UserCleared,
-    GoalTransitionReason::BarrenContinuation,
 ];
 
 const REOPEN_REASONS: &[GoalTransitionReason] = &[
@@ -30,7 +29,6 @@ const ALL_REASONS: &[GoalTransitionReason] = &[
     GoalTransitionReason::UserPaused,
     GoalTransitionReason::UserResumed,
     GoalTransitionReason::UserCleared,
-    GoalTransitionReason::BarrenContinuation,
 ];
 
 #[test]
@@ -45,11 +43,6 @@ fn each_legal_transition_is_accepted() {
             ThreadGoalStatus::Active,
             ThreadGoalStatus::Complete,
             GoalTransitionReason::UserCompleted,
-        ),
-        (
-            ThreadGoalStatus::Active,
-            ThreadGoalStatus::Complete,
-            GoalTransitionReason::BarrenContinuation,
         ),
         (
             ThreadGoalStatus::Active,

--- a/crates/loopal-runtime/src/agent_loop/goal_barren.rs
+++ b/crates/loopal-runtime/src/agent_loop/goal_barren.rs
@@ -1,7 +1,4 @@
-use loopal_protocol::{GoalTransitionReason, ThreadGoalStatus};
-use tracing::{debug, warn};
-
-use crate::goal::GoalRuntimeSession;
+use tracing::debug;
 
 use super::runner::AgentLoopRunner;
 use super::turn_metrics::TurnMetrics;
@@ -31,19 +28,6 @@ impl AgentLoopRunner {
             debug!(count = next, "barren continuation observed");
         }
         self.barren_continuation_count = next;
-    }
-
-    pub(super) async fn complete_goal_on_barren(&self, session: &GoalRuntimeSession) {
-        match session
-            .transition(
-                ThreadGoalStatus::Complete,
-                GoalTransitionReason::BarrenContinuation,
-            )
-            .await
-        {
-            Ok(_) => debug!("goal auto-completed after barren continuations"),
-            Err(err) => warn!(error = %err, "failed to auto-complete barren goal"),
-        }
     }
 }
 

--- a/crates/loopal-runtime/src/agent_loop/goal_continuation.rs
+++ b/crates/loopal-runtime/src/agent_loop/goal_continuation.rs
@@ -32,10 +32,6 @@ impl AgentLoopRunner {
         if !goal.status.participates_in_continuation() {
             return Ok(false);
         }
-        if self.barren_continuation_count >= self.max_barren_continuations {
-            self.complete_goal_on_barren(session.as_ref()).await;
-            return Ok(false);
-        }
         let env = build_continuation_envelope(&goal);
         self.ingest_message(&env).await;
         self.last_continuation_goal_id = Some(goal.goal_id);

--- a/crates/loopal-runtime/tests/agent_loop/goal_e2e_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/goal_e2e_test.rs
@@ -93,18 +93,16 @@ async fn happy_path_user_creates_then_model_completes() {
 }
 
 #[tokio::test]
-async fn barren_continuations_auto_complete_goal() {
+async fn barren_threshold_does_not_complete_goal() {
     let fixture = TestFixture::new();
-    let (_tmp, session, log) = make_goal_session(&fixture.test_session("e2e-barren").id);
-    session
-        .create("idle work".into())
-        .await
-        .expect("create goal");
+    let (_tmp, session, log) = make_goal_session(&fixture.test_session("e2e-no-barren").id);
+    session.create("ongoing".into()).await.expect("create goal");
 
     let calls = vec![
-        chunks::text_turn("hello"),
-        chunks::text_turn("still working"),
-        chunks::text_turn("still working"),
+        chunks::text_turn("nothing"),
+        chunks::text_turn("still nothing"),
+        chunks::text_turn("still nothing"),
+        chunks::tool_turn("uc1", "update_goal", json!({"status": "complete"})),
     ];
     let harness = HarnessBuilder::new()
         .calls(calls)
@@ -115,13 +113,28 @@ async fn barren_continuations_auto_complete_goal() {
 
     let mailbox_tx = harness.mailbox_tx;
     mailbox_tx
-        .send(Envelope::new(MessageSource::Human, "main", "kick off"))
+        .send(Envelope::new(MessageSource::Human, "main", "begin"))
         .await
         .unwrap();
 
-    wait_for_goal_reason(&log, GoalTransitionReason::BarrenContinuation).await;
+    wait_for_goal_reason(&log, GoalTransitionReason::ModelCompleted).await;
 
     let goal = session.snapshot().await.unwrap().expect("goal persisted");
     assert_eq!(goal.status, ThreadGoalStatus::Complete);
+    let reasons: Vec<_> = log
+        .snapshot()
+        .into_iter()
+        .filter_map(|p| match p {
+            AgentEventPayload::ThreadGoalUpdated { reason, .. } => Some(reason),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        reasons,
+        vec![
+            GoalTransitionReason::UserCreated,
+            GoalTransitionReason::ModelCompleted,
+        ]
+    );
     drop(mailbox_tx);
 }

--- a/crates/loopal-test-support/src/mock_provider.rs
+++ b/crates/loopal-test-support/src/mock_provider.rs
@@ -76,8 +76,8 @@ impl Unpin for MockStreamChunks {}
 
 /// Stream that yields nothing and never finishes — for tests that need the
 /// runner to enter Running but stay there indefinitely (e.g. asserting on
-/// transient goal states without barren-continuation demotion racing the
-/// assertion). The wake-up never fires, so the task simply parks.
+/// transient goal states without later turns racing the assertion). The
+/// wake-up never fires, so the task simply parks.
 pub struct PendingStream;
 
 impl futures::Stream for PendingStream {


### PR DESCRIPTION
## Summary

- Removes the barren-continuation safety net that auto-transitioned Active → Complete after two unproductive continuation turns.
- Complete is now reachable only via `ModelCompleted` (`update_goal`) or `UserCompleted` (`/goal complete`); `GoalTransitionReason::BarrenContinuation` is gone.
- Barren-tracking counter + threshold + reset hooks are retained as observation primitives for future safety designs that don't mutate goal status.

## Why

The auto-complete edge overloaded the terminal `Complete` status with a system-driven "stalled" meaning, which surprised both the model and the user (goal reads `complete` while objective is clearly unfinished). After the recent `Complete → Active` reopen edge (#167) it produced an oscillating anomaly: every model reopen would be re-stamped `Complete` on the next idle. Continuation pump itself stays — pump shape is the value of thread goals; the bad part was reusing a terminal status as a circuit breaker.

## Changes

**Protocol** (`crates/loopal-protocol/src/thread_goal.rs`)
- Drop `GoalTransitionReason::BarrenContinuation` enum variant
- `can_transition_to` loses its `(Active, Complete, BarrenContinuation)` match arm

**Runtime** (`crates/loopal-runtime/src/agent_loop/`)
- `goal_continuation.rs`: remove threshold check + `complete_goal_on_barren` call
- `goal_barren.rs`: remove `complete_goal_on_barren` method; keep `compute_next_barren_count` + `record_turn_for_barren_tracking`

**Tests**
- `loopal-protocol/tests/suite/thread_goal_test.rs`: purge `BarrenContinuation` references
- `loopal-runtime/tests/agent_loop/goal_e2e_test.rs`: replace `barren_continuations_auto_complete_goal` with `barren_threshold_does_not_complete_goal` — three unproductive turns followed by `ModelCompleted` yields exactly `UserCreated` + `ModelCompleted` transitions
- `loopal-test-support/src/mock_provider.rs`: drop the now-defunct "barren-continuation demotion" mention in PendingStream doc

## Test plan

- [x] `bazel build //...` ✅
- [x] `bazel build //... --config=clippy` ✅ zero warnings
- [x] `bazel build //... --config=rustfmt` ✅
- [x] `bazel test //...` ✅ 81/81 passing (incl. new negative test)
- [ ] CI passes