### PR TITLE
refactor(protocol): type sub-agent completion as MessageSource::AgentResult

### DIFF
--- a/crates/loopal-agent-hub/src/agent_registry/completion.rs
+++ b/crates/loopal-agent-hub/src/agent_registry/completion.rs
@@ -70,13 +70,16 @@ impl AgentRegistry {
         } else {
             result.to_string()
         };
-        let content = format!("<agent-result name=\"{child_name}\">\n{body}\n</agent-result>");
-        // Source carries the child's local view; uplink SNAT stamps the
-        // origin hub when this completion is delivered to a remote parent.
+        // Source carries the child's local view (uplink SNAT stamps the origin
+        // hub on cross-hub delivery). The `<agent-result>` wrapper is rebuilt at
+        // LLM projection time — the envelope body stays raw so observers render
+        // it structurally.
         let envelope = Envelope::new(
-            MessageSource::Agent(QualifiedAddress::local(child_name)),
+            MessageSource::AgentResult {
+                child: QualifiedAddress::local(child_name),
+            },
             parent.clone(),
-            content,
+            body,
         );
         Some((tx, envelope))
     }
@@ -118,7 +121,8 @@ impl AgentRegistry {
                     .iter()
                     .filter(|c| {
                         self.agents.get(c.as_str()).is_some_and(|a| {
-                            a.info.lifecycle == AgentLifecycle::Running && !a.state.is_shadow() // shadows are remote, can't interrupt locally
+                            a.info.lifecycle == AgentLifecycle::Running && !a.state.is_shadow()
+                            // shadows are remote, can't interrupt locally
                         })
                     })
                     .cloned()

--- a/crates/loopal-agent-hub/src/finish.rs
+++ b/crates/loopal-agent-hub/src/finish.rs
@@ -53,13 +53,12 @@ pub async fn finish_and_deliver(
         && parent.is_remote()
         && let Some(ul) = uplink
     {
-        let content = format!("<agent-result name=\"{name}\">\n{output_text}\n</agent-result>");
-        // Use Agent(local(child)) so uplink SNAT stamps the origin hub.
-        // System("agent-completed") cannot carry hub info — see review #3.
         let envelope = Envelope::new(
-            MessageSource::Agent(QualifiedAddress::local(name)),
+            MessageSource::AgentResult {
+                child: QualifiedAddress::local(name),
+            },
             parent.clone(),
-            content,
+            output_text,
         );
         if let Err(e) = ul.route(&envelope).await {
             tracing::warn!(agent = %name, parent = %parent, error = %e,

--- a/crates/loopal-agent-hub/src/uplink.rs
+++ b/crates/loopal-agent-hub/src/uplink.rs
@@ -114,12 +114,13 @@ pub async fn handle_reverse_requests(
                     let ok = if let Ok(env) =
                         serde_json::from_value::<loopal_protocol::Envelope>(params)
                     {
-                        // Remote agent completions arrive with the agent-result
-                        // marker in content. Detect by content (not source tag)
-                        // so it works with the typed Agent source after SNAT.
-                        if let Some(child) = extract_agent_result_name(&env) {
+                        // Remote agent completions arrive as a typed AgentResult
+                        // source (set by the origin hub, survives SNAT). The
+                        // child name is the bare agent segment.
+                        if let loopal_protocol::MessageSource::AgentResult { child } = &env.source {
                             let output = env.content.text.clone();
-                            crate::finish::deliver_cross_hub_completion(&hub, &child, output).await;
+                            crate::finish::deliver_cross_hub_completion(&hub, &child.agent, output)
+                                .await;
                         }
                         // Defense in depth: target should be local at this point
                         // (MetaHub router consumed the next-hop hub via DNAT).
@@ -168,12 +169,4 @@ pub async fn handle_reverse_requests(
         }
     }
     tracing::warn!(hub = %hub_name, "MetaHub reverse handler ended");
-}
-
-/// Extract child agent name from `<agent-result name="...">` envelope.
-fn extract_agent_result_name(env: &loopal_protocol::Envelope) -> Option<String> {
-    let text = &env.content.text;
-    let start = text.find("<agent-result name=\"")? + 20;
-    let end = text[start..].find('"')? + start;
-    Some(text[start..end].to_string())
 }

--- a/crates/loopal-agent-hub/tests/suite/completion_injection_test.rs
+++ b/crates/loopal-agent-hub/tests/suite/completion_injection_test.rs
@@ -97,15 +97,15 @@ async fn child_completion_delivered_to_parent_via_bridge() {
     assert!(
         matches!(
             envelope.source,
-            MessageSource::Agent(ref qa) if qa.agent == "child-a" && qa.is_local()
+            MessageSource::AgentResult { ref child } if child.agent == "child-a" && child.is_local()
         ),
-        "source should be Agent(local('child-a')), got: {:?}",
+        "source should be AgentResult(local('child-a')), got: {:?}",
         envelope.source
     );
     let text = &envelope.content.text;
     assert!(
-        text.contains("child-a") && text.contains("42 issues"),
-        "should contain child name and result, got: {text}"
+        text.contains("42 issues"),
+        "body should be the raw result, got: {text}"
     );
 }
 

--- a/crates/loopal-meta-hub/tests/suite/nat_routing_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/nat_routing_test.rs
@@ -302,16 +302,19 @@ async fn cross_hub_completion_carries_origin_hub_in_source() {
     };
     let env: Envelope = serde_json::from_value(params).unwrap();
 
-    // Source: Agent(QA{hub=["hub-b"], agent="child"}) — proves SNAT applied.
+    // Source: AgentResult{child=QA{hub=["hub-b"], agent="child"}} — proves
+    // SNAT applied to the typed completion source.
     assert_eq!(
         env.source,
-        MessageSource::Agent(QualifiedAddress::remote(["hub-b"], "child")),
+        MessageSource::AgentResult {
+            child: QualifiedAddress::remote(["hub-b"], "child")
+        },
         "completion source must carry origin hub"
     );
     // Target: local("parent") — proves DNAT consumed hub-A from the path.
     assert_eq!(env.target, QualifiedAddress::local("parent"));
-    assert!(env.content.text.contains("<agent-result name=\"child\">"));
-    assert!(env.content.text.contains("ok"));
+    // Body is raw now — the <agent-result> wrapper is a projection concern.
+    assert_eq!(env.content.text, "ok");
 }
 
 /// Cross-hub spawn: a child registered with a qualified `hub/agent` parent

--- a/crates/loopal-meta-hub/tests/suite/spawn_completion_test.rs
+++ b/crates/loopal-meta-hub/tests/suite/spawn_completion_test.rs
@@ -111,12 +111,16 @@ async fn completion_delivery_to_remote_parent() {
             let params = match &msg {
                 Incoming::Request { params, .. } | Incoming::Notification { params, .. } => params,
             };
-            let text = params
-                .get("content")
-                .and_then(|c| c.get("text"))
-                .and_then(|t| t.as_str())
-                .unwrap_or("");
-            if text.contains("agent-result") && text.contains("child-worker") {
+            // Completion is now a typed AgentResult source carrying the child
+            // name; the body is the raw output, not a wrapped marker.
+            let is_result = params
+                .get("source")
+                .and_then(|s| s.get("AgentResult"))
+                .and_then(|r| r.get("child"))
+                .and_then(|c| c.get("agent"))
+                .and_then(|a| a.as_str())
+                .is_some_and(|name| name == "child-worker");
+            if is_result {
                 return true;
             }
         }

--- a/crates/loopal-protocol/src/envelope.rs
+++ b/crates/loopal-protocol/src/envelope.rs
@@ -13,6 +13,9 @@ use crate::user_content::UserContent;
 pub enum MessageSource {
     Human,
     Agent(QualifiedAddress),
+    AgentResult {
+        child: QualifiedAddress,
+    },
     Channel {
         channel: String,
         from: QualifiedAddress,
@@ -27,6 +30,7 @@ impl MessageSource {
         match self {
             Self::Human => "human".to_string(),
             Self::Agent(addr) => addr.to_string(),
+            Self::AgentResult { child } => child.to_string(),
             Self::Channel { from, .. } => from.to_string(),
             Self::Scheduled => "scheduled".to_string(),
             Self::System(kind) => format!("system:{kind}"),
@@ -67,7 +71,11 @@ impl MessageSource {
     pub fn is_task_boundary(&self) -> bool {
         matches!(
             self,
-            Self::Human | Self::Scheduled | Self::Agent(_) | Self::Channel { .. }
+            Self::Human
+                | Self::Scheduled
+                | Self::Agent(_)
+                | Self::AgentResult { .. }
+                | Self::Channel { .. }
         )
     }
 
@@ -76,6 +84,7 @@ impl MessageSource {
     pub fn prepend_hub(&mut self, self_hub: &str) {
         match self {
             Self::Agent(addr) => addr.prepend_hub(self_hub.to_string()),
+            Self::AgentResult { child } => child.prepend_hub(self_hub.to_string()),
             Self::Channel { from, .. } => from.prepend_hub(self_hub.to_string()),
             _ => {}
         }
@@ -87,6 +96,7 @@ impl MessageSource {
     pub fn prepend_hub_if_local(&mut self, self_hub: &str) {
         match self {
             Self::Agent(addr) => addr.prepend_hub_if_local(self_hub.to_string()),
+            Self::AgentResult { child } => child.prepend_hub_if_local(self_hub.to_string()),
             Self::Channel { from, .. } => from.prepend_hub_if_local(self_hub.to_string()),
             _ => {}
         }

--- a/crates/loopal-protocol/tests/suite/envelope_test.rs
+++ b/crates/loopal-protocol/tests/suite/envelope_test.rs
@@ -248,3 +248,61 @@ fn test_non_human_sources_are_not_optimistically_rendered() {
         .is_optimistically_rendered()
     );
 }
+
+#[test]
+fn test_agent_result_label_uses_child_address() {
+    let local = MessageSource::AgentResult {
+        child: QualifiedAddress::local("worker"),
+    };
+    assert_eq!(local.label(), "worker");
+    let remote = MessageSource::AgentResult {
+        child: QualifiedAddress::remote(["hub-A"], "worker"),
+    };
+    assert_eq!(remote.label(), "hub-A/worker");
+}
+
+#[test]
+fn test_agent_result_is_task_boundary() {
+    assert!(
+        MessageSource::AgentResult {
+            child: QualifiedAddress::local("worker"),
+        }
+        .is_task_boundary()
+    );
+}
+
+#[test]
+fn test_agent_result_not_optimistically_rendered_nor_ephemeral() {
+    let src = MessageSource::AgentResult {
+        child: QualifiedAddress::local("worker"),
+    };
+    assert!(!src.is_optimistically_rendered());
+    assert!(!src.is_ephemeral_in_history());
+    assert!(!src.wakes_suspended_session());
+}
+
+#[test]
+fn test_agent_result_snat_stamps_child_hub() {
+    let mut env = Envelope::new(
+        MessageSource::AgentResult {
+            child: QualifiedAddress::local("worker"),
+        },
+        "hub-A/parent",
+        "done",
+    );
+    env.apply_snat("hub-B");
+    let MessageSource::AgentResult { child } = &env.source else {
+        panic!("expected AgentResult source");
+    };
+    assert_eq!(child, &QualifiedAddress::remote(["hub-B"], "worker"));
+}
+
+#[test]
+fn test_agent_result_serde_roundtrip() {
+    let src = MessageSource::AgentResult {
+        child: QualifiedAddress::remote(["hub-A"], "worker"),
+    };
+    let json = serde_json::to_string(&src).unwrap();
+    let back: MessageSource = serde_json::from_str(&json).unwrap();
+    assert_eq!(src, back);
+}

--- a/crates/loopal-provider-api/src/lib.rs
+++ b/crates/loopal-provider-api/src/lib.rs
@@ -17,7 +17,7 @@ pub use resolver::ProviderResolver;
 pub use thinking::*;
 pub use wire::{
     ContentBlock, ImageSource, Message, MessageOrigin, MessageRole, normalize_messages,
-    project_turn_to_messages, project_turns_to_messages,
+    project_turn_to_messages, project_turns_to_messages, trigger_llm_text,
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/loopal-provider-api/src/wire/mod.rs
+++ b/crates/loopal-provider-api/src/wire/mod.rs
@@ -6,4 +6,4 @@ pub mod turn_projection;
 pub use message::{ContentBlock, ImageSource, Message, MessageRole};
 pub use normalize::normalize_messages;
 pub use origin::MessageOrigin;
-pub use turn_projection::{project_turn_to_messages, project_turns_to_messages};
+pub use turn_projection::{project_turn_to_messages, project_turns_to_messages, trigger_llm_text};

--- a/crates/loopal-provider-api/src/wire/turn_projection/mod.rs
+++ b/crates/loopal-provider-api/src/wire/turn_projection/mod.rs
@@ -1,7 +1,10 @@
 mod blocks;
 mod compaction;
+mod prefix;
 mod step;
 mod trigger;
+
+pub use self::prefix::trigger_llm_text;
 
 use loopal_turn::{Turn, TurnStep};
 

--- a/crates/loopal-provider-api/src/wire/turn_projection/prefix.rs
+++ b/crates/loopal-provider-api/src/wire/turn_projection/prefix.rs
@@ -1,0 +1,66 @@
+use loopal_turn::TurnTrigger;
+
+/// SSOT for the LLM-facing text of a turn trigger: applies the source prefix
+/// (`[scheduled]`, `[from: ...]`) or `<agent-result>` marker. Returns `None`
+/// for triggers that produce no user message (`Resume`). Images on
+/// `UserInput` are structural and handled by the caller — this is text only.
+pub fn trigger_llm_text(trigger: &TurnTrigger) -> Option<String> {
+    match trigger {
+        TurnTrigger::UserInput { content, .. } => Some(content.clone()),
+        TurnTrigger::Cron { content, .. } => Some(format!("[scheduled] {content}")),
+        TurnTrigger::Agent { from, content, .. } => Some(format!("[from: {from}] {content}")),
+        TurnTrigger::AgentResult { from, content, .. } => Some(format!(
+            "<agent-result name=\"{from}\">\n{content}\n</agent-result>"
+        )),
+        TurnTrigger::Channel {
+            channel,
+            from,
+            content,
+            ..
+        } => Some(format!("[from: #{channel}/{from}] {content}")),
+        TurnTrigger::GoalContinuation { content, .. } => Some(content.clone()),
+        TurnTrigger::BackgroundHook { content, .. } => Some(content.clone()),
+        TurnTrigger::Resume => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent_result(from: &str, content: &str) -> TurnTrigger {
+        TurnTrigger::AgentResult {
+            envelope_id: String::new(),
+            from: from.into(),
+            content: content.into(),
+        }
+    }
+
+    #[test]
+    fn agent_result_wraps_in_marker() {
+        assert_eq!(
+            trigger_llm_text(&agent_result("worker", "done")).unwrap(),
+            "<agent-result name=\"worker\">\ndone\n</agent-result>"
+        );
+    }
+
+    #[test]
+    fn cron_and_agent_carry_source_prefix() {
+        let cron = TurnTrigger::Cron {
+            envelope_id: String::new(),
+            content: "tick".into(),
+        };
+        assert_eq!(trigger_llm_text(&cron).unwrap(), "[scheduled] tick");
+        let agent = TurnTrigger::Agent {
+            envelope_id: String::new(),
+            from: "hub/w".into(),
+            content: "hi".into(),
+        };
+        assert_eq!(trigger_llm_text(&agent).unwrap(), "[from: hub/w] hi");
+    }
+
+    #[test]
+    fn resume_produces_no_text() {
+        assert_eq!(trigger_llm_text(&TurnTrigger::Resume), None);
+    }
+}

--- a/crates/loopal-provider-api/src/wire/turn_projection/trigger.rs
+++ b/crates/loopal-provider-api/src/wire/turn_projection/trigger.rs
@@ -2,49 +2,41 @@ use loopal_turn::TurnTrigger;
 
 use super::super::message::{ContentBlock, ImageSource, Message, MessageRole};
 use super::super::origin::MessageOrigin;
+use super::prefix::trigger_llm_text;
 
 pub(super) fn project_trigger(trigger: &TurnTrigger) -> Option<Message> {
-    match trigger {
-        TurnTrigger::UserInput {
-            content, images, ..
-        } => Some(text_user_with_images(
+    // UserInput carries images — project structurally, not via text prefix.
+    if let TurnTrigger::UserInput {
+        content, images, ..
+    } = trigger
+    {
+        return Some(text_user_with_images(
             content,
             images,
             Some(MessageOrigin::Human),
-        )),
-        TurnTrigger::Cron { content, .. } => Some(text_user(
-            &format!("[scheduled] {content}"),
-            Some(MessageOrigin::Scheduled),
-        )),
-        TurnTrigger::Agent { from, content, .. } => Some(text_user(
-            &format!("[from: {from}] {content}"),
+        ));
+    }
+    let text = trigger_llm_text(trigger)?;
+    Some(text_user(&text, trigger_origin(trigger)))
+}
+
+fn trigger_origin(trigger: &TurnTrigger) -> Option<MessageOrigin> {
+    match trigger {
+        TurnTrigger::UserInput { .. } => Some(MessageOrigin::Human),
+        TurnTrigger::Cron { .. } => Some(MessageOrigin::Scheduled),
+        TurnTrigger::Agent { from, .. } | TurnTrigger::AgentResult { from, .. } => {
             Some(MessageOrigin::Agent {
                 label: from.clone(),
-            }),
-        )),
-        TurnTrigger::Channel {
-            channel,
-            from,
-            content,
-            ..
-        } => Some(text_user(
-            &format!("[from: #{channel}/{from}] {content}"),
-            Some(MessageOrigin::Channel {
-                name: channel.clone(),
-                from: from.clone(),
-            }),
-        )),
-        TurnTrigger::GoalContinuation { content, .. } => {
-            Some(text_user(content, Some(MessageOrigin::GoalContinuation)))
+            })
         }
-        TurnTrigger::BackgroundHook {
-            hook_kind, content, ..
-        } => Some(text_user(
-            content,
-            Some(MessageOrigin::Other {
-                label: hook_kind.clone(),
-            }),
-        )),
+        TurnTrigger::Channel { channel, from, .. } => Some(MessageOrigin::Channel {
+            name: channel.clone(),
+            from: from.clone(),
+        }),
+        TurnTrigger::GoalContinuation { .. } => Some(MessageOrigin::GoalContinuation),
+        TurnTrigger::BackgroundHook { hook_kind, .. } => Some(MessageOrigin::Other {
+            label: hook_kind.clone(),
+        }),
         TurnTrigger::Resume => None,
     }
 }

--- a/crates/loopal-provider-api/tests/suite/turn_projection_test.rs
+++ b/crates/loopal-provider-api/tests/suite/turn_projection_test.rs
@@ -489,3 +489,24 @@ fn cancelled_item_produces_error_tool_result() {
     assert_eq!(block.0, "Cancelled");
     assert!(block.1);
 }
+
+#[test]
+fn agent_result_trigger_rewraps_in_agent_result_marker() {
+    let t = turn_with(
+        TurnTrigger::AgentResult {
+            envelope_id: "env-r".into(),
+            from: "worker".into(),
+            content: "found 3 bugs".into(),
+        },
+        vec![],
+    );
+    let msgs = project_turn_to_messages(&t);
+    assert_eq!(
+        msgs[0].text_content(),
+        "<agent-result name=\"worker\">\nfound 3 bugs\n</agent-result>"
+    );
+    assert!(matches!(
+        &msgs[0].origin,
+        Some(MessageOrigin::Agent { label }) if label == "worker"
+    ));
+}

--- a/crates/loopal-provider/src/anthropic/request_turns/mod.rs
+++ b/crates/loopal-provider/src/anthropic/request_turns/mod.rs
@@ -105,22 +105,7 @@ fn push_turn(out: &mut Vec<Value>, turn: &Turn) {
 }
 
 fn trigger_user(trigger: &TurnTrigger) -> Option<Value> {
-    match trigger {
-        TurnTrigger::UserInput { content, .. } => Some(text_user(content)),
-        TurnTrigger::Cron { content, .. } => Some(text_user(&format!("[scheduled] {content}"))),
-        TurnTrigger::Agent { from, content, .. } => {
-            Some(text_user(&format!("[from: {from}] {content}")))
-        }
-        TurnTrigger::Channel {
-            channel,
-            from,
-            content,
-            ..
-        } => Some(text_user(&format!("[from: #{channel}/{from}] {content}"))),
-        TurnTrigger::GoalContinuation { content, .. } => Some(text_user(content)),
-        TurnTrigger::BackgroundHook { content, .. } => Some(text_user(content)),
-        TurnTrigger::Resume => None,
-    }
+    loopal_provider_api::trigger_llm_text(trigger).map(|text| text_user(&text))
 }
 
 fn push_step(out: &mut Vec<Value>, step: &TurnStep) {

--- a/crates/loopal-runtime/src/agent_loop/degeneration_detector.rs
+++ b/crates/loopal-runtime/src/agent_loop/degeneration_detector.rs
@@ -73,13 +73,12 @@ impl Governance for DegenerationDetector {
     }
 
     fn on_envelope_received(&mut self, source: &MessageSource) {
-        // External signal (human/cron/peer-agent) clears the silenced flag
-        // so a fresh degeneration window can re-emit. Without this, an
-        // /unsuspend followed by relapse would be silent.
-        if matches!(
-            source,
-            MessageSource::Human | MessageSource::Scheduled | MessageSource::Channel { .. }
-        ) {
+        // A fresh external task boundary (human/cron/peer-agent/agent-result/
+        // channel) clears the silenced flag so a new degeneration window can
+        // re-emit. Reuses MessageSource::is_task_boundary so the boundary set
+        // stays single-sourced — the previous hand-rolled list silently
+        // dropped peer-agent envelopes the comment claimed to cover.
+        if source.is_task_boundary() {
             self.silenced_until_progress = false;
         }
     }
@@ -196,5 +195,24 @@ mod tests {
         let r = h.last().cloned().unwrap();
         d.on_envelope_received(&MessageSource::System("goal_continuation".into()));
         assert!(matches!(d.on_after_turn(&r, &h), PostTurnAction::None));
+    }
+
+    #[test]
+    fn peer_agent_and_agent_result_envelopes_clear_silence() {
+        use loopal_protocol::QualifiedAddress;
+        for src in [
+            MessageSource::Agent(QualifiedAddress::local("worker")),
+            MessageSource::AgentResult {
+                child: QualifiedAddress::local("worker"),
+            },
+        ] {
+            let mut d = DegenerationDetector::new(50, 3, 600);
+            let mut h = TurnHistory::with_capacity(100);
+            push_barren(&mut h, 3, 7);
+            assert_degen(&mut d, &h);
+            d.on_envelope_received(&src);
+            // Silence lifted → the next barren window re-triggers.
+            assert_degen(&mut d, &h);
+        }
     }
 }

--- a/crates/loopal-runtime/src/agent_loop/turn_trigger_map.rs
+++ b/crates/loopal-runtime/src/agent_loop/turn_trigger_map.rs
@@ -28,6 +28,15 @@ pub fn envelope_to_trigger(env: &Envelope) -> TurnTrigger {
             from: addr.to_string(),
             content,
         },
+        MessageSource::AgentResult { child } => TurnTrigger::AgentResult {
+            envelope_id,
+            // reason: bare agent name (not child.to_string()) — the
+            // <agent-result name=...> marker must stay hub-agnostic. After
+            // uplink SNAT `child` carries a hub path; to_string() would leak
+            // it into the marker the parent LLM reads.
+            from: child.agent.clone(),
+            content,
+        },
         MessageSource::Channel { channel, from } => TurnTrigger::Channel {
             envelope_id,
             channel: channel.clone(),
@@ -49,6 +58,32 @@ pub fn envelope_to_trigger(env: &Envelope) -> TurnTrigger {
                     content,
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loopal_protocol::QualifiedAddress;
+
+    #[test]
+    fn agent_result_source_maps_to_bare_child_name() {
+        let env = Envelope::new(
+            MessageSource::AgentResult {
+                child: QualifiedAddress::remote(["hub-a"], "worker"),
+            },
+            "parent",
+            "done",
+        );
+        match envelope_to_trigger(&env) {
+            TurnTrigger::AgentResult { from, content, .. } => {
+                // Hub path is stripped: marker stays hub-agnostic even for
+                // cross-hub completions whose source was SNAT-stamped.
+                assert_eq!(from, "worker");
+                assert_eq!(content, "done");
+            }
+            other => panic!("expected AgentResult trigger, got {other:?}"),
         }
     }
 }

--- a/crates/loopal-runtime/tests/agent_loop/e2e_event_waiters.rs
+++ b/crates/loopal-runtime/tests/agent_loop/e2e_event_waiters.rs
@@ -180,6 +180,7 @@ fn turn_text_summary(turn: &loopal_turn::Turn) -> String {
         TurnTrigger::UserInput { content, .. }
         | TurnTrigger::Cron { content, .. }
         | TurnTrigger::Agent { content, .. }
+        | TurnTrigger::AgentResult { content, .. }
         | TurnTrigger::Channel { content, .. }
         | TurnTrigger::GoalContinuation { content, .. }
         | TurnTrigger::BackgroundHook { content, .. } => content.clone(),

--- a/crates/loopal-tui/src/views/progress/message_lines.rs
+++ b/crates/loopal-tui/src/views/progress/message_lines.rs
@@ -71,6 +71,7 @@ fn render_user(lines: &mut Vec<Line<'static>>, msg: &SessionMessage, width: u16)
 fn render_inbox_origin(lines: &mut Vec<Line<'static>>, origin: &InboxOrigin, width: u16) {
     let label = match &origin.source {
         MessageSource::Agent(addr) => format!("📨 from {addr}"),
+        MessageSource::AgentResult { child } => format!("✅ result from {child}"),
         MessageSource::Scheduled => "⏰ scheduled".to_string(),
         MessageSource::Channel { channel, from } => format!("📡 #{channel}/{from}"),
         MessageSource::System(kind) => format!("⚙ system:{kind}"),

--- a/crates/loopal-tui/tests/suite/inbox_render_test.rs
+++ b/crates/loopal-tui/tests/suite/inbox_render_test.rs
@@ -95,3 +95,18 @@ fn test_qualified_remote_agent_address_renders_in_label() {
     let text = flat(&message_to_lines(&m, 80));
     assert!(text.contains("📨 from hub-A/alpha"));
 }
+
+#[test]
+fn test_agent_result_inbox_origin_renders_result_label() {
+    let m = user_with_inbox(
+        "found 3 bugs",
+        MessageSource::AgentResult {
+            child: QualifiedAddress::local("worker"),
+        },
+        None,
+    );
+    let lines = message_to_lines(&m, 80);
+    let text = flat(&lines);
+    assert!(text.contains("✅ result from worker"));
+    assert!(text.contains("found 3 bugs"));
+}

--- a/crates/loopal-turn/src/turn.rs
+++ b/crates/loopal-turn/src/turn.rs
@@ -94,6 +94,16 @@ pub enum TurnTrigger {
         from: String,
         content: String,
     },
+    /// A spawned child agent's completion result routed back to its parent.
+    /// `from` is the bare child name; projection re-wraps `content` in the
+    /// `<agent-result name="{from}">` marker the LLM expects. Unlike `Agent`,
+    /// this deliberately omits the `[from: ...]` prefix — the marker already
+    /// identifies the source, so the prefix would be redundant double-labeling.
+    AgentResult {
+        envelope_id: String,
+        from: String,
+        content: String,
+    },
     /// Routed via a named channel.
     Channel {
         envelope_id: String,


### PR DESCRIPTION
## Summary
- Promote sub-agent completion results from an in-body `<agent-result name=...>` string to a typed `MessageSource::AgentResult { child }` variant, so the semantic lives in the type system rather than being string-parsed/string-rendered by each consumer.
- The envelope body stays raw; the `<agent-result>` wrapper is rebuilt only at LLM projection time. Cross-hub completion detection now matches the typed source instead of byte-scanning the content.
- Sweeps two adjacent debts: SSOT the turn-trigger LLM-text prefixes into `trigger_llm_text` (shared by wire projection + Anthropic builder), and fix DegenerationDetector to reuse `MessageSource::is_task_boundary` (its hand-rolled list silently dropped peer-agent envelopes its comment claimed to clear).

## Changes
- **loopal-protocol**: new `MessageSource::AgentResult { child }` variant + `label`/`is_task_boundary`/`prepend_hub`/`prepend_hub_if_local` arms.
- **loopal-turn**: new `TurnTrigger::AgentResult` variant.
- **loopal-agent-hub**: producers (`completion.rs`/`finish.rs`) emit raw body + typed source; `uplink.rs` detects completion by source type (removed `extract_agent_result_name` byte-parser).
- **loopal-provider-api**: extract `trigger_llm_text` SSOT (`prefix.rs`); refactor `trigger.rs` into text + origin projection.
- **loopal-provider**: Anthropic `trigger_user` collapses onto the shared `trigger_llm_text`.
- **loopal-runtime**: `turn_trigger_map` maps AgentResult source (bare child name); `degeneration_detector` reuses `is_task_boundary`.
- **loopal-tui**: `render_inbox_origin` shows a `✅ result from <child>` badge instead of raw XML tags.
- Tests updated/added across protocol, provider-api, runtime, tui, meta-hub.

## Notes
- The `<agent-result name=...>` marker uses the bare child name even for cross-hub completions (hub path stripped) to match the prior contract.
- Agent completions deliberately drop the redundant `[from: <child>]` prefix — the marker already identifies the source.
- ACP `_loopal/inbox.enqueued`.source now emits the new `AgentResult` wire variant (serde pass-through); IDE clients should handle it.

## Test plan
- [ ] CI passes (`bazel test //...`, clippy, rustfmt)