### PR TITLE
fix(tui-askuser): Enter confirms default option without prior ↑↓

### DIFF
--- a/crates/loopal-tui/src/question_ops.rs
+++ b/crates/loopal-tui/src/question_ops.rs
@@ -36,9 +36,6 @@ fn compute_answer_for(q: &PendingQuestion, idx: usize) -> String {
         return parts.join(", ");
     }
 
-    if !state.interacted() && !question.options.is_empty() {
-        return String::new();
-    }
     question
         .options
         .get(state.cursor())
@@ -140,24 +137,6 @@ pub(crate) async fn cancel(app: &mut App) {
 }
 
 pub(crate) async fn confirm(app: &mut App) {
-    // 防止 silent confirmation：当前题未交互且有选项 且 cursor 不在 Other 行时，
-    // 不提交答案，提示用户先用方向键选择或在 Other 行输入。
-    let needs_interaction = app.with_active_conversation(|conv| {
-        conv.pending_question
-            .as_ref()
-            .and_then(|q| {
-                let cur = q.questions.get(q.current_question)?;
-                let s = q.states.get(q.current_question)?;
-                let cursor_on_other = s.cursor() == cur.options.len();
-                Some(!s.interacted() && !cur.options.is_empty() && !cursor_on_other)
-            })
-            .unwrap_or(false)
-    });
-    if needs_interaction {
-        app.set_transient_status("Press ↑/↓ to choose, or type into Other.");
-        return;
-    }
-
     let advanced = app.with_active_conversation_mut(|conv| {
         conv.pending_question
             .as_mut()

--- a/crates/loopal-tui/tests/suite/e2e_question_test.rs
+++ b/crates/loopal-tui/tests/suite/e2e_question_test.rs
@@ -65,7 +65,7 @@ fn key(code: KeyCode) -> KeyEvent {
 }
 
 #[tokio::test]
-async fn askuser_silent_enter_without_interaction_does_not_submit() {
+async fn askuser_enter_without_interaction_submits_default_first_option() {
     let calls = vec![
         chunks::tool_turn(
             "tc-q",
@@ -82,27 +82,18 @@ async fn askuser_silent_enter_without_interaction_does_not_submit() {
     ];
     let inner = HarnessBuilder::new().calls(calls).build_spawned().await;
     let mut harness = build_tui(inner);
-    let _ = collect_until_question(&mut harness).await;
+    let mut events = collect_until_question(&mut harness).await;
 
-    // 用户没动 cursor 直接 Enter — 应该被防御不提交
+    // 用户没动 cursor 直接 Enter — 应直接提交默认第一项 "Yes"
     let action = handle_key(&mut harness.app, key(KeyCode::Enter));
     key_dispatch_for_test::dispatch(&mut harness.app, action).await;
 
-    // pending_question 应仍存在
-    let still_pending = harness
-        .app
-        .with_active_conversation(|conv| conv.pending_question.is_some());
-    assert!(
-        still_pending,
-        "silent Enter must NOT submit when user has not interacted"
-    );
+    let rest = harness.collect_until_idle().await;
+    events.extend(rest);
 
-    // transient_status 应有提示
-    let status = harness.app.current_transient_status().map(String::from);
-    assert!(
-        status.as_deref().is_some_and(|s| s.contains("Press")),
-        "transient_status should hint to press arrow keys, got: {status:?}"
-    );
+    let result =
+        assertions::find_tool_result(&events, "AskUser").expect("AskUser ToolResult event missing");
+    assert_q_prefix_and_answer(&result, 1, "Yes");
 }
 
 #[tokio::test]
@@ -125,12 +116,9 @@ async fn askuser_single_select_via_key_dispatch_passes_label_to_llm() {
     let mut harness = build_tui(inner);
     let mut events = collect_until_question(&mut harness).await;
 
-    // simulate user interaction: arrow down + up to acknowledge before Enter
+    // 方向键移到第二项后 Enter,提交 "No"
     let action = handle_key(&mut harness.app, key(KeyCode::Down));
     key_dispatch_for_test::dispatch(&mut harness.app, action).await;
-    let action = handle_key(&mut harness.app, key(KeyCode::Up));
-    key_dispatch_for_test::dispatch(&mut harness.app, action).await;
-
     let action = handle_key(&mut harness.app, key(KeyCode::Enter));
     key_dispatch_for_test::dispatch(&mut harness.app, action).await;
 
@@ -139,7 +127,7 @@ async fn askuser_single_select_via_key_dispatch_passes_label_to_llm() {
 
     let result =
         assertions::find_tool_result(&events, "AskUser").expect("AskUser ToolResult event missing");
-    assert_q_prefix_and_answer(&result, 1, "Yes");
+    assert_q_prefix_and_answer(&result, 1, "No");
 }
 
 #[tokio::test]

--- a/crates/loopal-tui/tests/suite/multi_question_test.rs
+++ b/crates/loopal-tui/tests/suite/multi_question_test.rs
@@ -81,12 +81,10 @@ fn single_select_invariant_selection_stays_empty() {
     let mut q = PendingQuestion::new("id".into(), vec![make_q(&["A", "B", "C"], false)]);
     if let Some(s) = q.states.get_mut(q.current_question) {
         s.cursor = 1;
-        s.interacted = true;
     }
     q.toggle();
     if let Some(s) = q.states.get_mut(q.current_question) {
         s.cursor = 2;
-        s.interacted = true;
     }
     q.toggle();
     assert!(
@@ -103,7 +101,6 @@ fn multi_question_independent_state() {
     );
     if let Some(s) = q.states.get_mut(q.current_question) {
         s.cursor = 1;
-        s.interacted = true;
     }
     q.toggle();
     "first".chars().for_each(|c| q.free_text_insert_char(c));
@@ -111,7 +108,6 @@ fn multi_question_independent_state() {
     q.next_question();
     if let Some(s) = q.states.get_mut(q.current_question) {
         s.cursor = 2;
-        s.interacted = true;
     }
 
     let answers: Vec<String> = compute_question_answers(&q);
@@ -145,7 +141,6 @@ fn options_window_around_cursor_in_narrow_area() {
     let mut q = PendingQuestion::new("id".into(), vec![make_q(&["A", "B", "C", "D", "E"], false)]);
     if let Some(s) = q.states.get_mut(q.current_question) {
         s.cursor = 4;
-        s.interacted = true;
     }
     let s = render_to_buffer(60, 5, |f, area| question_inline::render(f, &q, area, None));
     assert!(s.contains("E"), "cursor option must be visible:\n{s}");

--- a/crates/loopal-tui/tests/suite/question_confirm_test.rs
+++ b/crates/loopal-tui/tests/suite/question_confirm_test.rs
@@ -28,7 +28,6 @@ fn answers(q: &PendingQuestion) -> Vec<String> {
 fn set_cursor(q: &mut PendingQuestion, c: usize) {
     if let Some(s) = q.states.get_mut(q.current_question) {
         s.cursor = c;
-        s.interacted = true;
     }
 }
 

--- a/crates/loopal-tui/tests/suite/question_edge_test.rs
+++ b/crates/loopal-tui/tests/suite/question_edge_test.rs
@@ -102,13 +102,13 @@ fn answered_response_protocol_mismatch_is_warned() {
 }
 
 #[test]
-fn untouched_single_select_returns_empty_in_compute() {
+fn untouched_single_select_returns_first_option_label() {
     let q = PendingQuestion::new("id".into(), vec![make_q(&["A", "B"], false)]);
     let answers = compute_question_answers(&q);
     assert_eq!(
         answers,
-        vec![String::new()],
-        "untouched cursor must return empty answer to avoid silent confirmation"
+        vec!["A".to_string()],
+        "untouched cursor on single-select must return default (first) option label"
     );
 }
 

--- a/crates/loopal-view-state/src/conversation/pending_question.rs
+++ b/crates/loopal-view-state/src/conversation/pending_question.rs
@@ -85,14 +85,10 @@ impl PendingQuestion {
         self.current().map(|(_, s)| s.selection()).unwrap_or(&[])
     }
 
-    pub fn interacted(&self) -> bool {
-        self.current().map(|(_, s)| s.interacted()).unwrap_or(false)
-    }
-
     pub fn cursor_up(&mut self) {
         if let Some(s) = self.current_mut() {
             let next = s.cursor().saturating_sub(1);
-            s.user_set_cursor_clamped(next, usize::MAX);
+            s.set_cursor_clamped(next, usize::MAX);
         }
     }
 
@@ -100,7 +96,7 @@ impl PendingQuestion {
         let max = self.other_index();
         if let Some(s) = self.current_mut() {
             let next = s.cursor().saturating_add(1);
-            s.user_set_cursor_clamped(next, max);
+            s.set_cursor_clamped(next, max);
         }
     }
 

--- a/crates/loopal-view-state/src/conversation/question_state.rs
+++ b/crates/loopal-view-state/src/conversation/question_state.rs
@@ -12,8 +12,6 @@ pub struct QuestionState {
     pub free_text_cursor: usize,
     #[serde(default)]
     pub cursor: usize,
-    #[serde(default)]
-    pub interacted: bool,
 }
 
 impl QuestionState {
@@ -40,16 +38,8 @@ impl QuestionState {
         &self.selection
     }
 
-    pub fn interacted(&self) -> bool {
-        self.interacted
-    }
-
-    /// Move cursor (clamped) and mark this state as user-interacted.
-    /// Use this for user-driven cursor movement; programmatic cursor reset
-    /// (deserialization, advance-to-next) should set the field directly.
-    pub fn user_set_cursor_clamped(&mut self, c: usize, max: usize) {
+    pub fn set_cursor_clamped(&mut self, c: usize, max: usize) {
         self.cursor = c.min(max);
-        self.interacted = true;
     }
 
     pub(crate) fn insert_char(&mut self, c: char) {
@@ -57,7 +47,6 @@ impl QuestionState {
         let byte = char_index_to_byte(&self.free_text, cursor);
         self.free_text.insert(byte, c);
         self.free_text_cursor = cursor + 1;
-        self.interacted = true;
     }
 
     pub(crate) fn backspace(&mut self) {
@@ -70,7 +59,6 @@ impl QuestionState {
         let to = char_index_to_byte(&self.free_text, cursor);
         self.free_text.replace_range(from..to, "");
         self.free_text_cursor = prev;
-        self.interacted = true;
     }
 
     pub(crate) fn delete(&mut self) {
@@ -81,13 +69,11 @@ impl QuestionState {
         let from = char_index_to_byte(&self.free_text, self.free_text_cursor);
         let to = char_index_to_byte(&self.free_text, self.free_text_cursor + 1);
         self.free_text.replace_range(from..to, "");
-        self.interacted = true;
     }
 
     pub(crate) fn toggle_selection(&mut self) -> bool {
         if let Some(slot) = self.selection.get_mut(self.cursor) {
             *slot = !*slot;
-            self.interacted = true;
             true
         } else {
             false
@@ -96,7 +82,6 @@ impl QuestionState {
 
     pub(crate) fn toggle_other(&mut self) {
         self.other_selected = !self.other_selected;
-        self.interacted = true;
     }
 
     pub(crate) fn cursor_left(&mut self) {


### PR DESCRIPTION
## Summary
- 修复 AskUser 单选首次按 Enter 不提交默认项的视觉/行为不一致 bug
- 删除已成 dead code 的 `QuestionState.interacted` 字段、访问器、mutator 副作用、测试 fixture
- 重命名 `user_set_cursor_clamped` → `set_cursor_clamped`（副作用消失后名字也不该带 `user_`）

## Why
`confirm()` 之前要求 `state.interacted()=true` 才能提交,但渲染层始终把 `cursor=0` 显示为选中态（黄色 ▸ + (•) 圆点）。结果用户看到第一项已选中后按 Enter,却被拦截并被要求先按方向键——这是视觉与行为的矛盾,违背了 TUI 通行约定（Enter 接受当前 cursor 项）。

## Changes
- `crates/loopal-tui/src/question_ops.rs` — 删 `confirm()` 中的 `needs_interaction` 拦截 + `compute_answer_for()` 中的 untouched 返回空兜底
- `crates/loopal-view-state/src/conversation/question_state.rs` — 删 `interacted` 字段及方法、6 处 mutator 副作用,重命名 `user_set_cursor_clamped`
- `crates/loopal-view-state/src/conversation/pending_question.rs` — 删 `interacted()` 转发方法,更新调用点
- 测试文件 — 反转 silent Enter 断言、清理 6 处死赋值、补充 cursor 移动后的覆盖路径

## Test plan
- [x] `bazel build //... --config=clippy` 全绿
- [x] `bazel test //...` 82/82 通过
- [ ] CI passes