### PR TITLE
fix(cluster): surface remote spawn LLM errors & fix self-target spawn deadlock

### DIFF
--- a/crates/loopal-agent-hub/src/dispatch/spawn_routing.rs
+++ b/crates/loopal-agent-hub/src/dispatch/spawn_routing.rs
@@ -34,9 +34,30 @@ pub async fn handle_spawn_agent(
                 "'target_hub' cannot contain '/' (cross-hub address encoding), got: {target}"
             ));
         }
-        return super::cross_hub_forward::forward_cross_hub_spawn(hub, params, from_agent).await;
+        let own_hub = hub
+            .lock()
+            .await
+            .uplink
+            .as_ref()
+            .map(|u| u.hub_name().to_string());
+        if !is_self_target(own_hub.as_deref(), target) {
+            return super::cross_hub_forward::forward_cross_hub_spawn(hub, params, from_agent).await;
+        }
+        let mut local_params = params;
+        if let Some(obj) = local_params.as_object_mut() {
+            obj.remove("target_hub");
+        }
+        return spawn_local(hub, local_params, from_agent).await;
     }
     spawn_local(hub, params, from_agent).await
+}
+
+// reason: a hub targeting itself would pre-register a shadow then route back
+// through MetaHub into its own registry, colliding as "already registered" and
+// orphaning a forked process. Self-target must spawn locally — same registry,
+// no MetaHub round-trip.
+fn is_self_target(own_hub: Option<&str>, target: &str) -> bool {
+    own_hub == Some(target)
 }
 
 async fn spawn_local(
@@ -148,4 +169,24 @@ pub(super) async fn spawn_via_manager(
         .map_err(|e| format!("spawn failed: {e}"))?;
     info!(agent = %name, %agent_id, "spawn done");
     Ok(json!({"agent_id": agent_id, "name": name}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_self_target;
+
+    #[test]
+    fn own_hub_equals_target_is_self() {
+        assert!(is_self_target(Some("hub-a"), "hub-a"));
+    }
+
+    #[test]
+    fn different_hub_is_not_self() {
+        assert!(!is_self_target(Some("hub-a"), "hub-b"));
+    }
+
+    #[test]
+    fn no_uplink_is_never_self() {
+        assert!(!is_self_target(None, "hub-a"));
+    }
 }

--- a/crates/loopal-agent-hub/src/dispatch/spawn_routing.rs
+++ b/crates/loopal-agent-hub/src/dispatch/spawn_routing.rs
@@ -41,7 +41,8 @@ pub async fn handle_spawn_agent(
             .as_ref()
             .map(|u| u.hub_name().to_string());
         if !is_self_target(own_hub.as_deref(), target) {
-            return super::cross_hub_forward::forward_cross_hub_spawn(hub, params, from_agent).await;
+            return super::cross_hub_forward::forward_cross_hub_spawn(hub, params, from_agent)
+                .await;
         }
         let mut local_params = params;
         if let Some(obj) = local_params.as_object_mut() {

--- a/crates/loopal-agent/src/tools/collaboration/agent.rs
+++ b/crates/loopal-agent/src/tools/collaboration/agent.rs
@@ -29,7 +29,10 @@ impl Tool for AgentTool {
                 "prompt": { "type": "string" },
                 "name": { "type": "string" },
                 "subagent_type": { "type": "string" },
-                "model": { "type": "string" },
+                "model": {
+                    "type": "string",
+                    "description": "Omit to inherit the parent agent's model. Only set to override, and only to a model the target hub actually has — a cross-hub spawn forwards this name verbatim, so an unsupported model fails with 'Model not found'."
+                },
                 "target_hub": {
                     "type": "string",
                     "description": "Spawn on a remote hub in the cluster (e.g. 'hub-b'). Requires MetaHub connection."

--- a/crates/loopal-runtime/src/agent_loop/run.rs
+++ b/crates/loopal-runtime/src/agent_loop/run.rs
@@ -15,6 +15,7 @@ use super::turn_context::TurnContext;
 impl AgentLoopRunner {
     pub(super) async fn run_loop(&mut self) -> Result<AgentOutput> {
         let mut last_output = String::new();
+        let mut last_error: Option<String> = None;
         let mut server_block_retry = false;
         let mut context_overflow_retry = false;
         // Need user input whenever the last message isn't User — covers empty
@@ -108,16 +109,29 @@ impl AgentLoopRunner {
                         continue;
                     }
                     error!(error = %e, "LLM request failed");
-                    self.transition_error(LoopalError::to_string(&e)).await?;
+                    let msg = LoopalError::to_string(&e);
+                    self.transition_error(msg.clone()).await?;
+                    last_error = Some(msg);
+                    // reason: an ephemeral agent has no UI/parent to retry, so an
+                    // unrecovered turn error must terminate the loop with the real
+                    // error — not fall through to "idle, exiting" which would report
+                    // a successful empty result and hide the failure from the caller.
+                    if matches!(self.params.config.lifecycle, LifecycleMode::Ephemeral) {
+                        break;
+                    }
                 }
             }
             server_block_retry = false;
             context_overflow_retry = false;
         }
 
+        let (result, terminate_reason) = match last_error {
+            Some(err) if last_output.is_empty() => (err, TerminateReason::Error),
+            _ => (last_output, TerminateReason::Goal),
+        };
         Ok(AgentOutput {
-            result: last_output,
-            terminate_reason: TerminateReason::Goal,
+            result,
+            terminate_reason,
         })
     }
 

--- a/crates/loopal-runtime/tests/agent_loop/run_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/run_test.rs
@@ -1,6 +1,7 @@
 use loopal_error::{LoopalError, TerminateReason};
 use loopal_protocol::AgentEventPayload;
 use loopal_provider_api::{StopReason, StreamChunk};
+use loopal_runtime::agent_loop::LifecycleMode;
 
 use super::mock_provider::{
     make_interactive_multi_runner, make_multi_runner, make_runner_with_mock_provider,
@@ -131,6 +132,32 @@ async fn test_prompt_driven_error_exits_cleanly() {
         ),
         "prompt-driven error should exit, got: {:?}",
         output.terminate_reason
+    );
+}
+
+/// Reproduces the cross-hub failure: a spawned (ephemeral) agent whose model
+/// has no provider on this hub. resolve_provider errors on the first LLM call;
+/// the loop must surface that error as the result + TerminateReason::Error
+/// instead of returning an empty, falsely-successful Goal completion.
+#[tokio::test]
+async fn test_ephemeral_unresolved_model_propagates_error_to_result() {
+    let calls = vec![vec![
+        Ok(StreamChunk::Text { text: "unused".into() }),
+        Ok(StreamChunk::Done {
+            stop_reason: StopReason::EndTurn,
+        }),
+    ]];
+    let (mut runner, _event_rx) = make_multi_runner(calls);
+    runner.params.config.lifecycle = LifecycleMode::Ephemeral;
+    runner.params.config.router =
+        loopal_provider_api::ModelRouter::new("unknown-model-xyz".to_string());
+
+    let output = runner.run().await.unwrap();
+    assert_eq!(output.terminate_reason, TerminateReason::Error);
+    assert!(
+        !output.result.is_empty() && output.result.contains("unknown-model-xyz"),
+        "real provider error must reach result (caller-visible), got: {:?}",
+        output.result
     );
 }
 

--- a/crates/loopal-runtime/tests/agent_loop/run_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/run_test.rs
@@ -142,7 +142,9 @@ async fn test_prompt_driven_error_exits_cleanly() {
 #[tokio::test]
 async fn test_ephemeral_unresolved_model_propagates_error_to_result() {
     let calls = vec![vec![
-        Ok(StreamChunk::Text { text: "unused".into() }),
+        Ok(StreamChunk::Text {
+            text: "unused".into(),
+        }),
         Ok(StreamChunk::Done {
             stop_reason: StopReason::EndTurn,
         }),


### PR DESCRIPTION
## Summary
- 跨 hub spawn 故障排查发现三个叠加缺陷,共同表现为"远端 agent 返回空结果 / already registered"这种难排查的症状。
- 核心修复:远端 LLM 调用失败(如目标 hub 没有该 model 的 provider)时把真实 error 回传父 agent,不再吞成"成功的空结果"。
- 附带消除 self-target spawn 的注册撞名假死,并给 Agent 工具 `model` 字段补上引导文案,从源头阻止 LLM 猜测不被支持的模型。

## Changes
- `loopal-runtime/src/agent_loop/run.rs` — ephemeral agent 遇未恢复 turn 错误立即终止,返回 `TerminateReason::Error` + 真实错误文本作为 result。
- `loopal-agent/src/tools/collaboration/agent.rs` — `model` 字段补 description:留空继承父模型;跨 hub 原样透传,不支持的 model 会 `Model not found`。
- `loopal-agent-hub/src/dispatch/spawn_routing.rs` — 抽出 `is_self_target` 纯函数,自指 spawn 改走本地,避免 shadow 与回转注册撞名 + orphan 进程。
- `loopal-runtime/tests/agent_loop/run_test.rs` — 新增 ephemeral 未解析 model 的错误回传回归测试;`spawn_routing.rs` 内联 self-target 单测。

## Test plan
- [x] `loopal-runtime` / `loopal-agent-hub` / `loopal-agent` 的 unit + 集成测试全部通过
- [x] clippy 零警告
- [ ] CI passes