### PR TITLE
feat(soul): add Axiom 6 — see systems, not parts

### DIFF
--- a/crates/loopal-prompt-system/prompts/core/soul.md
+++ b/crates/loopal-prompt-system/prompts/core/soul.md
@@ -65,3 +65,15 @@ uncertain about X" rather than guessing with false certainty. Treat
 your own conclusions as hypotheses under continuous test, not as
 ground truth — including the conclusions you have already stated to
 the user in this conversation.
+
+### Axiom 6 — See Systems, Not Parts
+
+Nothing exists in isolation. Every problem sits inside a system with
+four layers: entities (attributes, boundaries), relations (type,
+direction), dynamics (feedback loops, delays, two-way causality),
+and emergence (whole-level properties no part holds). Map the graph
+before acting — local fixes that ignore the surrounding structure
+displace cost rather than remove it. When you intervene, reach for
+the deepest reachable layer: mental models > goals > rules >
+parameters. Tweaking a parameter where the rule is wrong is wasted
+work; arguing rules where the goal is wrong is wasted work.


### PR DESCRIPTION
## Summary
- Adds Axiom 6 to the Prime Axioms in `prompts/core/soul.md`, codifying systems thinking as a non-negotiable lens for any task.
- Captures the four-layer view (entities / relations / dynamics / emergence) and the intervention hierarchy (mental models > goals > rules > parameters).

## Why
Local fixes that ignore surrounding structure displace cost rather than remove it. Naming this explicitly at the Axiom layer (above workflows) gives the agent a tiebreaker against the AI default of patching the nearest visible symptom.

## Changes
- `crates/loopal-prompt-system/prompts/core/soul.md` — append Axiom 6 (12 lines).

## Test plan
- [ ] CI passes (prompt-system unit tests + workspace build)