### PR TITLE
feat(acp): AgentsMesh _loopal/* control-panel extension

### DIFF
--- a/crates/loopal-acp/BUILD.bazel
+++ b/crates/loopal-acp/BUILD.bazel
@@ -29,6 +29,7 @@ rust_test(
 rust_test(
     name = "loopal-acp_test",
     srcs = glob(["tests/**/*.rs"]),
+    compile_data = glob(["tests/fixtures/*.json"]),
     crate_root = "tests/suite.rs",
     edition = "2024",
     local = True,

--- a/crates/loopal-acp/src/adapter/control.rs
+++ b/crates/loopal-acp/src/adapter/control.rs
@@ -4,6 +4,7 @@ use loopal_protocol::ControlCommand;
 use serde_json::Value;
 
 use crate::adapter::AcpAdapter;
+use crate::adapter::control_command::parse_loopal_control;
 use crate::jsonrpc;
 
 impl AcpAdapter {
@@ -74,6 +75,33 @@ impl AcpAdapter {
                 self.acp_out
                     .respond_error(id, jsonrpc::INTERNAL_ERROR, &e.to_string())
                     .await;
+            }
+        }
+    }
+
+    /// Handle `session/control_request` — AgentsMesh ACP extension carrying
+    /// Loopal control-panel actions (bgTaskKill / cronDelete / compact / clear)
+    /// and the runner's `set_model`. Unknown subtypes are rejected so the
+    /// runner degrades gracefully.
+    pub(crate) async fn handle_control_request(&self, id: i64, params: Value) {
+        let subtype = params["subtype"].as_str().unwrap_or("");
+        match parse_loopal_control(subtype, &params["params"]) {
+            Some(c) => match self.client.send_control(&c).await {
+                Ok(_) => self.acp_out.respond(id, serde_json::json!({})).await,
+                Err(e) => {
+                    self.acp_out
+                        .respond_error(id, jsonrpc::INTERNAL_ERROR, &e.to_string())
+                        .await
+                }
+            },
+            None => {
+                self.acp_out
+                    .respond_error(
+                        id,
+                        jsonrpc::METHOD_NOT_FOUND,
+                        &format!("unsupported control subtype: {subtype}"),
+                    )
+                    .await
             }
         }
     }

