### PR TITLE
fix(acp): advertise permissionModes capability + handle set_permission_mode

### DIFF
--- a/crates/loopal-acp/src/adapter/control_command.rs
+++ b/crates/loopal-acp/src/adapter/control_command.rs
@@ -51,6 +51,9 @@ pub(crate) fn parse_loopal_control(subtype: &str, p: &Value) -> Option<ControlCo
         "loopal.goalReopen" => Some(C::GoalUserReopen),
         "loopal.goalClear" => Some(C::GoalClear),
         "set_model" => p["model"].as_str().map(|s| C::ModelSwitch(s.to_string())),
+        "set_permission_mode" => p["mode"]
+            .as_str()
+            .map(|s| C::PermissionModeSwitch(s.to_string())),
         _ => None,
     }
 }
@@ -77,6 +80,10 @@ mod tests {
         assert!(matches!(
             parse_loopal_control("loopal.mode", &json!({"mode":"plan"})),
             Some(ControlCommand::ModeSwitch(AgentMode::Plan))
+        ));
+        assert!(matches!(
+            parse_loopal_control("set_permission_mode", &json!({"mode":"ask_dangerous"})),
+            Some(ControlCommand::PermissionModeSwitch(m)) if m == "ask_dangerous"
         ));
     }
 
@@ -105,5 +112,6 @@ mod tests {
         assert!(parse_loopal_control("loopal.bogus", &json!({})).is_none());
         assert!(parse_loopal_control("loopal.bgTaskKill", &json!({})).is_none());
         assert!(parse_loopal_control("loopal.mode", &json!({"mode":"bogus"})).is_none());
+        assert!(parse_loopal_control("set_permission_mode", &json!({})).is_none());
     }
 }

--- a/crates/loopal-acp/src/adapter/lifecycle.rs
+++ b/crates/loopal-acp/src/adapter/lifecycle.rs
@@ -6,20 +6,29 @@ use tracing::info;
 use crate::adapter::AcpAdapter;
 use crate::types::make_init_response;
 
+/// `initialize` result + AgentsMesh extensions: `controlRequest` (runner routes
+/// control-panel actions via `session/control_request`) and `permissionModes`
+/// (AgentsMesh selector renders loopal's modes, not Claude Code's).
+/// `permissionModes` must match `loopal_tool_api::PermissionMode` (SSOT).
+fn init_response_with_extensions() -> Value {
+    let mut result = serde_json::to_value(make_init_response()).unwrap_or_default();
+    if let Some(obj) = result.as_object_mut() {
+        obj.insert(
+            "agentsmeshExtensions".into(),
+            serde_json::json!({
+                "controlRequest": true,
+                "permissionModes": ["bypass", "ask_dangerous", "ask_any_write"],
+            }),
+        );
+    }
+    result
+}
+
 impl AcpAdapter {
-    /// Handle `initialize` — return agent capabilities and info. Advertises
-    /// the AgentsMesh `controlRequest` extension so the runner routes Loopal
-    /// control-panel actions (bg-task kill / cron delete) via
-    /// `session/control_request`.
     pub(crate) async fn handle_initialize(&self, id: i64, _params: Value) {
-        let mut result = serde_json::to_value(make_init_response()).unwrap_or_default();
-        if let Some(obj) = result.as_object_mut() {
-            obj.insert(
-                "agentsmeshExtensions".into(),
-                serde_json::json!({ "controlRequest": true }),
-            );
-        }
-        self.acp_out.respond(id, result).await;
+        self.acp_out
+            .respond(id, init_response_with_extensions())
+            .await;
         info!("ACP initialized");
     }
 
@@ -27,5 +36,21 @@ impl AcpAdapter {
     /// validation needed. Always returns success.
     pub(crate) async fn handle_authenticate(&self, id: i64, _params: Value) {
         self.acp_out.respond(id, serde_json::json!({})).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_response_advertises_control_and_permission_modes() {
+        let resp = init_response_with_extensions();
+        let ext = &resp["agentsmeshExtensions"];
+        assert_eq!(ext["controlRequest"], serde_json::json!(true));
+        assert_eq!(
+            ext["permissionModes"],
+            serde_json::json!(["bypass", "ask_dangerous", "ask_any_write"])
+        );
     }
 }


### PR DESCRIPTION
## Problem
AgentsMesh's workspace permission selector hardcoded Claude Code's 4 modes
(bypassPermissions/acceptEdits/default/dontAsk) and sent them to every ACP agent.
loopal only accepts bypass/ask_dangerous/ask_any_write, so the selector was
semantically wrong and non-functional for loopal pods — Claude Code's permission
rules leaked into loopal's control surface.

## Fix (loopal side)
- `adapter/lifecycle.rs`: advertise `agentsmeshExtensions.permissionModes`
  `["bypass","ask_dangerous","ask_any_write"]` in the initialize response
  (mirrors #195's `controlRequest`), so AgentsMesh renders loopal's modes.
- `adapter/control_command.rs`: map the `set_permission_mode` control subtype to
  `ControlCommand::PermissionModeSwitch`. Runtime path
  (`input_control_config` → `PermissionMode::from_str`) already wired.

## AgentsMesh side (separate change)
Runner parses the capability + forwards via session snapshot; core stores
`supported_permission_modes` with a merge guard; web selector renders the
advertised modes dynamically (Claude fallback for agents that don't advertise).

## Test
- `control_command.rs`: `set_permission_mode` → `PermissionModeSwitch`; missing mode → None
- `lifecycle.rs`: initialize advertises both `controlRequest` + `permissionModes`
- `bazel test //crates/loopal-acp/...` + clippy + rustfmt all green