### PR TITLE
fix(provider): replay reasoning blocks so web_search/thinking survive multi-turn

### DIFF
--- a/crates/loopal-context/src/ingestion/mod.rs
+++ b/crates/loopal-context/src/ingestion/mod.rs
@@ -88,7 +88,7 @@ fn condense_server_blocks_in_message(msg: &mut Message) {
                 replacements.push((
                     bi,
                     ContentBlock::Text {
-                        text: format!("[server tool '{name}' result condensed]"),
+                        text: server_tool_condensed_marker(name),
                     },
                 ));
             }
@@ -120,24 +120,39 @@ pub fn condense_old_server_blocks(messages: &mut [Message]) {
     }
 }
 
+// Unified placeholder a condensed server-tool result collapses to. Shared by the
+// ContentBlock-layer (wire Message) and AssistantOutput-layer (Turn) condensers.
+pub(crate) fn server_tool_condensed_marker(name: &str) -> String {
+    format!("[server tool '{name}' result condensed]")
+}
+
+// Fold one assistant response's server-tool pairs into text markers and drop the
+// server_blocks (reasoning included — its web_search_call no longer exists). Shared
+// by ingestion's defensive recovery and turn_degradation's old-turn budget trim.
+pub(crate) fn condense_server_pairs_into_text(response: &mut loopal_turn::AssistantOutput) {
+    use loopal_turn::{ServerBlock, TextBlock};
+    if response.server_blocks.is_empty() {
+        return;
+    }
+    for block in &response.server_blocks {
+        if let ServerBlock::ToolPair(p) = block {
+            response.text_blocks.push(TextBlock {
+                text: server_tool_condensed_marker(&p.call.name),
+            });
+        }
+    }
+    response.server_blocks.clear();
+}
+
 // Defensive recovery for Anthropic ServerBlockError: clears server tool
 // pairs across all turns and leaves a marker so next request validates.
 pub(crate) fn condense_server_blocks_in_turns(turns: &mut [loopal_turn::Turn]) {
-    use loopal_turn::{TextBlock, TurnStep};
+    use loopal_turn::TurnStep;
     for turn in turns {
         for step in &mut turn.body.steps {
-            let TurnStep::LlmCall { response, .. } = step else {
-                continue;
-            };
-            if response.server_blocks.is_empty() {
-                continue;
+            if let TurnStep::LlmCall { response, .. } = step {
+                condense_server_pairs_into_text(response);
             }
-            for pair in &response.server_blocks {
-                response.text_blocks.push(TextBlock {
-                    text: format!("[server tool '{}' result condensed]", pair.call.name),
-                });
-            }
-            response.server_blocks.clear();
         }
     }
 }

--- a/crates/loopal-context/src/ingestion/tests.rs
+++ b/crates/loopal-context/src/ingestion/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use loopal_turn::{
-    AssistantOutput, ServerToolCall, ServerToolPair, ServerToolResult, StopReason, Turn, TurnStep,
-    TurnTrigger,
+    AssistantOutput, OrderedToolBatch, ServerBlock, ServerToolCall, ServerToolPair,
+    ServerToolResult, StopReason, ThinkingBlock, Turn, TurnStep, TurnTrigger,
 };
 
 #[test]
@@ -10,10 +10,9 @@ fn condense_server_blocks_in_turns_clears_pairs_and_appends_marker() {
     turn.body.steps.push(TurnStep::LlmCall {
         model: "test".into(),
         response: AssistantOutput {
-            thinking: None,
             text_blocks: vec![],
             tool_calls: vec![],
-            server_blocks: vec![ServerToolPair {
+            server_blocks: vec![ServerBlock::ToolPair(ServerToolPair {
                 call: ServerToolCall {
                     id: "s1".into(),
                     name: "web_search".into(),
@@ -23,7 +22,7 @@ fn condense_server_blocks_in_turns_clears_pairs_and_appends_marker() {
                     block_type: "web_search_tool_result".into(),
                     content: serde_json::json!({"hits": []}),
                 },
-            }],
+            })],
             stop_reason: StopReason::EndTurn,
         },
     });
@@ -44,7 +43,6 @@ fn condense_server_blocks_in_turns_noop_when_empty() {
     turn.body.steps.push(TurnStep::LlmCall {
         model: "test".into(),
         response: AssistantOutput {
-            thinking: None,
             text_blocks: vec![],
             tool_calls: vec![],
             server_blocks: vec![],
@@ -57,4 +55,58 @@ fn condense_server_blocks_in_turns_noop_when_empty() {
         panic!("expected LlmCall step");
     };
     assert!(response.text_blocks.is_empty());
+}
+
+// reason: 混合 Reasoning + ToolPair 时,只有 ToolPair 产 marker;Reasoning 一并清除
+// 但不产 marker(避免把 reasoning 误当 server tool result)。
+#[test]
+fn condense_clears_reasoning_without_marker_keeps_one_per_pair() {
+    let mut turn = Turn::new(TurnTrigger::Resume);
+    turn.body.steps.push(TurnStep::LlmCall {
+        model: "test".into(),
+        response: AssistantOutput {
+            text_blocks: vec![],
+            tool_calls: vec![],
+            server_blocks: vec![
+                ServerBlock::Reasoning(ThinkingBlock {
+                    thinking: "r".into(),
+                    signature: Some("rs_1".into()),
+                }),
+                ServerBlock::ToolPair(ServerToolPair {
+                    call: ServerToolCall {
+                        id: "ws_1".into(),
+                        name: "web_search".into(),
+                        input: serde_json::json!({}),
+                    },
+                    result: ServerToolResult {
+                        block_type: "web_search_tool_result".into(),
+                        content: serde_json::json!({}),
+                    },
+                }),
+            ],
+            stop_reason: StopReason::EndTurn,
+        },
+    });
+    // 非 LlmCall step → 命中 condense 循环的 continue 臂(防御性跳过)。
+    turn.body
+        .steps
+        .push(TurnStep::ToolBatch(OrderedToolBatch { items: vec![] }));
+    let mut turns = vec![turn];
+    condense_server_blocks_in_turns(&mut turns);
+    let TurnStep::LlmCall { response, .. } = &turns[0].body.steps[0] else {
+        panic!("expected LlmCall step");
+    };
+    assert!(
+        response.server_blocks.is_empty(),
+        "all server blocks cleared"
+    );
+    let markers = response
+        .text_blocks
+        .iter()
+        .filter(|t| t.text.contains("condensed"))
+        .count();
+    assert_eq!(
+        markers, 1,
+        "exactly one marker (from the ToolPair, not Reasoning)"
+    );
 }

--- a/crates/loopal-context/src/turn_degradation/mod.rs
+++ b/crates/loopal-context/src/turn_degradation/mod.rs
@@ -1,9 +1,10 @@
-use loopal_turn::{TextBlock, ToolExecState, Turn, TurnStep};
+use loopal_turn::{ServerBlock, ToolExecState, Turn, TurnStep};
 
 use crate::budget::ContextBudget;
 use crate::compact_config::{
     LAYER1_TRIGGER_PERCENT, LAYER1_TRUNCATE_MAX_BYTES, LAYER1_TRUNCATE_MAX_LINES,
 };
+use crate::ingestion::condense_server_pairs_into_text;
 use crate::token_counter::estimate_tokens;
 
 const CAP_MAX_LINES: usize = 500;
@@ -22,27 +23,9 @@ pub fn degrade_turns_for_wire(turns: &mut [Turn], budget: &ContextBudget) {
             match step {
                 TurnStep::LlmCall { response, .. } => {
                     if !is_current {
-                        // signature 是 OpenAI reasoning_item_id 跨 turn 配对锚点 —
-                        // 必须保留。早期写法依赖 server_blocks 非空判断 → 第二次
-                        // degrade 时 server_blocks 已清空，signature 被错误 drop。
-                        if response
-                            .thinking
-                            .as_ref()
-                            .is_none_or(|t| t.signature.is_none())
-                        {
-                            response.thinking = None;
-                        }
-                        if !response.server_blocks.is_empty() {
-                            for pair in &response.server_blocks {
-                                response.text_blocks.push(TextBlock {
-                                    text: format!(
-                                        "[server tool '{}' result condensed]",
-                                        pair.call.name
-                                    ),
-                                });
-                            }
-                            response.server_blocks.clear();
-                        }
+                        // 旧 turn：web_search_call 被 condense 成 text 后不复存在，
+                        // 其 reasoning 锚点(及 Anthropic thinking)无需保留 → 全清。
+                        condense_server_pairs_into_text(response);
                     }
                 }
                 TurnStep::ToolBatch(batch) => {
@@ -130,8 +113,10 @@ pub fn estimate_turns_tokens(turns: &[Turn]) -> u32 {
                     for t in &response.text_blocks {
                         total = total.saturating_add(estimate_tokens(&t.text));
                     }
-                    if let Some(t) = &response.thinking {
-                        total = total.saturating_add(estimate_tokens(&t.thinking));
+                    for block in &response.server_blocks {
+                        if let ServerBlock::Reasoning(t) = block {
+                            total = total.saturating_add(estimate_tokens(&t.thinking));
+                        }
                     }
                 }
                 TurnStep::ToolBatch(batch) => {

--- a/crates/loopal-context/src/turn_degradation/tests.rs
+++ b/crates/loopal-context/src/turn_degradation/tests.rs
@@ -1,8 +1,9 @@
 use super::*;
 use loopal_tool_invocation as _;
 use loopal_turn::{
-    AssistantOutput, OrderedToolBatch, StopReason, TextBlock, ThinkingBlock, ToolBatchItem,
-    ToolCall, ToolCallId, ToolResult, Turn, TurnTrigger,
+    AssistantOutput, OrderedToolBatch, ServerBlock, ServerToolCall, ServerToolPair,
+    ServerToolResult, StopReason, TextBlock, ThinkingBlock, ToolBatchItem, ToolCall, ToolCallId,
+    ToolResult, Turn, TurnTrigger,
 };
 
 fn budget() -> ContextBudget {
@@ -19,22 +20,22 @@ fn budget() -> ContextBudget {
 
 fn make_turn_with_llm_call(thinking: bool) -> Turn {
     let mut turn = Turn::new(TurnTrigger::Resume);
+    let server_blocks = if thinking {
+        vec![ServerBlock::Reasoning(ThinkingBlock {
+            thinking: "deep thoughts".into(),
+            signature: Some("sig-1".into()),
+        })]
+    } else {
+        vec![]
+    };
     turn.body.steps.push(TurnStep::LlmCall {
         model: "test".into(),
         response: AssistantOutput {
-            thinking: if thinking {
-                Some(ThinkingBlock {
-                    thinking: "deep thoughts".into(),
-                    signature: None,
-                })
-            } else {
-                None
-            },
             text_blocks: vec![TextBlock {
                 text: "reply".into(),
             }],
             tool_calls: vec![],
-            server_blocks: vec![],
+            server_blocks,
             stop_reason: StopReason::EndTurn,
         },
     });
@@ -61,17 +62,65 @@ fn make_turn_with_tool_result(body: String) -> Turn {
 }
 
 #[test]
-fn strips_thinking_from_old_turns_only() {
+fn strips_reasoning_from_old_turns_only() {
     let mut turns = vec![make_turn_with_llm_call(true), make_turn_with_llm_call(true)];
     degrade_turns_for_wire(&mut turns, &budget());
     let TurnStep::LlmCall { response, .. } = &turns[0].body.steps[0] else {
         panic!();
     };
-    assert!(response.thinking.is_none());
+    assert!(
+        response.server_blocks.is_empty(),
+        "old turn reasoning must be dropped"
+    );
     let TurnStep::LlmCall { response, .. } = &turns[1].body.steps[0] else {
         panic!();
     };
-    assert!(response.thinking.is_some());
+    assert!(
+        response
+            .server_blocks
+            .iter()
+            .any(|b| matches!(b, ServerBlock::Reasoning(_))),
+        "current turn reasoning must be kept"
+    );
+}
+
+// reason: 旧 turn 的 ToolPair 必须被 condense 成 marker text(web_search_call 已不
+// 存在,其 reasoning 锚点亦无需保留),覆盖 degrade 的 ToolPair 臂。
+#[test]
+fn condenses_tool_pair_in_old_turn_to_marker() {
+    let mut old = Turn::new(TurnTrigger::Resume);
+    old.body.steps.push(TurnStep::LlmCall {
+        model: "test".into(),
+        response: AssistantOutput {
+            text_blocks: vec![],
+            tool_calls: vec![],
+            server_blocks: vec![ServerBlock::ToolPair(ServerToolPair {
+                call: ServerToolCall {
+                    id: "ws_1".into(),
+                    name: "web_search".into(),
+                    input: serde_json::json!({}),
+                },
+                result: ServerToolResult {
+                    block_type: "web_search_tool_result".into(),
+                    content: serde_json::json!({}),
+                },
+            })],
+            stop_reason: StopReason::EndTurn,
+        },
+    });
+    let mut turns = vec![old, make_turn_with_llm_call(false)];
+    degrade_turns_for_wire(&mut turns, &budget());
+    let TurnStep::LlmCall { response, .. } = &turns[0].body.steps[0] else {
+        panic!();
+    };
+    assert!(response.server_blocks.is_empty());
+    assert!(
+        response
+            .text_blocks
+            .iter()
+            .any(|t| t.text.contains("web_search") && t.text.contains("condensed")),
+        "old-turn ToolPair must condense to a marker"
+    );
 }
 
 #[test]
@@ -93,4 +142,16 @@ fn caps_oversized_tool_results() {
 fn empty_turns_noop() {
     let mut turns: Vec<Turn> = Vec::new();
     degrade_turns_for_wire(&mut turns, &budget());
+}
+
+// reason: reasoning token 必须计入预算,否则删 thinking 字段后 reasoning 体量从
+// compaction 预算消失、触发时机偏移。
+#[test]
+fn estimate_counts_reasoning_text() {
+    let with = estimate_turns_tokens(&[make_turn_with_llm_call(true)]);
+    let without = estimate_turns_tokens(&[make_turn_with_llm_call(false)]);
+    assert!(
+        with > without,
+        "reasoning text must contribute to the token estimate"
+    );
 }

--- a/crates/loopal-context/src/turn_tracker/derive/tests.rs
+++ b/crates/loopal-context/src/turn_tracker/derive/tests.rs
@@ -23,7 +23,6 @@ fn llm_call_with_tools(ids: &[&str]) -> TurnStep {
     TurnStep::LlmCall {
         model: "m".into(),
         response: AssistantOutput {
-            thinking: None,
             text_blocks: Vec::new(),
             tool_calls: ids
                 .iter()

--- a/crates/loopal-context/src/turn_tracker/wire_mutator.rs
+++ b/crates/loopal-context/src/turn_tracker/wire_mutator.rs
@@ -36,8 +36,8 @@ pub fn condense_server_blocks(turns: &mut [Turn]) {
 mod tests {
     use super::*;
     use loopal_turn::{
-        AssistantOutput, ServerToolCall, ServerToolPair, ServerToolResult, StopReason, TextBlock,
-        Turn, TurnStep, TurnTrigger,
+        AssistantOutput, ServerBlock, ServerToolCall, ServerToolPair, ServerToolResult, StopReason,
+        TextBlock, Turn, TurnStep, TurnTrigger,
     };
 
     fn turn_with_server_blocks() -> Turn {
@@ -49,10 +49,9 @@ mod tests {
         t.body.steps.push(TurnStep::LlmCall {
             model: "m".into(),
             response: AssistantOutput {
-                thinking: None,
                 text_blocks: vec![TextBlock { text: "ok".into() }],
                 tool_calls: Vec::new(),
-                server_blocks: vec![ServerToolPair {
+                server_blocks: vec![ServerBlock::ToolPair(ServerToolPair {
                     call: ServerToolCall {
                         id: "s1".into(),
                         name: "web_search".into(),
@@ -62,7 +61,7 @@ mod tests {
                         block_type: "web_search_tool_result".into(),
                         content: serde_json::json!({"x": 1}),
                     },
-                }],
+                })],
                 stop_reason: StopReason::EndTurn,
             },
         });
@@ -119,7 +118,6 @@ mod tests {
         t.body.steps.push(TurnStep::LlmCall {
             model: "m".into(),
             response: AssistantOutput {
-                thinking: None,
                 text_blocks: Vec::new(),
                 tool_calls: vec![ToolCall {
                     id: ToolCallId::new("c1"),

--- a/crates/loopal-context/tests/suite/turn_store_test.rs
+++ b/crates/loopal-context/tests/suite/turn_store_test.rs
@@ -42,7 +42,6 @@ fn llm_step() -> TurnStep {
     TurnStep::LlmCall {
         model: "claude-opus-4-7".into(),
         response: AssistantOutput {
-            thinking: None,
             text_blocks: vec![],
             tool_calls: vec![],
             server_blocks: vec![],

--- a/crates/loopal-provider-api/src/wire/turn_projection/step.rs
+++ b/crates/loopal-provider-api/src/wire/turn_projection/step.rs
@@ -1,5 +1,6 @@
 use loopal_turn::{
-    AssistantOutput, InjectionKind, OrderedToolBatch, ToolBatchItem, ToolExecState, TurnStep,
+    AssistantOutput, InjectionKind, OrderedToolBatch, ServerBlock, ToolBatchItem, ToolExecState,
+    TurnStep,
 };
 
 use super::super::message::{ContentBlock, Message, MessageRole};
@@ -20,19 +21,21 @@ pub(super) fn project_step(step: &TurnStep) -> Vec<Message> {
     }
 }
 
+// reason: server_blocks 在最前 → reasoning 作为 content 首块(Anthropic 约束)且
+// 紧贴其 web_search_call;text、tool_calls 随后(OpenAI: server 块先于 function_call)。
 fn project_assistant(response: &AssistantOutput) -> Message {
     let mut content = Vec::new();
-    if let Some(t) = &response.thinking {
-        content.push(thinking_block(t));
+    for block in &response.server_blocks {
+        match block {
+            ServerBlock::Reasoning(t) => content.push(thinking_block(t)),
+            ServerBlock::ToolPair(p) => content.extend(server_pair_blocks(p)),
+        }
     }
     for block in &response.text_blocks {
         content.push(text_block(block));
     }
     for call in &response.tool_calls {
         content.push(tool_use_block(call));
-    }
-    for pair in &response.server_blocks {
-        content.extend(server_pair_blocks(pair));
     }
     Message {
         id: None,

--- a/crates/loopal-provider-api/tests/suite/turn_projection_test.rs
+++ b/crates/loopal-provider-api/tests/suite/turn_projection_test.rs
@@ -3,9 +3,9 @@ use loopal_provider_api::{
     ContentBlock, MessageRole, project_turn_to_messages, project_turns_to_messages,
 };
 use loopal_turn::{
-    AssistantOutput, OrderedToolBatch, ServerToolCall, ServerToolPair, ServerToolResult,
-    StopReason, TextBlock, ToolBatchItem, ToolCall, ToolCallId, ToolExecState, ToolResult, Turn,
-    TurnBody, TurnStep, TurnTrigger,
+    AssistantOutput, OrderedToolBatch, ServerBlock, ServerToolCall, ServerToolPair,
+    ServerToolResult, StopReason, TextBlock, ThinkingBlock, ToolBatchItem, ToolCall, ToolCallId,
+    ToolExecState, ToolResult, Turn, TurnBody, TurnStep, TurnTrigger,
 };
 
 fn turn_with(trigger: TurnTrigger, steps: Vec<TurnStep>) -> Turn {
@@ -26,7 +26,6 @@ fn llm_step(text: &str, calls: Vec<ToolCall>) -> TurnStep {
     TurnStep::LlmCall {
         model: "m".into(),
         response: AssistantOutput {
-            thinking: None,
             text_blocks: if text.is_empty() {
                 vec![]
             } else {
@@ -252,10 +251,9 @@ fn server_tool_pair_emits_use_and_result() {
         vec![TurnStep::LlmCall {
             model: "m".into(),
             response: AssistantOutput {
-                thinking: None,
                 text_blocks: vec![],
                 tool_calls: vec![],
-                server_blocks: vec![pair],
+                server_blocks: vec![ServerBlock::ToolPair(pair)],
                 stop_reason: StopReason::EndTurn,
             },
         }],
@@ -274,6 +272,74 @@ fn server_tool_pair_emits_use_and_result() {
         .iter()
         .any(|b| matches!(b, ContentBlock::ServerToolResult { .. }));
     assert!(has_use && has_result);
+}
+
+// reason: 回归 #190 — reasoning 必须是 content 首块(Anthropic)且紧贴各自的
+// web_search_call(OpenAI);text/tool_calls 排在所有 server 块之后。
+#[test]
+fn reasoning_precedes_each_web_search_and_text_follows() {
+    let mk_pair = |id: &str| ServerToolPair {
+        call: ServerToolCall {
+            id: id.into(),
+            name: "web_search".into(),
+            input: serde_json::json!({}),
+        },
+        result: ServerToolResult {
+            block_type: "web_search_tool_result".into(),
+            content: serde_json::json!({}),
+        },
+    };
+    let mk_reason = |sig: &str| {
+        ServerBlock::Reasoning(ThinkingBlock {
+            thinking: "r".into(),
+            signature: Some(sig.into()),
+        })
+    };
+    let t = turn_with(
+        user_trigger("q"),
+        vec![TurnStep::LlmCall {
+            model: "m".into(),
+            response: AssistantOutput {
+                text_blocks: vec![TextBlock { text: "ans".into() }],
+                tool_calls: vec![],
+                server_blocks: vec![
+                    mk_reason("rs_1"),
+                    ServerBlock::ToolPair(mk_pair("ws_1")),
+                    mk_reason("rs_2"),
+                    ServerBlock::ToolPair(mk_pair("ws_2")),
+                ],
+                stop_reason: StopReason::EndTurn,
+            },
+        }],
+    );
+    let msgs = project_turn_to_messages(&t);
+    let asst = msgs
+        .iter()
+        .find(|m| m.role == MessageRole::Assistant)
+        .unwrap();
+    assert!(
+        matches!(asst.content[0], ContentBlock::Thinking { .. }),
+        "first block must be reasoning (Anthropic content[0] constraint)"
+    );
+    for (i, b) in asst.content.iter().enumerate() {
+        if matches!(b, ContentBlock::ServerToolUse { .. }) {
+            assert!(
+                matches!(asst.content[i - 1], ContentBlock::Thinking { .. }),
+                "web_search_call at idx {i} must be preceded by its reasoning"
+            );
+        }
+    }
+    let text_idx = asst
+        .content
+        .iter()
+        .position(|b| matches!(b, ContentBlock::Text { .. }))
+        .unwrap();
+    let last_server = asst
+        .content
+        .iter()
+        .rposition(|b| matches!(b, ContentBlock::ServerToolResult { .. }))
+        .unwrap();
+    assert!(text_idx > last_server, "text must follow all server blocks");
 }
 
 #[test]
@@ -359,7 +425,6 @@ fn compaction_summary_projects_before_other_steps() {
             TurnStep::LlmCall {
                 model: "claude-haiku-4-5".into(),
                 response: AssistantOutput {
-                    thinking: None,
                     text_blocks: vec![TextBlock {
                         text: "RESP".into(),
                     }],

--- a/crates/loopal-provider/src/anthropic/request_turns/mod.rs
+++ b/crates/loopal-provider/src/anthropic/request_turns/mod.rs
@@ -178,3 +178,5 @@ fn push_compaction_rehydrate(out: &mut Vec<Value>, r: &CompactionRehydrate) {
 mod tests_boundary;
 #[cfg(test)]
 mod tests_merge;
+#[cfg(test)]
+mod tests_reasoning;

--- a/crates/loopal-provider/src/anthropic/request_turns/tests_reasoning.rs
+++ b/crates/loopal-provider/src/anthropic/request_turns/tests_reasoning.rs
@@ -1,0 +1,127 @@
+use super::*;
+use loopal_turn::{
+    AssistantOutput, ServerBlock, ServerToolCall, ServerToolPair, ServerToolResult, StopReason,
+    TextBlock, ThinkingBlock, ToolCall, ToolCallId, TurnStep,
+};
+
+fn turn_with_user(content: &str) -> Turn {
+    Turn::new(TurnTrigger::UserInput {
+        envelope_id: String::new(),
+        content: content.into(),
+        images: Vec::new(),
+    })
+}
+
+fn web_search_pair() -> ServerToolPair {
+    ServerToolPair {
+        call: ServerToolCall {
+            id: "ws_1".into(),
+            name: "web_search".into(),
+            input: serde_json::json!({"query": "x"}),
+        },
+        result: ServerToolResult {
+            block_type: "web_search_tool_result".into(),
+            content: serde_json::json!({"status": "completed"}),
+        },
+    }
+}
+
+fn assistant_content_with(server_blocks: Vec<ServerBlock>) -> Vec<serde_json::Value> {
+    let provider = AnthropicProvider::new(String::new());
+    let mut turn = turn_with_user("q");
+    turn.body.steps.push(TurnStep::LlmCall {
+        model: "m".into(),
+        response: AssistantOutput {
+            text_blocks: vec![],
+            tool_calls: vec![],
+            server_blocks,
+            stop_reason: StopReason::EndTurn,
+        },
+    });
+    let params = ChatParams::new("claude-sonnet-4-20250514".into(), vec![turn], String::new());
+    let out = provider.build_messages_json_from_turns(&params);
+    out.into_iter()
+        .find(|m| m["role"] == "assistant")
+        .and_then(|m| m["content"].as_array().cloned())
+        .expect("assistant message with content array")
+}
+
+// reason: 完整 turn(reasoning + text + tool_use)必须按 server→text→tool_use 投影,
+// 覆盖 build_assistant 的 text_blocks / tool_calls 两个循环臂。
+#[test]
+fn full_turn_orders_reasoning_then_text_then_tool_use() {
+    let provider = AnthropicProvider::new(String::new());
+    let mut turn = turn_with_user("q");
+    turn.body.steps.push(TurnStep::LlmCall {
+        model: "m".into(),
+        response: AssistantOutput {
+            text_blocks: vec![TextBlock {
+                text: "here".into(),
+            }],
+            tool_calls: vec![ToolCall {
+                id: ToolCallId::new("tc_1"),
+                name: "Read".into(),
+                input: serde_json::json!({"file_path": "a.rs"}),
+            }],
+            server_blocks: vec![ServerBlock::Reasoning(ThinkingBlock {
+                thinking: "r".into(),
+                signature: Some("sig".into()),
+            })],
+            stop_reason: StopReason::ToolUse,
+        },
+    });
+    let params = ChatParams::new("claude-sonnet-4-20250514".into(), vec![turn], String::new());
+    let out = provider.build_messages_json_from_turns(&params);
+    let content = out
+        .into_iter()
+        .find(|m| m["role"] == "assistant")
+        .and_then(|m| m["content"].as_array().cloned())
+        .unwrap();
+    let types: Vec<&str> = content.iter().filter_map(|b| b["type"].as_str()).collect();
+    assert_eq!(types, vec!["thinking", "text", "tool_use"]);
+}
+
+#[test]
+fn reasoning_emits_thinking_first_with_signature() {
+    let content = assistant_content_with(vec![
+        ServerBlock::Reasoning(ThinkingBlock {
+            thinking: "deep".into(),
+            signature: Some("sig-1".into()),
+        }),
+        ServerBlock::ToolPair(web_search_pair()),
+    ]);
+    assert_eq!(content[0]["type"], "thinking");
+    assert_eq!(content[0]["signature"], "sig-1");
+    assert_eq!(content[1]["type"], "server_tool_use");
+    assert_eq!(content[2]["type"], "web_search_tool_result");
+}
+
+// reason: 无签名 Reasoning 必须被跳过——Anthropic 密码学校验签名，空签名会 400。
+#[test]
+fn reasoning_without_signature_is_skipped() {
+    let content = assistant_content_with(vec![
+        ServerBlock::Reasoning(ThinkingBlock {
+            thinking: "unsigned".into(),
+            signature: None,
+        }),
+        ServerBlock::ToolPair(web_search_pair()),
+    ]);
+    assert!(
+        content.iter().all(|b| b["type"] != "thinking"),
+        "unsigned reasoning must not be emitted: {content:?}"
+    );
+    assert_eq!(content[0]["type"], "server_tool_use");
+}
+
+// reason: 对抗——空字符串签名等同无签名(Anthropic 同样拒绝),必须走 filter 跳过臂。
+#[test]
+fn reasoning_with_empty_signature_is_skipped() {
+    let content = assistant_content_with(vec![ServerBlock::Reasoning(ThinkingBlock {
+        thinking: "blank sig".into(),
+        signature: Some(String::new()),
+    })]);
+    assert!(
+        content.iter().all(|b| b["type"] != "thinking"),
+        "empty-string signature must be skipped like unsigned: {content:?}"
+    );
+}

--- a/crates/loopal-provider/src/anthropic/request_turns/to_json.rs
+++ b/crates/loopal-provider/src/anthropic/request_turns/to_json.rs
@@ -1,16 +1,18 @@
 use loopal_turn::{
-    AssistantOutput, CancelCause, OrderedToolBatch, ServerToolPair, TextBlock, ThinkingBlock,
-    ToolBatchItem, ToolCall, ToolExecState, ToolResult,
+    AssistantOutput, CancelCause, OrderedToolBatch, ServerBlock, ServerToolPair, TextBlock,
+    ThinkingBlock, ToolBatchItem, ToolCall, ToolExecState, ToolResult,
 };
 use serde_json::{Value, json};
 
 pub(super) fn build_assistant(response: &AssistantOutput) -> Value {
     let mut content: Vec<Value> = Vec::new();
-    if let Some(t) = &response.thinking {
-        content.push(thinking_to_json(t));
-    }
-    for pair in &response.server_blocks {
-        content.extend(server_pair_to_json(pair));
+    // reason: server_blocks 在最前 → thinking 必须是 assistant content 首块(Anthropic
+    // 硬约束)且紧贴其 server_tool_use。
+    for block in &response.server_blocks {
+        match block {
+            ServerBlock::Reasoning(t) => content.extend(thinking_to_json(t)),
+            ServerBlock::ToolPair(p) => content.extend(server_pair_to_json(p)),
+        }
     }
     for tb in &response.text_blocks {
         content.push(text_to_json(tb));
@@ -63,12 +65,15 @@ fn text_to_json(tb: &TextBlock) -> Value {
     json!({"type": "text", "text": tb.text})
 }
 
-fn thinking_to_json(t: &ThinkingBlock) -> Value {
-    json!({
+// reason: Anthropic 对 thinking 块密码学校验 signature，空/缺签名会 400。无签名的
+// Reasoning 直接跳过(纵深防御),正常 extended-thinking 流必带签名。
+fn thinking_to_json(t: &ThinkingBlock) -> Option<Value> {
+    let signature = t.signature.as_deref().filter(|s| !s.is_empty())?;
+    Some(json!({
         "type": "thinking",
         "thinking": t.thinking,
-        "signature": t.signature.as_deref().unwrap_or(""),
-    })
+        "signature": signature,
+    }))
 }
 
 fn tool_call_to_json(c: &ToolCall) -> Value {

--- a/crates/loopal-provider/tests/suite.rs
+++ b/crates/loopal-provider/tests/suite.rs
@@ -15,6 +15,8 @@ mod model_info_overlay_test;
 mod model_info_test;
 #[path = "suite/model_supports_prefill_test.rs"]
 mod model_supports_prefill_test;
+#[path = "suite/openai_input_reasoning_test.rs"]
+mod openai_input_reasoning_test;
 #[path = "suite/openai_reasoning_e2e_test.rs"]
 mod openai_reasoning_e2e_test;
 #[path = "suite/openai_stream_edge_test.rs"]

--- a/crates/loopal-provider/tests/suite/openai_input_reasoning_test.rs
+++ b/crates/loopal-provider/tests/suite/openai_input_reasoning_test.rs
@@ -1,0 +1,92 @@
+use super::stream_helpers::test_chat_params;
+use loopal_provider::OpenAiProvider;
+use loopal_provider_api::{ContentBlock, Message, MessageRole};
+use serde_json::json;
+
+fn assistant(content: Vec<ContentBlock>) -> Message {
+    Message {
+        id: None,
+        role: MessageRole::Assistant,
+        content,
+        origin: None,
+        ephemeral_in_history: false,
+    }
+}
+
+fn reasoning(id: &str) -> ContentBlock {
+    ContentBlock::Thinking {
+        thinking: format!("thinking {id}"),
+        signature: Some(id.into()),
+    }
+}
+
+fn web_search(id: &str) -> Vec<ContentBlock> {
+    vec![
+        ContentBlock::ServerToolUse {
+            id: id.into(),
+            name: "web_search".into(),
+            input: json!({"query": "q"}),
+        },
+        ContentBlock::ServerToolResult {
+            block_type: "web_search_tool_result".into(),
+            tool_use_id: id.into(),
+            content: json!({"status": "completed"}),
+        },
+    ]
+}
+
+fn item_kinds(input: &[serde_json::Value]) -> Vec<(String, String)> {
+    input
+        .iter()
+        .filter_map(|v| {
+            let ty = v["type"].as_str()?;
+            if ty == "reasoning" || ty == "web_search_call" {
+                Some((ty.to_string(), v["id"].as_str().unwrap_or("").to_string()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+// reason: 回归 #190 — 多个 web_search_call 在 wire `input` 里必须各自带前导 reasoning
+// item，否则 OpenAI Responses API 400 "web_search_call provided without its
+// required reasoning item"。这是当时线上 400 的精确复现。
+#[test]
+fn each_web_search_call_is_preceded_by_its_reasoning_item() {
+    let mut content = vec![reasoning("rs_1")];
+    content.extend(web_search("ws_1"));
+    content.push(reasoning("rs_2"));
+    content.extend(web_search("ws_2"));
+
+    let provider = OpenAiProvider::new("test-key".into());
+    let input = provider.build_input_from_messages(&[assistant(content)], &test_chat_params());
+
+    assert_eq!(
+        item_kinds(&input),
+        vec![
+            ("reasoning".into(), "rs_1".into()),
+            ("web_search_call".into(), "ws_1".into()),
+            ("reasoning".into(), "rs_2".into()),
+            ("web_search_call".into(), "ws_2".into()),
+        ],
+        "every web_search_call must be immediately preceded by its reasoning item"
+    );
+}
+
+#[test]
+fn single_reasoning_web_search_round_trips() {
+    let mut content = vec![reasoning("rs_a")];
+    content.extend(web_search("ws_a"));
+
+    let provider = OpenAiProvider::new("test-key".into());
+    let input = provider.build_input_from_messages(&[assistant(content)], &test_chat_params());
+
+    assert_eq!(
+        item_kinds(&input),
+        vec![
+            ("reasoning".into(), "rs_a".into()),
+            ("web_search_call".into(), "ws_a".into()),
+        ]
+    );
+}

--- a/crates/loopal-runtime/src/agent_loop/llm_record.rs
+++ b/crates/loopal-runtime/src/agent_loop/llm_record.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+
 use loopal_provider_api::ContentBlock;
 use loopal_turn::{
-    AssistantOutput, ServerToolCall, ServerToolPair, ServerToolResult,
+    AssistantOutput, ServerBlock, ServerToolCall, ServerToolPair, ServerToolResult,
     StopReason as TurnStopReason, TextBlock, ThinkingBlock, ToolCall, ToolCallId, TurnStep,
 };
 use tracing::{error, warn};
@@ -13,16 +15,13 @@ impl AgentLoopRunner {
         &mut self,
         assistant_text: &str,
         tool_uses: &[(String, String, serde_json::Value)],
-        thinking_text: &str,
-        thinking_signature: Option<&str>,
         server_blocks: Vec<ContentBlock>,
     ) {
-        let has_thinking = thinking_signature.is_some()
-            && (!thinking_text.is_empty() || !server_blocks.is_empty());
         let has_text = !assistant_text.is_empty();
         let has_tools = !tool_uses.is_empty();
+        // reason: reasoning(Thinking) 与 web_search 都在 server_blocks 里，非空即有内容
         let has_server = !server_blocks.is_empty();
-        if !has_thinking && !has_text && !has_tools && !has_server {
+        if !has_text && !has_tools && !has_server {
             warn!(
                 "LLM returned an empty response (no text, tool_use, thinking, or \
                  server block); turn ends with no assistant output — check the \
@@ -34,8 +33,6 @@ impl AgentLoopRunner {
             self.params.config.model(),
             assistant_text,
             tool_uses,
-            thinking_text,
-            thinking_signature,
             &server_blocks,
         );
         if let Err(e) = self.append_step_record(step) {
@@ -48,24 +45,8 @@ fn build_llm_call_step(
     model: &str,
     assistant_text: &str,
     tool_uses: &[(String, String, serde_json::Value)],
-    thinking_text: &str,
-    thinking_signature: Option<&str>,
     server_blocks: &[ContentBlock],
 ) -> TurnStep {
-    // reason: signature 在 OpenAI 路径上承载 reasoning_item_id；只要 signature
-    // 在场且 text 或 server_blocks 之一非空，就必须保留 ThinkingBlock。否则
-    // multi-turn web_search 跨 turn 配对（OpenAI server tool）会丢失 reasoning
-    // item id，下一次 wire projection 缺少必要锚点 → API 拒绝。
-    let thinking = if thinking_signature.is_some()
-        && (!thinking_text.is_empty() || !server_blocks.is_empty())
-    {
-        Some(ThinkingBlock {
-            thinking: thinking_text.to_string(),
-            signature: thinking_signature.map(String::from),
-        })
-    } else {
-        None
-    };
     let text_blocks = if assistant_text.is_empty() {
         vec![]
     } else {
@@ -81,7 +62,6 @@ fn build_llm_call_step(
             input: input.clone(),
         })
         .collect();
-    let server_pairs = pair_server_blocks(server_blocks);
     let stop_reason = if tool_uses.is_empty() {
         TurnStopReason::EndTurn
     } else {
@@ -90,44 +70,56 @@ fn build_llm_call_step(
     TurnStep::LlmCall {
         model: model.to_string(),
         response: AssistantOutput {
-            thinking,
             text_blocks,
             tool_calls,
-            server_blocks: server_pairs,
+            server_blocks: build_server_blocks(server_blocks),
             stop_reason,
         },
     }
 }
 
-fn pair_server_blocks(blocks: &[ContentBlock]) -> Vec<ServerToolPair> {
-    let mut uses: std::collections::HashMap<String, (String, serde_json::Value)> =
-        Default::default();
-    let mut pairs = Vec::new();
-    for b in blocks {
-        if let ContentBlock::ServerToolUse { id, name, input } = b {
-            uses.insert(id.clone(), (name.clone(), input.clone()));
-        }
-    }
+// reason: 单趟按 Thinking/ServerToolUse 的流位置构造 ServerBlock，保留 reasoning 与
+// web_search 的交错顺序（OpenAI 要求 reasoning 紧贴其 web_search_call）。result 按
+// id 查表配对，容忍 use/result 非紧邻；孤立 use(截断响应)被丢弃。
+fn build_server_blocks(blocks: &[ContentBlock]) -> Vec<ServerBlock> {
+    let mut results: HashMap<&str, (&str, &serde_json::Value)> = HashMap::new();
     for b in blocks {
         if let ContentBlock::ServerToolResult {
             block_type,
             tool_use_id,
             content,
         } = b
-            && let Some((name, input)) = uses.remove(tool_use_id)
         {
-            pairs.push(ServerToolPair {
-                call: ServerToolCall {
-                    id: tool_use_id.clone(),
-                    name,
-                    input,
-                },
-                result: ServerToolResult {
-                    block_type: block_type.clone(),
-                    content: content.clone(),
-                },
-            });
+            results.insert(tool_use_id, (block_type, content));
         }
     }
-    pairs
+    let mut out = Vec::new();
+    for b in blocks {
+        match b {
+            ContentBlock::Thinking {
+                thinking,
+                signature,
+            } => out.push(ServerBlock::Reasoning(ThinkingBlock {
+                thinking: thinking.clone(),
+                signature: signature.clone(),
+            })),
+            ContentBlock::ServerToolUse { id, name, input } => {
+                if let Some((block_type, content)) = results.get(id.as_str()) {
+                    out.push(ServerBlock::ToolPair(ServerToolPair {
+                        call: ServerToolCall {
+                            id: id.clone(),
+                            name: name.clone(),
+                            input: input.clone(),
+                        },
+                        result: ServerToolResult {
+                            block_type: (*block_type).to_string(),
+                            content: (*content).clone(),
+                        },
+                    }));
+                }
+            }
+            _ => {}
+        }
+    }
+    out
 }

--- a/crates/loopal-runtime/src/agent_loop/llm_result.rs
+++ b/crates/loopal-runtime/src/agent_loop/llm_result.rs
@@ -11,9 +11,9 @@ pub struct LlmStreamResult {
     pub stream_error: bool,
     pub stop_reason: StopReason,
     pub thinking_text: String,
-    pub thinking_signature: Option<String>,
     pub thinking_tokens: u32,
-    /// Server-side tool blocks (e.g. web_search), preserved in stream order.
+    /// Reasoning + server-side tool blocks (Thinking / web_search), preserved in
+    /// stream order so projection replays reasoning adjacent to its web_search_call.
     pub server_blocks: Vec<ContentBlock>,
 }
 
@@ -25,9 +25,64 @@ impl Default for LlmStreamResult {
             stream_error: false,
             stop_reason: StopReason::EndTurn,
             thinking_text: String::new(),
-            thinking_signature: None,
             thinking_tokens: 0,
             server_blocks: Vec::new(),
         }
+    }
+}
+
+impl LlmStreamResult {
+    // reason: ThinkingSignature 把 thinking_text mem::take 进 server_blocks，故 metrics
+    // 必须数 server_blocks 里的 Thinking 块；残留 thinking_text(未配 signature)算 1。
+    pub fn thinking_block_count(&self) -> u32 {
+        let in_blocks = self
+            .server_blocks
+            .iter()
+            .filter(|b| matches!(b, ContentBlock::Thinking { .. }))
+            .count() as u32;
+        in_blocks + u32::from(!self.thinking_text.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn thinking(id: &str) -> ContentBlock {
+        ContentBlock::Thinking {
+            thinking: id.into(),
+            signature: Some(id.into()),
+        }
+    }
+
+    #[test]
+    fn counts_thinking_blocks_not_other_server_blocks() {
+        let r = LlmStreamResult {
+            server_blocks: vec![
+                thinking("a"),
+                ContentBlock::ServerToolUse {
+                    id: "w".into(),
+                    name: "web_search".into(),
+                    input: serde_json::json!({}),
+                },
+                thinking("b"),
+            ],
+            ..Default::default()
+        };
+        assert_eq!(r.thinking_block_count(), 2);
+    }
+
+    #[test]
+    fn counts_residual_unsigned_thinking_text_as_one() {
+        let r = LlmStreamResult {
+            thinking_text: "partial".into(),
+            ..Default::default()
+        };
+        assert_eq!(r.thinking_block_count(), 1);
+    }
+
+    #[test]
+    fn empty_response_counts_zero() {
+        assert_eq!(LlmStreamResult::default().thinking_block_count(), 0);
     }
 }

--- a/crates/loopal-runtime/src/agent_loop/turn_response.rs
+++ b/crates/loopal-runtime/src/agent_loop/turn_response.rs
@@ -31,10 +31,12 @@ fn record_text_metrics(turn_ctx: &mut TurnContext, text: &str) {
     turn_ctx.metrics.text_hash = Some(hash_text(text));
 }
 
-fn record_thinking_metrics(turn_ctx: &mut TurnContext, thinking_text: &str) {
-    if !thinking_text.is_empty() {
-        turn_ctx.metrics.thinking_block_count =
-            turn_ctx.metrics.thinking_block_count.saturating_add(1);
+fn record_thinking_metrics(turn_ctx: &mut TurnContext, thinking_blocks: u32) {
+    if thinking_blocks > 0 {
+        turn_ctx.metrics.thinking_block_count = turn_ctx
+            .metrics
+            .thinking_block_count
+            .saturating_add(thinking_blocks);
     }
 }
 
@@ -62,32 +64,26 @@ impl AgentLoopRunner {
 
         if result.stream_error {
             if !result.assistant_text.is_empty() {
-                self.record_assistant_message(
-                    &result.assistant_text,
-                    &[],
-                    &result.thinking_text,
-                    result.thinking_signature.as_deref(),
-                    result.server_blocks,
-                );
+                let thinking_blocks = result.thinking_block_count();
+                self.record_assistant_message(&result.assistant_text, &[], result.server_blocks);
                 c.last_text.clone_from(&result.assistant_text);
                 record_text_metrics(turn_ctx, &result.assistant_text);
-                record_thinking_metrics(turn_ctx, &result.thinking_text);
+                record_thinking_metrics(turn_ctx, thinking_blocks);
             }
             return Ok(TurnState::Complete);
         }
 
+        let thinking_blocks = result.thinking_block_count();
         self.record_assistant_message(
             &result.assistant_text,
             &result.tool_uses,
-            &result.thinking_text,
-            result.thinking_signature.as_deref(),
             result.server_blocks,
         );
         if !result.assistant_text.is_empty() {
             c.last_text.clone_from(&result.assistant_text);
             record_text_metrics(turn_ctx, &result.assistant_text);
         }
-        record_thinking_metrics(turn_ctx, &result.thinking_text);
+        record_thinking_metrics(turn_ctx, thinking_blocks);
 
         if result.tool_uses.is_empty() {
             return self
@@ -116,18 +112,13 @@ impl AgentLoopRunner {
         } else {
             &result.tool_uses
         };
-        self.record_assistant_message(
-            &result.assistant_text,
-            tools,
-            &result.thinking_text,
-            result.thinking_signature.as_deref(),
-            result.server_blocks,
-        );
+        let thinking_blocks = result.thinking_block_count();
+        self.record_assistant_message(&result.assistant_text, tools, result.server_blocks);
         if !result.assistant_text.is_empty() {
             c.last_text.clone_from(&result.assistant_text);
             record_text_metrics(turn_ctx, &result.assistant_text);
         }
-        record_thinking_metrics(turn_ctx, &result.thinking_text);
+        record_thinking_metrics(turn_ctx, thinking_blocks);
         if c.continuation_count >= c.max_continuations {
             return Ok(TurnState::Complete);
         }

--- a/crates/loopal-runtime/tests/agent_loop/cancel_finalize_e2e_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/cancel_finalize_e2e_test.rs
@@ -26,7 +26,6 @@ fn in_progress_turn_with_open_tool() -> Turn {
         TurnStep::LlmCall {
             model: "m".into(),
             response: AssistantOutput {
-                thinking: None,
                 text_blocks: vec![],
                 tool_calls: vec![call.clone()],
                 server_blocks: vec![],

--- a/crates/loopal-runtime/tests/agent_loop/mod.rs
+++ b/crates/loopal-runtime/tests/agent_loop/mod.rs
@@ -100,6 +100,7 @@ mod permission_test_ext;
 mod plan_mode_filter_test;
 mod plan_mode_test;
 mod preflight_test;
+mod record_message_edge_test;
 mod record_message_test;
 mod recovery_invariant_test;
 mod resume_invariant_test;

--- a/crates/loopal-runtime/tests/agent_loop/record_message_edge_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/record_message_edge_test.rs
@@ -1,0 +1,79 @@
+use loopal_provider_api::ContentBlock;
+
+use super::make_runner;
+
+fn count_server_use(content: &[ContentBlock]) -> usize {
+    content
+        .iter()
+        .filter(|b| matches!(b, ContentBlock::ServerToolUse { .. }))
+        .count()
+}
+
+// reason: 截断响应会留下没有 result 的 ServerToolUse。build_server_blocks 必须丢弃它
+// (不配对成 ToolPair、不 panic),否则 wire 里出现孤立 web_search_call → API 400。
+#[test]
+fn orphan_server_tool_use_without_result_is_dropped() {
+    let (mut runner, _rx) = make_runner();
+    let server_blocks = vec![
+        ContentBlock::Thinking {
+            thinking: "r1".into(),
+            signature: Some("rs_1".into()),
+        },
+        ContentBlock::ServerToolUse {
+            id: "ws_orphan".into(),
+            name: "web_search".into(),
+            input: serde_json::json!({"query": "x"}),
+        },
+    ];
+    runner.record_assistant_message("done", &[], server_blocks);
+
+    let msg = &runner.turns.view().messages()[0];
+    assert_eq!(
+        count_server_use(&msg.content),
+        0,
+        "orphan web_search_call (no result) must be dropped"
+    );
+    assert!(
+        msg.content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::Thinking { .. })),
+        "reasoning before the orphan must still survive"
+    );
+}
+
+// reason: 孤立 ServerToolResult(无配对 use)不得凭空产出块。
+#[test]
+fn orphan_server_tool_result_without_use_is_ignored() {
+    let (mut runner, _rx) = make_runner();
+    let server_blocks = vec![ContentBlock::ServerToolResult {
+        block_type: "web_search_tool_result".into(),
+        tool_use_id: "ws_ghost".into(),
+        content: serde_json::json!({"status": "completed"}),
+    }];
+    runner.record_assistant_message("hi", &[], server_blocks);
+
+    let msg = &runner.turns.view().messages()[0];
+    let has_server = msg.content.iter().any(|b| {
+        matches!(
+            b,
+            ContentBlock::ServerToolUse { .. } | ContentBlock::ServerToolResult { .. }
+        )
+    });
+    assert!(!has_server, "orphan result must not emit any server block");
+}
+
+// reason: 仅有 reasoning(无 text/tool)也必须被记录——has_server 分支,
+// 否则纯思考转 web_search 的 turn 会被空响应 guard 误丢。
+#[test]
+fn reasoning_only_response_is_recorded() {
+    let (mut runner, _rx) = make_runner();
+    let server_blocks = vec![ContentBlock::Thinking {
+        thinking: "only thinking".into(),
+        signature: Some("rs_solo".into()),
+    }];
+    runner.record_assistant_message("", &[], server_blocks);
+
+    assert_eq!(runner.turns.view().len(), 1, "reasoning-only must record");
+    let msg = &runner.turns.view().messages()[0];
+    assert!(matches!(msg.content[0], ContentBlock::Thinking { .. }));
+}

--- a/crates/loopal-runtime/tests/agent_loop/record_message_test.rs
+++ b/crates/loopal-runtime/tests/agent_loop/record_message_test.rs
@@ -7,7 +7,7 @@ fn test_record_assistant_message_text_only() {
     let (mut runner, _rx) = make_runner();
     assert!(runner.turns.view().is_empty());
 
-    runner.record_assistant_message("Hello, world!", &[], "", None, vec![]);
+    runner.record_assistant_message("Hello, world!", &[], vec![]);
 
     assert_eq!(runner.turns.view().len(), 1);
     let msg = &runner.turns.view().messages()[0];
@@ -36,7 +36,7 @@ fn test_record_assistant_message_with_tool_uses() {
         ),
     ];
 
-    runner.record_assistant_message("Let me check that.", &tool_uses, "", None, vec![]);
+    runner.record_assistant_message("Let me check that.", &tool_uses, vec![]);
 
     assert_eq!(runner.turns.view().len(), 1);
     let msg = &runner.turns.view().messages()[0];
@@ -66,7 +66,7 @@ fn test_record_assistant_message_with_tool_uses() {
 #[test]
 fn test_record_assistant_message_empty_adds_nothing() {
     let (mut runner, _rx) = make_runner();
-    runner.record_assistant_message("", &[], "", None, vec![]);
+    runner.record_assistant_message("", &[], vec![]);
 
     assert!(
         runner.turns.view().is_empty(),
@@ -84,7 +84,7 @@ fn test_record_assistant_message_tool_uses_only_no_text() {
         serde_json::json!({"command": "echo hi"}),
     )];
 
-    runner.record_assistant_message("", &tool_uses, "", None, vec![]);
+    runner.record_assistant_message("", &tool_uses, vec![]);
 
     assert_eq!(runner.turns.view().len(), 1);
     let msg = &runner.turns.view().messages()[0];
@@ -101,10 +101,86 @@ fn test_record_assistant_message_tool_uses_only_no_text() {
 #[tokio::test]
 async fn test_record_assistant_message_saves_to_session() {
     let (mut runner, _rx) = make_runner();
-    runner.record_assistant_message("test message", &[], "", None, vec![]);
+    runner.record_assistant_message("test message", &[], vec![]);
     assert_eq!(runner.turns.view().len(), 1);
     assert_eq!(
         runner.turns.view().messages()[0].text_content(),
         "test message"
+    );
+}
+
+// reason: 回归 #190 — 多个 reasoning + web_search 交错必须保序投影，每个
+// web_search_call 前都有其 reasoning item，否则 OpenAI Responses API 400。
+#[test]
+fn record_interleaved_reasoning_and_web_search_preserves_pairing() {
+    let (mut runner, _rx) = make_runner();
+    let server_blocks = vec![
+        ContentBlock::Thinking {
+            thinking: "r1".into(),
+            signature: Some("rs_1".into()),
+        },
+        ContentBlock::ServerToolUse {
+            id: "ws_1".into(),
+            name: "web_search".into(),
+            input: serde_json::json!({"query": "a"}),
+        },
+        ContentBlock::ServerToolResult {
+            block_type: "web_search_tool_result".into(),
+            tool_use_id: "ws_1".into(),
+            content: serde_json::json!({"status": "completed"}),
+        },
+        ContentBlock::Thinking {
+            thinking: "r2".into(),
+            signature: Some("rs_2".into()),
+        },
+        ContentBlock::ServerToolUse {
+            id: "ws_2".into(),
+            name: "web_search".into(),
+            input: serde_json::json!({"query": "b"}),
+        },
+        ContentBlock::ServerToolResult {
+            block_type: "web_search_tool_result".into(),
+            tool_use_id: "ws_2".into(),
+            content: serde_json::json!({"status": "completed"}),
+        },
+    ];
+    runner.record_assistant_message("done", &[], server_blocks);
+
+    let msg = &runner.turns.view().messages()[0];
+    let kinds: Vec<&str> = msg
+        .content
+        .iter()
+        .map(|b| match b {
+            ContentBlock::Thinking { signature, .. } => match signature.as_deref() {
+                Some("rs_1") => "think:rs_1",
+                Some("rs_2") => "think:rs_2",
+                _ => "think:?",
+            },
+            ContentBlock::ServerToolUse { id, .. } => match id.as_str() {
+                "ws_1" => "use:ws_1",
+                "ws_2" => "use:ws_2",
+                _ => "use:?",
+            },
+            ContentBlock::ServerToolResult { tool_use_id, .. } => match tool_use_id.as_str() {
+                "ws_1" => "res:ws_1",
+                "ws_2" => "res:ws_2",
+                _ => "res:?",
+            },
+            ContentBlock::Text { .. } => "text",
+            _ => "other",
+        })
+        .collect();
+    assert_eq!(
+        kinds,
+        vec![
+            "think:rs_1",
+            "use:ws_1",
+            "res:ws_1",
+            "think:rs_2",
+            "use:ws_2",
+            "res:ws_2",
+            "text",
+        ],
+        "each web_search_call must be preceded by its reasoning, in stream order"
     );
 }

--- a/crates/loopal-runtime/tests/agent_loop/try_recover_helpers.rs
+++ b/crates/loopal-runtime/tests/agent_loop/try_recover_helpers.rs
@@ -201,7 +201,6 @@ pub fn seed_prior_completed_turn(runner: &mut AgentLoopRunner) {
         .append_step_record(loopal_turn::TurnStep::LlmCall {
             model: "test-model".into(),
             response: loopal_turn::AssistantOutput {
-                thinking: None,
                 text_blocks: vec![loopal_turn::TextBlock {
                     text: "seed-reply".into(),
                 }],
@@ -225,7 +224,6 @@ pub fn seed_prior_completed_turn(runner: &mut AgentLoopRunner) {
         .append_step_record(loopal_turn::TurnStep::LlmCall {
             model: "test-model".into(),
             response: loopal_turn::AssistantOutput {
-                thinking: None,
                 text_blocks: vec![loopal_turn::TextBlock {
                     text: "seed-reply-2".into(),
                 }],

--- a/crates/loopal-runtime/tests/suite/read_image_e2e_test.rs
+++ b/crates/loopal-runtime/tests/suite/read_image_e2e_test.rs
@@ -73,7 +73,6 @@ fn turn_with_tool_images(tool_use_id: &str, images: Vec<ToolImageBlock>) -> Turn
             TurnStep::LlmCall {
                 model: "claude-test".into(),
                 response: AssistantOutput {
-                    thinking: None,
                     text_blocks: vec![],
                     tool_calls: vec![ToolCall {
                         id: ToolCallId::new(tool_use_id),

--- a/crates/loopal-storage/tests/suite/fold_events_test.rs
+++ b/crates/loopal-storage/tests/suite/fold_events_test.rs
@@ -9,7 +9,6 @@ fn empty_llm_step() -> TurnStep {
     TurnStep::LlmCall {
         model: "m".into(),
         response: AssistantOutput {
-            thinking: None,
             text_blocks: Vec::new(),
             tool_calls: Vec::new(),
             server_blocks: Vec::new(),

--- a/crates/loopal-storage/tests/suite/turn_event_store_test.rs
+++ b/crates/loopal-storage/tests/suite/turn_event_store_test.rs
@@ -23,7 +23,6 @@ fn empty_llm_step() -> TurnStep {
     TurnStep::LlmCall {
         model: "m".into(),
         response: AssistantOutput {
-            thinking: None,
             text_blocks: vec![],
             tool_calls: vec![],
             server_blocks: vec![],

--- a/crates/loopal-storage/tests/suite/turn_synthesize_test.rs
+++ b/crates/loopal-storage/tests/suite/turn_synthesize_test.rs
@@ -9,7 +9,6 @@ fn turn_with_llm_call_and_tools(tool_ids: &[&str]) -> Turn {
     turn.body.steps.push(TurnStep::LlmCall {
         model: "test".into(),
         response: AssistantOutput {
-            thinking: None,
             text_blocks: vec![],
             tool_calls: tool_ids
                 .iter()
@@ -30,7 +29,6 @@ fn llm_call_with_tool(id: &str) -> TurnStep {
     TurnStep::LlmCall {
         model: "test".into(),
         response: AssistantOutput {
-            thinking: None,
             text_blocks: Vec::new(),
             tool_calls: vec![ToolCall {
                 id: ToolCallId::new(id),

--- a/crates/loopal-test-support/src/seed_history.rs
+++ b/crates/loopal-test-support/src/seed_history.rs
@@ -31,7 +31,6 @@ pub fn reverse_project_messages_to_turns(messages: Vec<Message>) -> Vec<Turn> {
                 let step = TurnStep::LlmCall {
                     model: "test".into(),
                     response: AssistantOutput {
-                        thinking: None,
                         text_blocks: if text.is_empty() {
                             vec![]
                         } else {

--- a/crates/loopal-test-support/src/tool_history.rs
+++ b/crates/loopal-test-support/src/tool_history.rs
@@ -51,7 +51,6 @@ pub fn tool_history_turn(trigger_content: &str, steps: Vec<ToolStep>) -> Turn {
     turn.body.steps.push(TurnStep::LlmCall {
         model: "test".into(),
         response: AssistantOutput {
-            thinking: None,
             text_blocks: vec![],
             tool_calls: tool_calls.clone(),
             server_blocks: vec![],

--- a/crates/loopal-turn/src/content.rs
+++ b/crates/loopal-turn/src/content.rs
@@ -1,4 +1,6 @@
 use loopal_tool_invocation::ToolImageBlock;
+use serde::de::{self, Deserializer};
+use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -63,4 +65,43 @@ pub struct ServerToolResult {
 pub struct ServerToolPair {
     pub call: ServerToolCall,
     pub result: ServerToolResult,
+}
+
+// reason: OpenAI Responses 要求每个 web_search_call 紧贴其 reasoning item；
+// Anthropic 要求 thinking 块复现。reasoning 与 server tool 必须在同一序列里
+// 保留 LLM 的流式发射顺序，单一 Option 装不下多个交错的 reasoning。
+#[derive(Debug, Clone)]
+pub enum ServerBlock {
+    Reasoning(ThinkingBlock),
+    ToolPair(ServerToolPair),
+}
+
+impl Serialize for ServerBlock {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            ServerBlock::Reasoning(t) => t.serialize(serializer),
+            ServerBlock::ToolPair(p) => p.serialize(serializer),
+        }
+    }
+}
+
+// reason: 自定义 Deser 按 key 探测而非 #[serde(untagged)]，兼容旧 turns.jsonl
+// 里 `{call,result}` 形状(直接读回 ToolPair)且错误信息可读。
+impl<'de> Deserialize<'de> for ServerBlock {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        if value.get("call").is_some() {
+            serde_json::from_value(value)
+                .map(ServerBlock::ToolPair)
+                .map_err(de::Error::custom)
+        } else if value.get("thinking").is_some() {
+            serde_json::from_value(value)
+                .map(ServerBlock::Reasoning)
+                .map_err(de::Error::custom)
+        } else {
+            Err(de::Error::custom(
+                "ServerBlock: expected `call` (ToolPair) or `thinking` (Reasoning) key",
+            ))
+        }
+    }
 }

--- a/crates/loopal-turn/src/lib.rs
+++ b/crates/loopal-turn/src/lib.rs
@@ -5,8 +5,8 @@ mod step;
 mod turn;
 
 pub use content::{
-    ServerToolCall, ServerToolPair, ServerToolResult, TextBlock, ThinkingBlock, ToolCall,
-    ToolCallId, ToolResult,
+    ServerBlock, ServerToolCall, ServerToolPair, ServerToolResult, TextBlock, ThinkingBlock,
+    ToolCall, ToolCallId, ToolResult,
 };
 pub use event::TurnEvent;
 pub use repo::{InMemoryTurnRepo, TurnRepo, TurnRepoError, TurnRepoResult};

--- a/crates/loopal-turn/src/step.rs
+++ b/crates/loopal-turn/src/step.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::content::{ServerToolPair, TextBlock, ThinkingBlock, ToolCall, ToolCallId, ToolResult};
+use crate::content::{ServerBlock, TextBlock, ToolCall, ToolCallId, ToolResult};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TurnStep {
@@ -27,16 +27,16 @@ pub enum TurnStep {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssistantOutput {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub thinking: Option<ThinkingBlock>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub text_blocks: Vec<TextBlock>,
     // reason: Vec 顺序 = LLM stream emission 顺序; ToolBatchItem 通过 id 匹配回此处的
     // tool_calls. I4 invariant (parallel ordering) 在此处的 Vec ordering 上锁定。
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tool_calls: Vec<ToolCall>,
+    // reason: reasoning(Reasoning) 与 server tool(ToolPair) 按 LLM 流顺序混排，
+    // 投影时 reasoning 必须先于其 web_search_call / 作为 Anthropic content 首块。
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub server_blocks: Vec<ServerToolPair>,
+    pub server_blocks: Vec<ServerBlock>,
     pub stop_reason: StopReason,
 }
 

--- a/crates/loopal-turn/tests/suite.rs
+++ b/crates/loopal-turn/tests/suite.rs
@@ -2,6 +2,8 @@
 mod event_test;
 #[path = "suite/repo_test.rs"]
 mod repo_test;
+#[path = "suite/server_block_serde_test.rs"]
+mod server_block_serde_test;
 #[path = "suite/turn_basic_test.rs"]
 mod turn_basic_test;
 #[path = "suite/turn_trigger_test.rs"]

--- a/crates/loopal-turn/tests/suite/event_test.rs
+++ b/crates/loopal-turn/tests/suite/event_test.rs
@@ -89,7 +89,6 @@ fn step_appended_carries_tool_batch() {
 fn assistant_output_with_thinking_serialization() {
     // 单 LLM call 即使 stop_reason=EndTurn 也合法（empty response 不算 protocol violation）
     let output = AssistantOutput {
-        thinking: None,
         text_blocks: vec![],
         tool_calls: vec![],
         server_blocks: vec![],

--- a/crates/loopal-turn/tests/suite/repo_test.rs
+++ b/crates/loopal-turn/tests/suite/repo_test.rs
@@ -37,7 +37,6 @@ fn append_step_emits_event_and_grows_body() {
             TurnStep::LlmCall {
                 model: snapshot(),
                 response: AssistantOutput {
-                    thinking: None,
                     text_blocks: vec![],
                     tool_calls: vec![],
                     server_blocks: vec![],
@@ -103,7 +102,6 @@ fn cannot_append_after_end() {
             TurnStep::LlmCall {
                 model: snapshot(),
                 response: AssistantOutput {
-                    thinking: None,
                     text_blocks: vec![],
                     tool_calls: vec![],
                     server_blocks: vec![],
@@ -124,7 +122,6 @@ fn update_state_rejects_non_tool_batch_step() {
         TurnStep::LlmCall {
             model: snapshot(),
             response: AssistantOutput {
-                thinking: None,
                 text_blocks: vec![],
                 tool_calls: vec![],
                 server_blocks: vec![],

--- a/crates/loopal-turn/tests/suite/server_block_serde_test.rs
+++ b/crates/loopal-turn/tests/suite/server_block_serde_test.rs
@@ -1,0 +1,139 @@
+use loopal_turn::{
+    AssistantOutput, ServerBlock, ServerToolCall, ServerToolPair, ServerToolResult, StopReason,
+    ThinkingBlock,
+};
+
+fn tool_pair() -> ServerToolPair {
+    ServerToolPair {
+        call: ServerToolCall {
+            id: "ws_1".into(),
+            name: "web_search".into(),
+            input: serde_json::json!({"query": "x"}),
+        },
+        result: ServerToolResult {
+            block_type: "web_search_tool_result".into(),
+            content: serde_json::json!({"status": "completed"}),
+        },
+    }
+}
+
+#[test]
+fn reasoning_block_round_trips() {
+    let block = ServerBlock::Reasoning(ThinkingBlock {
+        thinking: "deep".into(),
+        signature: Some("rs_1".into()),
+    });
+    let json = serde_json::to_string(&block).unwrap();
+    let back: ServerBlock = serde_json::from_str(&json).unwrap();
+    match back {
+        ServerBlock::Reasoning(t) => {
+            assert_eq!(t.thinking, "deep");
+            assert_eq!(t.signature.as_deref(), Some("rs_1"));
+        }
+        ServerBlock::ToolPair(_) => panic!("expected Reasoning"),
+    }
+}
+
+#[test]
+fn tool_pair_block_round_trips() {
+    let block = ServerBlock::ToolPair(tool_pair());
+    let json = serde_json::to_string(&block).unwrap();
+    let back: ServerBlock = serde_json::from_str(&json).unwrap();
+    match back {
+        ServerBlock::ToolPair(p) => {
+            assert_eq!(p.call.id, "ws_1");
+            assert_eq!(p.result.block_type, "web_search_tool_result");
+        }
+        ServerBlock::Reasoning(_) => panic!("expected ToolPair"),
+    }
+}
+
+// reason: 旧 turns.jsonl 的 AssistantOutput 携带顶层 `thinking` 字段且 server_blocks
+// 是裸 `{call,result}`。新模型删了 thinking、server_blocks 变 Vec<ServerBlock>。
+// 自定义 Deser 必须把旧 `{call,result}` 读成 ToolPair，并静默忽略残留 `thinking` key。
+#[test]
+fn deserializes_legacy_assistant_output_with_stray_thinking_key() {
+    let legacy = r#"{
+        "thinking": {"thinking": "old reasoning", "signature": "rs_old"},
+        "text_blocks": [{"text": "hi"}],
+        "tool_calls": [],
+        "server_blocks": [
+            {"call": {"id": "ws_1", "name": "web_search", "input": {}},
+             "result": {"block_type": "web_search_tool_result", "content": {}}}
+        ],
+        "stop_reason": "EndTurn"
+    }"#;
+    let out: AssistantOutput = serde_json::from_str(legacy).unwrap();
+    assert_eq!(out.text_blocks.len(), 1);
+    assert_eq!(out.server_blocks.len(), 1);
+    match &out.server_blocks[0] {
+        ServerBlock::ToolPair(p) => assert_eq!(p.call.id, "ws_1"),
+        ServerBlock::Reasoning(_) => panic!("legacy {{call,result}} must read as ToolPair"),
+    }
+}
+
+#[test]
+fn rejects_block_without_discriminating_key() {
+    let bad = r#"{"unknown": 1}"#;
+    let err = serde_json::from_str::<ServerBlock>(bad).unwrap_err();
+    assert!(
+        err.to_string().contains("ToolPair") || err.to_string().contains("Reasoning"),
+        "error should name the expected variants: {err}"
+    );
+}
+
+// reason: `call` 键存在但结构损坏(缺 result)→ from_value 失败,必须走 map_err
+// 错误臂返回 Err 而非 panic 或误判。
+#[test]
+fn malformed_tool_pair_with_call_key_errors() {
+    let bad = r#"{"call": {"id": "x", "name": "web_search", "input": {}}}"#;
+    assert!(
+        serde_json::from_str::<ServerBlock>(bad).is_err(),
+        "call-keyed object missing `result` must error, not silently drop"
+    );
+}
+
+// reason: `thinking` 键存在但类型错误(非字符串)→ Reasoning 错误臂返回 Err。
+#[test]
+fn malformed_reasoning_with_thinking_key_errors() {
+    let bad = r#"{"thinking": 123}"#;
+    assert!(
+        serde_json::from_str::<ServerBlock>(bad).is_err(),
+        "thinking-keyed object with non-string thinking must error"
+    );
+}
+
+// reason: 对抗——同时含 `call` 与 `thinking` 键时,precedence 必须确定(call 先判),
+// 否则旧 ToolPair 数据可能被误读成 Reasoning。
+#[test]
+fn both_keys_present_resolves_to_tool_pair() {
+    let ambiguous = r#"{
+        "call": {"id": "ws_x", "name": "web_search", "input": {}},
+        "result": {"block_type": "web_search_tool_result", "content": {}},
+        "thinking": "should be ignored"
+    }"#;
+    match serde_json::from_str::<ServerBlock>(ambiguous).unwrap() {
+        ServerBlock::ToolPair(p) => assert_eq!(p.call.id, "ws_x"),
+        ServerBlock::Reasoning(_) => panic!("`call` key must win over `thinking`"),
+    }
+}
+
+#[test]
+fn mixed_server_blocks_preserve_order() {
+    let out = AssistantOutput {
+        text_blocks: vec![],
+        tool_calls: vec![],
+        server_blocks: vec![
+            ServerBlock::Reasoning(ThinkingBlock {
+                thinking: "r1".into(),
+                signature: Some("rs_1".into()),
+            }),
+            ServerBlock::ToolPair(tool_pair()),
+        ],
+        stop_reason: StopReason::EndTurn,
+    };
+    let json = serde_json::to_string(&out).unwrap();
+    let back: AssistantOutput = serde_json::from_str(&json).unwrap();
+    assert!(matches!(back.server_blocks[0], ServerBlock::Reasoning(_)));
+    assert!(matches!(back.server_blocks[1], ServerBlock::ToolPair(_)));
+}

--- a/crates/loopal-turn/tests/suite/turn_basic_test.rs
+++ b/crates/loopal-turn/tests/suite/turn_basic_test.rs
@@ -45,7 +45,6 @@ fn ordered_tool_batch_preserves_call_order() {
     t.body.steps.push(TurnStep::LlmCall {
         model: snapshot(),
         response: AssistantOutput {
-            thinking: None,
             text_blocks: vec![],
             tool_calls: calls.clone(),
             server_blocks: vec![],
@@ -87,7 +86,6 @@ fn turn_with_steps_round_trip() {
     t.body.steps.push(TurnStep::LlmCall {
         model: snapshot(),
         response: AssistantOutput {
-            thinking: None,
             text_blocks: vec![],
             tool_calls: vec![],
             server_blocks: vec![],


### PR DESCRIPTION
## Summary
- Fixes OpenAI Responses 400 `web_search_call ... without its required reasoning item` and the symmetric silent drop of Anthropic thinking blocks.
- Root cause: Turn-as-Unit `AssistantOutput` modeled thinking as a single `Option` and `pair_server_blocks` dropped all `Thinking` blocks, so reasoning never reached the wire. Regression from #161 undone by #183's projection refactor, untested on the record→project path.
- Replaces the model with an ordered `Vec<ServerBlock>` (`Reasoning | ToolPair`) that preserves the LLM's stream order, so every `web_search_call` replays with its reasoning anchor.

## Changes
- **loopal-turn**: new `ServerBlock` enum + custom `Deserialize` (reads legacy `{call,result}` for backward compat); `AssistantOutput` drops `thinking`, `server_blocks: Vec<ServerBlock>`.
- **loopal-runtime**: single-pass `build_server_blocks` preserves reasoning↔web_search order; fixes `thinking_block_count` metric (was reading a `mem::take`-emptied buffer).
- **loopal-provider / -api**: OpenAI + Anthropic projection emit reasoning before each `web_search_call`, unified `server_blocks → text → tool_calls` order; Anthropic skips unsigned reasoning (defends against a new 400).
- **loopal-context**: `turn_degradation` / `ingestion` adapt to `ServerBlock`; condense marker + per-response fold deduped into one shared helper.
- **tests**: serde migration, adversarial (orphan use/result, malformed, empty-signature, key-precedence), wire-level e2e reproducing the original 400. Measured 99.4% changed-line coverage.

## Test plan
- [ ] CI passes (build, clippy zero-warnings, rustfmt, full `bazel test //...`)
- [x] Local: `bazel test //...` 94/94 targets pass; clippy + rustfmt clean