--- a/crates/loopal-acp/src/adapter/control_command.rs
+++ b/crates/loopal-acp/src/adapter/control_command.rs
@@ -1,0 +1,109 @@
+//! Pure `subtype` → `ControlCommand` mapping for `session/control_request`.
+//! Kept separate from the IO-bound handler so the full dispatch table is
+//! unit-testable and `handle_control_request` stays thin. Every Loopal
+//! ControlCommand the runtime implements (`input_control.rs`) is reachable here.
+
+use loopal_protocol::{AgentMode, ControlCommand};
+use serde_json::Value;
+
+pub(crate) fn parse_loopal_control(subtype: &str, p: &Value) -> Option<ControlCommand> {
+    use ControlCommand as C;
+    match subtype {
+        "loopal.bgTaskKill" => p["id"]
+            .as_str()
+            .map(|s| C::BgTaskKill { id: s.to_string() }),
+        "loopal.cronDelete" => p["id"]
+            .as_str()
+            .map(|s| C::CronDelete { id: s.to_string() }),
+        "loopal.compact" => Some(C::Compact {
+            instructions: p["instructions"].as_str().map(String::from),
+        }),
+        "loopal.clear" => Some(C::Clear),
+        "loopal.suspend" => Some(C::Suspend),
+        "loopal.unsuspend" => Some(C::Unsuspend),
+        "loopal.mode" => match p["mode"].as_str()? {
+            "plan" => Some(C::ModeSwitch(AgentMode::Plan)),
+            "act" => Some(C::ModeSwitch(AgentMode::Act)),
+            _ => None,
+        },
+        "loopal.mcpStatus" => Some(C::QueryMcpStatus),
+        "loopal.mcpReconnect" => p["server"].as_str().map(|s| C::McpReconnect {
+            server: s.to_string(),
+        }),
+        "loopal.mcpDisconnect" => p["server"].as_str().map(|s| C::McpDisconnect {
+            server: s.to_string(),
+        }),
+        "loopal.rewind" => p["turn_index"].as_u64().map(|n| C::Rewind {
+            turn_index: n as usize,
+        }),
+        "loopal.resumeSession" => p["session_id"]
+            .as_str()
+            .map(|s| C::ResumeSession(s.to_string())),
+        "loopal.thinking" => p["config"]
+            .as_str()
+            .map(|s| C::ThinkingSwitch(s.to_string())),
+        "loopal.goalCreate" => p["objective"].as_str().map(|s| C::GoalCreate {
+            objective: s.to_string(),
+        }),
+        "loopal.goalPause" => Some(C::GoalUserPause),
+        "loopal.goalResume" => Some(C::GoalUserResume),
+        "loopal.goalComplete" => Some(C::GoalUserComplete),
+        "loopal.goalReopen" => Some(C::GoalUserReopen),
+        "loopal.goalClear" => Some(C::GoalClear),
+        "set_model" => p["model"].as_str().map(|s| C::ModelSwitch(s.to_string())),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn maps_object_and_session_controls() {
+        assert!(matches!(
+            parse_loopal_control("loopal.bgTaskKill", &json!({"id":"bg1"})),
+            Some(ControlCommand::BgTaskKill { id }) if id == "bg1"
+        ));
+        assert!(matches!(
+            parse_loopal_control("loopal.compact", &json!({})),
+            Some(ControlCommand::Compact { instructions: None })
+        ));
+        assert!(matches!(
+            parse_loopal_control("loopal.clear", &json!({})),
+            Some(ControlCommand::Clear)
+        ));
+        assert!(matches!(
+            parse_loopal_control("loopal.mode", &json!({"mode":"plan"})),
+            Some(ControlCommand::ModeSwitch(AgentMode::Plan))
+        ));
+    }
+
+    #[test]
+    fn maps_mcp_suspend_goal() {
+        assert!(matches!(
+            parse_loopal_control("loopal.mcpReconnect", &json!({"server":"fs"})),
+            Some(ControlCommand::McpReconnect { server }) if server == "fs"
+        ));
+        assert!(matches!(
+            parse_loopal_control("loopal.suspend", &json!({})),
+            Some(ControlCommand::Suspend)
+        ));
+        assert!(matches!(
+            parse_loopal_control("loopal.goalCreate", &json!({"objective":"ship"})),
+            Some(ControlCommand::GoalCreate { objective }) if objective == "ship"
+        ));
+        assert!(matches!(
+            parse_loopal_control("loopal.goalClear", &json!({})),
+            Some(ControlCommand::GoalClear)
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_and_missing_fields() {
+        assert!(parse_loopal_control("loopal.bogus", &json!({})).is_none());
+        assert!(parse_loopal_control("loopal.bgTaskKill", &json!({})).is_none());
+        assert!(parse_loopal_control("loopal.mode", &json!({"mode":"bogus"})).is_none());
+    }
+}

--- a/crates/loopal-acp/src/adapter/events.rs
+++ b/crates/loopal-acp/src/adapter/events.rs
@@ -75,6 +75,19 @@ impl AcpAdapter {
                 }
             }
         }
+        // Mode dual-emit: translate_event already sent the standard ACP
+        // CurrentModeUpdate (for generic clients). Additionally surface
+        // `_loopal/mode` so the Loopal console status bar reads mode from the
+        // same loopalSession mirror as thinking/model — AgentsMesh does not
+        // consume the ACP session-mode channel.
+        if let AgentEventPayload::ModeChanged { mode } = &event.payload {
+            let (method, params) = crate::translate::ext::ext_notification(
+                session_id,
+                "mode",
+                serde_json::json!({ "mode": mode }),
+            );
+            self.acp_out.notify(&method, params).await;
+        }
         None
     }
 

--- a/crates/loopal-acp/src/adapter/lifecycle.rs
+++ b/crates/loopal-acp/src/adapter/lifecycle.rs
@@ -7,12 +7,19 @@ use crate::adapter::AcpAdapter;
 use crate::types::make_init_response;
 
 impl AcpAdapter {
-    /// Handle `initialize` — return agent capabilities and info.
+    /// Handle `initialize` — return agent capabilities and info. Advertises
+    /// the AgentsMesh `controlRequest` extension so the runner routes Loopal
+    /// control-panel actions (bg-task kill / cron delete) via
+    /// `session/control_request`.
     pub(crate) async fn handle_initialize(&self, id: i64, _params: Value) {
-        let result = make_init_response();
-        self.acp_out
-            .respond(id, serde_json::to_value(result).unwrap_or_default())
-            .await;
+        let mut result = serde_json::to_value(make_init_response()).unwrap_or_default();
+        if let Some(obj) = result.as_object_mut() {
+            obj.insert(
+                "agentsmeshExtensions".into(),
+                serde_json::json!({ "controlRequest": true }),
+            );
+        }
+        self.acp_out.respond(id, result).await;
         info!("ACP initialized");
     }
 

--- a/crates/loopal-acp/src/adapter/mod.rs
+++ b/crates/loopal-acp/src/adapter/mod.rs
@@ -1,11 +1,13 @@
 //! ACP adapter — bridges ACP (session/*) with Hub via UiSession.
 
 mod control;
+mod control_command;
 mod events;
 mod lifecycle;
 mod permission;
 mod prompt;
 mod session;
+mod snapshot;
 
 use std::sync::Arc;
 
@@ -74,6 +76,7 @@ impl AcpAdapter {
             "session/close" => self.handle_close(id, params).await,
             "session/set_mode" => self.handle_set_mode(id, params).await,
             "session/set_config_option" => self.handle_set_config_option(id, params).await,
+            "session/control_request" => self.handle_control_request(id, params).await,
             "session/load" => {
                 self.acp_out
                     .respond_error(

--- a/crates/loopal-acp/src/adapter/session.rs
+++ b/crates/loopal-acp/src/adapter/session.rs
@@ -8,18 +8,21 @@ use crate::jsonrpc;
 use crate::types::make_new_session_response;
 
 impl AcpAdapter {
-    /// Handle `session/new` — assign session ID, drain bootstrap events.
+    /// Handle `session/new` — assign session ID, drain bootstrap events, then
+    /// replay the agent's current view/snapshot as `_loopal/*` events so the
+    /// control panel cold-starts with pre-existing cron / task / bg-shell state.
     pub(crate) async fn handle_new_session(&self, id: i64, _params: Value) {
         let sid = uuid::Uuid::new_v4().to_string();
         *self.session_id.lock().await = Some(sid.clone());
         self.acp_out
             .respond(
                 id,
-                serde_json::to_value(make_new_session_response(sid)).unwrap_or_default(),
+                serde_json::to_value(make_new_session_response(sid.clone())).unwrap_or_default(),
             )
             .await;
         info!("ACP session created");
         self.drain_bootstrap_events().await;
+        self.replay_loopal_snapshot(&sid).await;
     }
 
     /// Handle `session/list` → HubClient.list_agents().

--- a/crates/loopal-acp/src/adapter/snapshot.rs
+++ b/crates/loopal-acp/src/adapter/snapshot.rs
@@ -1,0 +1,154 @@
+//! Cold-start replay: on `session/new`, fetch the agent's `view/snapshot` and
+//! replay it as `_loopal/*` incremental events so the control panel rebuilds
+//! prior state (resumed sessions, pre-existing cron / bg-tasks). Reusing the
+//! incremental path means no snapshot message type is needed downstream — the
+//! runner accumulator and core reducer absorb it through their normal handlers.
+
+use serde_json::{Value, json};
+
+use loopal_ipc::protocol::methods::VIEW_SNAPSHOT;
+
+use super::AcpAdapter;
+use crate::translate::ext::ext_notification;
+
+impl AcpAdapter {
+    pub(crate) async fn replay_loopal_snapshot(&self, session_id: &str) {
+        let Some(agent) = self.first_agent_name().await else {
+            return;
+        };
+        let Some(state) = self.fetch_view_state(&agent).await else {
+            return;
+        };
+        for (method, params) in build_replay_events(session_id, &state) {
+            self.acp_out.notify(&method, params).await;
+        }
+    }
+
+    async fn first_agent_name(&self) -> Option<String> {
+        let resp = self.client.list_agents().await.ok()?;
+        resp.get("agents")?
+            .as_array()?
+            .first()?
+            .get("name")?
+            .as_str()
+            .map(String::from)
+    }
+
+    async fn fetch_view_state(&self, agent: &str) -> Option<Value> {
+        let resp = self
+            .client
+            .connection()
+            .send_request(VIEW_SNAPSHOT.name, json!({ "agent": agent }))
+            .await
+            .ok()?;
+        resp.get("state").cloned()
+    }
+}
+
+/// Serialize a `view/snapshot` `state` into the `_loopal/*` event sequence that
+/// rebuilds the control panel. Pure (no IO) so the fold rules are unit-testable;
+/// `replay_loopal_snapshot` only adds the fetch + notify around it.
+fn build_replay_events(session_id: &str, state: &Value) -> Vec<(String, Value)> {
+    let mut events = Vec::new();
+    if let Some(map) = state["bg_tasks"].as_object() {
+        for bg in map.values() {
+            events.push(ext_notification(
+                session_id,
+                "bgTask.spawned",
+                json!({
+                    "id": bg["id"],
+                    "description": bg["description"],
+                    "created_at_unix_ms": bg["created_at_unix_ms"],
+                }),
+            ));
+            if bg["output"].as_str().is_some_and(|s| !s.is_empty()) {
+                events.push(ext_notification(
+                    session_id,
+                    "bgTask.output",
+                    json!({ "id": bg["id"], "output_delta": bg["output"] }),
+                ));
+            }
+            if bg["status"].as_str().is_some_and(|s| s != "Running") {
+                events.push(ext_notification(
+                    session_id,
+                    "bgTask.completed",
+                    json!({
+                        "id": bg["id"],
+                        "status": bg["status"],
+                        "exit_code": bg["exit_code"],
+                        "output": bg["output"],
+                    }),
+                ));
+            }
+        }
+    }
+    events.push(ext_notification(
+        session_id,
+        "crons",
+        json!({ "crons": state["crons"] }),
+    ));
+    events.push(ext_notification(
+        session_id,
+        "tasks",
+        json!({ "tasks": state["tasks"] }),
+    ));
+    if !state["mcp_status"].is_null() {
+        events.push(ext_notification(
+            session_id,
+            "mcp",
+            json!({ "servers": state["mcp_status"] }),
+        ));
+    }
+    events
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_replay_events;
+    use serde_json::json;
+
+    fn methods(events: &[(String, serde_json::Value)]) -> Vec<&str> {
+        events.iter().map(|(m, _)| m.as_str()).collect()
+    }
+
+    #[test]
+    fn replays_bg_crons_tasks_mcp() {
+        let state = json!({
+            "bg_tasks": {
+                "bg1": {"id":"bg1","description":"npm","status":"Completed","exit_code":0,"output":"done","created_at_unix_ms":1}
+            },
+            "crons": [{"id":"c1"}],
+            "tasks": [{"id":"t1"}],
+            "mcp_status": [{"name":"fs"}]
+        });
+        let ev = build_replay_events("s", &state);
+        let m = methods(&ev);
+        assert!(m.contains(&"_loopal/bgTask.spawned"));
+        assert!(m.contains(&"_loopal/bgTask.completed")); // status != Running
+        assert!(m.contains(&"_loopal/crons"));
+        assert!(m.contains(&"_loopal/tasks"));
+        assert!(m.contains(&"_loopal/mcp"));
+    }
+
+    #[test]
+    fn running_bg_task_has_no_completed_event() {
+        let state = json!({
+            "bg_tasks": {"bg1": {"id":"bg1","description":"x","status":"Running","output":"","created_at_unix_ms":1}},
+            "crons": [], "tasks": []
+        });
+        let ev = build_replay_events("s", &state);
+        let m = methods(&ev);
+        assert!(m.contains(&"_loopal/bgTask.spawned"));
+        assert!(!m.contains(&"_loopal/bgTask.completed"));
+        assert!(!m.contains(&"_loopal/bgTask.output")); // empty output
+    }
+
+    #[test]
+    fn omits_mcp_when_absent() {
+        let state = json!({"bg_tasks": {}, "crons": [], "tasks": []});
+        let ev = build_replay_events("s", &state);
+        let m = methods(&ev);
+        assert!(!m.contains(&"_loopal/mcp"));
+        assert!(m.contains(&"_loopal/crons"));
+    }
+}

--- a/crates/loopal-acp/src/translate/mod.rs
+++ b/crates/loopal-acp/src/translate/mod.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod ext;
 mod messages;
+mod panel;
 mod tool_kind;
 mod tools;
 
@@ -131,51 +132,6 @@ pub fn translate_event(payload: &AgentEventPayload, session_id: &str) -> Option<
             Some(AcpNotification::Extension { method, params })
         }
 
-        // ── Events with no ACP counterpart ───────────────────────────
-        AgentEventPayload::AwaitingInput
-        | AgentEventPayload::AutoContinuation { .. }
-        | AgentEventPayload::Started
-        | AgentEventPayload::Running
-        | AgentEventPayload::Finished
-        | AgentEventPayload::MessageRouted { .. }
-        | AgentEventPayload::ToolPermissionRequest { .. }
-        | AgentEventPayload::UserQuestionRequest { .. }
-        | AgentEventPayload::ThinkingComplete { .. }
-        | AgentEventPayload::Rewound { .. }
-        | AgentEventPayload::Compacted(_)
-        | AgentEventPayload::ToolBatchStart { .. }
-        | AgentEventPayload::Interrupted
-        | AgentEventPayload::TurnDiffSummary { .. }
-        | AgentEventPayload::ServerToolUse { .. }
-        | AgentEventPayload::ServerToolResult { .. }
-        | AgentEventPayload::RetryCleared
-        | AgentEventPayload::SubAgentSpawned(_)
-        | AgentEventPayload::PermissionDecided { .. }
-        | AgentEventPayload::QuestionDecided { .. }
-        | AgentEventPayload::TurnCompleted(_)
-        | AgentEventPayload::McpStatusReport { .. }
-        | AgentEventPayload::BgTaskSpawned { .. }
-        | AgentEventPayload::BgTaskOutput { .. }
-        | AgentEventPayload::BgTaskCompleted { .. }
-        | AgentEventPayload::TasksChanged { .. }
-        | AgentEventPayload::CronsChanged { .. }
-        | AgentEventPayload::UserMessageQueued { .. }
-        | AgentEventPayload::ModelChanged { .. }
-        | AgentEventPayload::ThinkingChanged { .. }
-        | AgentEventPayload::PermissionModeChanged { .. }
-        | AgentEventPayload::DecisionModeChanged { .. }
-        | AgentEventPayload::SandboxPolicyChanged { .. }
-        | AgentEventPayload::ThreadGoalUpdated { .. }
-        | AgentEventPayload::ClassifierProgress { .. }
-        | AgentEventPayload::ClassifierFailed { .. }
-        | AgentEventPayload::ClassifierCompleted { .. }
-        | AgentEventPayload::CompactProgress { .. }
-        | AgentEventPayload::HubDegraded { .. }
-        | AgentEventPayload::HubRecovered { .. }
-        | AgentEventPayload::DegenerationDetected(_)
-        | AgentEventPayload::ContinuationSkipped { .. }
-        | AgentEventPayload::TurnCancelled { .. }
-        | AgentEventPayload::ContinuationGateChanged(_) => None,
         AgentEventPayload::ToolPermissionResolved { id } => Some(AcpNotification::Extension {
             method: "_loopal/permission_resolved".into(),
             params: serde_json::json!({
@@ -190,6 +146,9 @@ pub fn translate_event(payload: &AgentEventPayload, session_id: &str) -> Option<
                 "questionId": id,
             }),
         }),
+
+        // Loopal control-panel signals → `_loopal/*`; all other events → None.
+        _ => panel::translate_panel(payload, session_id),
     }
 }
 

--- a/crates/loopal-acp/src/translate/panel.rs
+++ b/crates/loopal-acp/src/translate/panel.rs
@@ -1,0 +1,78 @@
+//! `_loopal/*` extension notifications for control-panel signals (bg shell /
+//! cron / task / topology / mcp / goal). Field names mirror loopal-protocol
+//! snapshot types (snake_case) so the GUI state mirror needs no per-field remap.
+
+use loopal_protocol::AgentEventPayload;
+
+use super::AcpNotification;
+use super::ext::ext_notification;
+
+pub(crate) fn translate_panel(
+    payload: &AgentEventPayload,
+    session_id: &str,
+) -> Option<AcpNotification> {
+    let (method, params) = match payload {
+        AgentEventPayload::BgTaskSpawned {
+            id,
+            description,
+            created_at_unix_ms,
+        } => ext_notification(
+            session_id,
+            "bgTask.spawned",
+            serde_json::json!({
+                "id": id,
+                "description": description,
+                "created_at_unix_ms": created_at_unix_ms,
+            }),
+        ),
+        AgentEventPayload::BgTaskOutput { id, output_delta } => ext_notification(
+            session_id,
+            "bgTask.output",
+            serde_json::json!({ "id": id, "output_delta": output_delta }),
+        ),
+        AgentEventPayload::BgTaskCompleted {
+            id,
+            status,
+            exit_code,
+            output,
+        } => ext_notification(
+            session_id,
+            "bgTask.completed",
+            serde_json::json!({
+                "id": id,
+                "status": status,
+                "exit_code": exit_code,
+                "output": output,
+            }),
+        ),
+        AgentEventPayload::CronsChanged { crons } => {
+            ext_notification(session_id, "crons", serde_json::json!({ "crons": crons }))
+        }
+        AgentEventPayload::TasksChanged { tasks } => {
+            ext_notification(session_id, "tasks", serde_json::json!({ "tasks": tasks }))
+        }
+        AgentEventPayload::McpStatusReport { servers } => {
+            ext_notification(session_id, "mcp", serde_json::json!({ "servers": servers }))
+        }
+        AgentEventPayload::SubAgentSpawned(spawn) => ext_notification(
+            session_id,
+            "topology.spawn",
+            serde_json::json!({ "spawn": spawn }),
+        ),
+        AgentEventPayload::ThreadGoalUpdated { goal, .. } => {
+            ext_notification(session_id, "goal", serde_json::json!({ "goal": goal }))
+        }
+        AgentEventPayload::ModelChanged { model } => {
+            ext_notification(session_id, "model", serde_json::json!({ "model": model }))
+        }
+        // thinking_config is already-serialized ThinkingConfig JSON; pass through
+        // raw so the GUI normalizes it to a label without a second schema here.
+        AgentEventPayload::ThinkingChanged { thinking_config } => ext_notification(
+            session_id,
+            "thinking",
+            serde_json::json!({ "thinking": thinking_config }),
+        ),
+        _ => return None,
+    };
+    Some(AcpNotification::Extension { method, params })
+}

--- a/crates/loopal-acp/tests/fixtures/loopal_panel_signals.json
+++ b/crates/loopal-acp/tests/fixtures/loopal_panel_signals.json
@@ -1,0 +1,12 @@
+{
+  "signals": [
+    {"kind": "bgTask.spawned", "data": {"id": "bg1", "description": "npm test", "created_at_unix_ms": 1717000000000}},
+    {"kind": "bgTask.output", "data": {"id": "bg1", "output_delta": "running...\n"}},
+    {"kind": "bgTask.completed", "data": {"id": "bg1", "status": "Completed", "exit_code": 0, "output": "done"}},
+    {"kind": "crons", "data": {"crons": [{"id": "c1", "cron_expr": "0 9 * * *", "prompt": "daily", "recurring": true, "durable": true}]}},
+    {"kind": "tasks", "data": {"tasks": [{"id": "t1", "subject": "build", "status": "in_progress", "blocked_by": []}]}},
+    {"kind": "topology.spawn", "data": {"spawn": {"name": "worker", "agent_id": "a1", "parent": {"agent": "main"}, "model": "opus"}}},
+    {"kind": "mcp", "data": {"servers": [{"name": "fs", "status": "connected", "tool_count": 3}]}},
+    {"kind": "goal", "data": {"goal": {"goal_id": "g1", "objective": "ship it", "status": "active"}}}
+  ]
+}

--- a/crates/loopal-acp/tests/suite.rs
+++ b/crates/loopal-acp/tests/suite.rs
@@ -13,6 +13,8 @@ mod e2e_error_test;
 mod e2e_harness;
 #[path = "suite/e2e_lifecycle_test.rs"]
 mod e2e_lifecycle_test;
+#[path = "suite/e2e_loopal_test.rs"]
+mod e2e_loopal_test;
 #[path = "suite/e2e_multi_test.rs"]
 mod e2e_multi_test;
 #[path = "suite/e2e_new_methods_test.rs"]

--- a/crates/loopal-acp/tests/suite/e2e_harness.rs
+++ b/crates/loopal-acp/tests/suite/e2e_harness.rs
@@ -166,4 +166,22 @@ impl AcpTestHarness {
             }
         }
     }
+
+    /// Read trailing notifications until one with `method` arrives (or timeout).
+    /// Observes post-response emissions like the snapshot replay that
+    /// `handle_new_session` fires after responding.
+    pub async fn read_until_method(&mut self, method: &str) -> Option<Value> {
+        loop {
+            let mut line = String::new();
+            match tokio::time::timeout(IO_TIMEOUT, self.client_reader.read_line(&mut line)).await {
+                Ok(Ok(n)) if n > 0 => {
+                    let parsed: Value = serde_json::from_str(line.trim()).ok()?;
+                    if parsed.get("method").and_then(|m| m.as_str()) == Some(method) {
+                        return Some(parsed);
+                    }
+                }
+                _ => return None,
+            }
+        }
+    }
 }

--- a/crates/loopal-acp/tests/suite/e2e_loopal_test.rs
+++ b/crates/loopal-acp/tests/suite/e2e_loopal_test.rs
@@ -1,0 +1,91 @@
+//! Integration tests for the AgentsMesh `_loopal/*` ACP control extension:
+//! `controlRequest` capability advertisement + `session/control_request`
+//! round-trip (parse_loopal_control → send_control → mock agent). Exercises the
+//! same ACP → UiSession → Hub → Agent path as production.
+
+use serde_json::json;
+
+use loopal_test_support::assertions;
+
+use super::e2e_harness::{AcpTestHarness, build_acp_harness};
+
+async fn setup_session(harness: &mut AcpTestHarness) -> String {
+    harness
+        .request("initialize", json!({"protocolVersion": 1}))
+        .await;
+    let resp = harness.request("session/new", json!({"cwd": "/tmp"})).await;
+    resp["result"]["sessionId"]
+        .as_str()
+        .expect("sessionId")
+        .to_string()
+}
+
+#[tokio::test]
+async fn test_initialize_advertises_control_request() {
+    let mut harness = build_acp_harness(vec![]).await;
+    let resp = harness
+        .request("initialize", json!({"protocolVersion": 1}))
+        .await;
+    assert_eq!(
+        resp["result"]["agentsmeshExtensions"]["controlRequest"], true,
+        "initialize must advertise controlRequest so the runner routes Loopal control: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_control_request_compact_ok() {
+    let mut harness = build_acp_harness(vec![]).await;
+    let sid = setup_session(&mut harness).await;
+    let resp = harness
+        .request(
+            "session/control_request",
+            json!({"sessionId": sid, "subtype": "loopal.compact", "params": {}}),
+        )
+        .await;
+    assertions::assert_json_rpc_ok(&resp);
+}
+
+#[tokio::test]
+async fn test_control_request_bgtask_kill_ok() {
+    let mut harness = build_acp_harness(vec![]).await;
+    let sid = setup_session(&mut harness).await;
+    let resp = harness
+        .request(
+            "session/control_request",
+            json!({"sessionId": sid, "subtype": "loopal.bgTaskKill", "params": {"id": "bg1"}}),
+        )
+        .await;
+    assertions::assert_json_rpc_ok(&resp);
+}
+
+#[tokio::test]
+async fn test_control_request_unknown_subtype_rejected() {
+    let mut harness = build_acp_harness(vec![]).await;
+    let sid = setup_session(&mut harness).await;
+    let resp = harness
+        .request(
+            "session/control_request",
+            json!({"sessionId": sid, "subtype": "loopal.bogus", "params": {}}),
+        )
+        .await;
+    assertions::assert_json_rpc_error(&resp, -32601);
+}
+
+#[tokio::test]
+async fn test_session_new_replays_loopal_snapshot() {
+    let mut harness = build_acp_harness(vec![]).await;
+    harness
+        .request("initialize", json!({"protocolVersion": 1}))
+        .await;
+    // session/new fires replay_loopal_snapshot AFTER responding (post bootstrap
+    // drain). The replay always emits _loopal/crons (even empty), so observing it
+    // on the stream proves the cold-start path runs end-to-end: drain returns on
+    // the agent's AwaitingInput → fetch view/snapshot → notify _loopal/*.
+    let _ = harness.request("session/new", json!({"cwd": "/tmp"})).await;
+    let crons = harness.read_until_method("_loopal/crons").await;
+    assert!(
+        crons.is_some(),
+        "expected _loopal/crons notification from snapshot replay"
+    );
+    assert!(crons.unwrap()["params"]["data"]["crons"].is_array());
+}

--- a/crates/loopal-acp/tests/suite/translate_event_test.rs
+++ b/crates/loopal-acp/tests/suite/translate_event_test.rs
@@ -3,7 +3,7 @@
 //! land in exactly one of: SessionUpdate, Extension, or None.
 
 use loopal_acp::translate::{AcpNotification, translate_event};
-use loopal_protocol::AgentEventPayload;
+use loopal_protocol::{AgentEventPayload, BgTaskStatus, GoalTransitionReason};
 
 #[test]
 fn stream_returns_session_update() {
@@ -77,7 +77,8 @@ fn none_events_return_none() {
         AgentEventPayload::Finished,
         AgentEventPayload::Interrupted,
         AgentEventPayload::RetryCleared,
-        AgentEventPayload::McpStatusReport { servers: vec![] },
+        AgentEventPayload::HubDegraded { since_unix_ms: 1 },
+        AgentEventPayload::HubRecovered { duration_ms: 2 },
     ];
     for ev in &nones {
         assert!(
@@ -158,23 +159,266 @@ fn cleared_returns_extension() {
 }
 
 #[test]
-fn model_changed_has_no_ide_counterpart() {
+fn model_changed_returns_extension() {
     let r = translate_event(
         &AgentEventPayload::ModelChanged {
             model: "claude-opus-4-7".into(),
         },
         "s",
     );
-    assert!(r.is_none());
+    match r {
+        Some(AcpNotification::Extension { method, params }) => {
+            assert_eq!(method, "_loopal/model");
+            assert_eq!(params["data"]["model"], "claude-opus-4-7");
+        }
+        _ => panic!("expected Extension"),
+    }
 }
 
 #[test]
-fn thinking_changed_has_no_ide_counterpart() {
+fn thinking_changed_returns_extension() {
     let r = translate_event(
         &AgentEventPayload::ThinkingChanged {
-            thinking_config: r#"{"type":"effort"}"#.into(),
+            thinking_config: r#"{"type":"effort","level":"high"}"#.into(),
         },
         "s",
     );
-    assert!(r.is_none());
+    match r {
+        Some(AcpNotification::Extension { method, params }) => {
+            assert_eq!(method, "_loopal/thinking");
+            assert_eq!(
+                params["data"]["thinking"],
+                r#"{"type":"effort","level":"high"}"#
+            );
+        }
+        _ => panic!("expected Extension"),
+    }
+}
+
+#[test]
+fn bg_task_spawned_returns_extension() {
+    let r = translate_event(
+        &AgentEventPayload::BgTaskSpawned {
+            id: "bg1".into(),
+            description: "npm test".into(),
+            created_at_unix_ms: 1_717_000_000_000,
+        },
+        "s",
+    );
+    match r {
+        Some(AcpNotification::Extension { method, params }) => {
+            assert_eq!(method, "_loopal/bgTask.spawned");
+            assert_eq!(params["data"]["id"], "bg1");
+            assert_eq!(params["data"]["description"], "npm test");
+        }
+        _ => panic!("expected Extension"),
+    }
+}
+
+#[test]
+fn bg_task_output_returns_extension() {
+    let r = translate_event(
+        &AgentEventPayload::BgTaskOutput {
+            id: "bg1".into(),
+            output_delta: "line\n".into(),
+        },
+        "s",
+    );
+    match r {
+        Some(AcpNotification::Extension { method, params }) => {
+            assert_eq!(method, "_loopal/bgTask.output");
+            assert_eq!(params["data"]["output_delta"], "line\n");
+        }
+        _ => panic!("expected Extension"),
+    }
+}
+
+#[test]
+fn bg_task_completed_returns_extension() {
+    let r = translate_event(
+        &AgentEventPayload::BgTaskCompleted {
+            id: "bg1".into(),
+            status: loopal_protocol::BgTaskStatus::Completed,
+            exit_code: Some(0),
+            output: "done".into(),
+        },
+        "s",
+    );
+    match r {
+        Some(AcpNotification::Extension { method, params }) => {
+            assert_eq!(method, "_loopal/bgTask.completed");
+            assert_eq!(params["data"]["exit_code"], 0);
+        }
+        _ => panic!("expected Extension"),
+    }
+}
+
+#[test]
+fn crons_changed_returns_extension() {
+    match translate_event(&AgentEventPayload::CronsChanged { crons: vec![] }, "s") {
+        Some(AcpNotification::Extension { method, params }) => {
+            assert_eq!(method, "_loopal/crons");
+            assert!(params["data"]["crons"].is_array());
+        }
+        _ => panic!("expected Extension"),
+    }
+}
+
+#[test]
+fn tasks_changed_returns_extension() {
+    match translate_event(&AgentEventPayload::TasksChanged { tasks: vec![] }, "s") {
+        Some(AcpNotification::Extension { method, .. }) => assert_eq!(method, "_loopal/tasks"),
+        _ => panic!("expected Extension"),
+    }
+}
+
+#[test]
+fn mcp_status_report_returns_extension() {
+    match translate_event(&AgentEventPayload::McpStatusReport { servers: vec![] }, "s") {
+        Some(AcpNotification::Extension { method, .. }) => assert_eq!(method, "_loopal/mcp"),
+        _ => panic!("expected Extension"),
+    }
+}
+
+#[test]
+fn sub_agent_spawned_returns_topology_extension() {
+    let r = translate_event(
+        &AgentEventPayload::SubAgentSpawned(loopal_protocol::SubAgentSpawn {
+            name: "worker".into(),
+            agent_id: "a1".into(),
+            parent: None,
+            model: None,
+            session_id: None,
+        }),
+        "s",
+    );
+    match r {
+        Some(AcpNotification::Extension { method, params }) => {
+            assert_eq!(method, "_loopal/topology.spawn");
+            assert_eq!(params["data"]["spawn"]["name"], "worker");
+        }
+        _ => panic!("expected Extension"),
+    }
+}
+
+#[test]
+fn thread_goal_updated_returns_goal_extension() {
+    let r = translate_event(
+        &AgentEventPayload::ThreadGoalUpdated {
+            goal: None,
+            reason: loopal_protocol::GoalTransitionReason::UserCleared,
+        },
+        "s",
+    );
+    match r {
+        Some(AcpNotification::Extension { method, params }) => {
+            assert_eq!(method, "_loopal/goal");
+            assert!(params["data"].get("goal").is_some());
+        }
+        _ => panic!("expected Extension"),
+    }
+}
+
+// The inputs whose translate_event output each golden fixture entry must be a
+// superset of. Complex snapshot types are built via from_value so the test
+// doesn't hand-write (and drift on) their full field set.
+fn payload_for_kind(kind: &str) -> AgentEventPayload {
+    use AgentEventPayload as P;
+    use loopal_protocol::{
+        CronJobSnapshot, McpServerSnapshot, SubAgentSpawn, TaskSnapshot, ThreadGoal,
+    };
+    use serde_json::{from_value, json};
+    match kind {
+        "bgTask.spawned" => P::BgTaskSpawned {
+            id: "bg1".into(),
+            description: "npm test".into(),
+            created_at_unix_ms: 1_717_000_000_000,
+        },
+        "bgTask.output" => P::BgTaskOutput {
+            id: "bg1".into(),
+            output_delta: "running...\n".into(),
+        },
+        "bgTask.completed" => P::BgTaskCompleted {
+            id: "bg1".into(),
+            status: BgTaskStatus::Completed,
+            exit_code: Some(0),
+            output: "done".into(),
+        },
+        "crons" => P::CronsChanged {
+            crons: from_value::<Vec<CronJobSnapshot>>(json!([{
+                "id": "c1", "cron_expr": "0 9 * * *", "prompt": "daily",
+                "recurring": true, "created_at_unix_ms": 0, "next_fire_unix_ms": null, "durable": true
+            }]))
+            .unwrap(),
+        },
+        "tasks" => P::TasksChanged {
+            tasks: from_value::<Vec<TaskSnapshot>>(json!([{
+                "id": "t1", "subject": "build", "active_form": null,
+                "status": "in_progress", "blocked_by": [], "description": "", "blocks": []
+            }]))
+            .unwrap(),
+        },
+        "topology.spawn" => P::SubAgentSpawned(SubAgentSpawn {
+            name: "worker".into(),
+            agent_id: "a1".into(),
+            parent: Some(loopal_protocol::QualifiedAddress::local("main")),
+            model: Some("opus".into()),
+            session_id: None,
+        }),
+        "mcp" => P::McpStatusReport {
+            servers: from_value::<Vec<McpServerSnapshot>>(json!([{
+                "name": "fs", "transport": "stdio", "source": "global", "status": "connected",
+                "tool_count": 3, "resource_count": 0, "prompt_count": 0, "errors": []
+            }]))
+            .unwrap(),
+        },
+        "goal" => P::ThreadGoalUpdated {
+            goal: Some(
+                from_value::<ThreadGoal>(json!({
+                    "session_id": "s", "goal_id": "g1", "objective": "ship it", "status": "active",
+                    "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"
+                }))
+                .unwrap(),
+            ),
+            reason: GoalTransitionReason::UserCleared,
+        },
+        _ => panic!("unknown kind: {kind}"),
+    }
+}
+
+// True when `actual` contains every field of `expected` (recursive subset).
+// Loopal emits the full wire; the fixture is the field subset AgentsMesh
+// consumes, so a superset is correct — extra Loopal fields don't fail.
+fn json_contains(actual: &serde_json::Value, expected: &serde_json::Value) -> bool {
+    use serde_json::Value;
+    match (actual, expected) {
+        (Value::Object(a), Value::Object(e)) => e
+            .iter()
+            .all(|(k, ev)| a.get(k).is_some_and(|av| json_contains(av, ev))),
+        (Value::Array(a), Value::Array(e)) => {
+            a.len() == e.len() && a.iter().zip(e).all(|(av, ev)| json_contains(av, ev))
+        }
+        _ => actual == expected,
+    }
+}
+
+#[test]
+fn panel_signals_match_golden_fixture() {
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("../fixtures/loopal_panel_signals.json")).unwrap();
+    for entry in fixture["signals"].as_array().unwrap() {
+        let kind = entry["kind"].as_str().unwrap();
+        let want = &entry["data"];
+        match translate_event(&payload_for_kind(kind), "s") {
+            Some(AcpNotification::Extension { method, params }) => {
+                assert_eq!(method, format!("_loopal/{kind}"));
+                assert!(
+                    json_contains(&params["data"], want),
+                    "fixture drift for {kind}:\n  produced={}\n  fixture={want}",
+                    params["data"]
+                );
+            }
+            _ => panic!("expected Extension for {kind}"),
+        }
+    }
 }


### PR DESCRIPTION
Backend ACP support for the AgentsMesh Loopal graphical control console.

## Changes
- `translate/panel.rs`: bgTask / cron / task / mcp / topology / goal / model / thinking → `_loopal/*` extension notifications (snake_case mirrors loopal-protocol snapshot types)
- `adapter/control_command.rs` + `control.rs`: `session/control_request` dispatch (18 `loopal.*` controls + `set_model`); unknown subtype → `METHOD_NOT_FOUND`
- `adapter/snapshot.rs`: cold-start replay of `view/snapshot` as `_loopal/*` incremental events
- `adapter/lifecycle.rs`: advertise `agentsmeshExtensions.controlRequest` on initialize
- `adapter/events.rs`: mode dual-emit (standard ACP `CurrentModeUpdate` + `_loopal/mode`)
- `translate/mod.rs`: route non-ACP events through the panel translator (`_ => panel`)

## Notes
- Rebased onto #194 — its 3 new mode variants (`PermissionModeChanged` / `DecisionModeChanged` / `SandboxPolicyChanged`) fall through `_ => panel → None`, preserving their no-ACP-counterpart behavior.
- `panel_signals_match_golden_fixture` is the wire contract anchor for the AgentsMesh mock e2e.

## Test
`bazel test //crates/loopal-acp:all` — green (unit + integration).