### PR TITLE
fix(acp): replay config observables on cold-start so selectors show current values

### DIFF
--- a/crates/loopal-acp/src/adapter/snapshot.rs
+++ b/crates/loopal-acp/src/adapter/snapshot.rs
@@ -99,7 +99,32 @@ fn build_replay_events(session_id: &str, state: &Value) -> Vec<(String, Value)> 
             json!({ "servers": state["mcp_status"] }),
         ));
     }
+    push_config_observables(session_id, state, &mut events);
     events
+}
+
+/// Replay the agent's config observables (permission_mode / model / mode /
+/// thinking) from `state.agent.observable`. The bootstrap broadcast emits these
+/// on agent start, but `session/new` drains that channel before the IDE
+/// subscribes — the snapshot is the only cold-start source. `thinking` reads the
+/// snapshot's `thinking_config` but emits under `thinking` to match the live
+/// `ThinkingChanged` notification's field name.
+fn push_config_observables(session_id: &str, state: &Value, events: &mut Vec<(String, Value)>) {
+    let obs = &state["agent"]["observable"];
+    let mut push = |ext_type: &str, raw: &Value| {
+        if let Some(s) = raw.as_str().filter(|s| !s.is_empty()) {
+            let data = Value::Object(
+                [(ext_type.to_string(), Value::String(s.to_string()))]
+                    .into_iter()
+                    .collect(),
+            );
+            events.push(ext_notification(session_id, ext_type, data));
+        }
+    };
+    push("permission_mode", &obs["permission_mode"]);
+    push("model", &obs["model"]);
+    push("mode", &obs["mode"]);
+    push("thinking", &obs["thinking_config"]);
 }
 
 #[cfg(test)]
@@ -150,5 +175,27 @@ mod tests {
         let m = methods(&ev);
         assert!(!m.contains(&"_loopal/mcp"));
         assert!(m.contains(&"_loopal/crons"));
+    }
+
+    #[test]
+    fn replays_config_observables_skipping_empty() {
+        let state = json!({
+            "agent": {"observable": {
+                "permission_mode": "bypass", "model": "opus", "mode": "", "thinking_config": "auto"
+            }},
+            "bg_tasks": {}, "crons": [], "tasks": []
+        });
+        let ev = build_replay_events("s", &state);
+        let m = methods(&ev);
+        assert!(m.contains(&"_loopal/permission_mode"));
+        assert!(m.contains(&"_loopal/model"));
+        assert!(!m.contains(&"_loopal/mode")); // empty → skipped
+        assert!(m.contains(&"_loopal/thinking"));
+        let by = |k: &str| ev.iter().find(|(meth, _)| meth == k).unwrap().1.clone();
+        assert_eq!(
+            by("_loopal/permission_mode")["data"]["permission_mode"],
+            "bypass"
+        );
+        assert_eq!(by("_loopal/thinking")["data"]["thinking"], "auto"); // thinking_config → thinking
     }
 }


### PR DESCRIPTION
## 根因

permission selector 初始永久显 \"—\" 的真根因不在 panel.rs（#198 v0.6.2 已修「运行中切档」run_event_loop 路径），而在**冷启动重放**：

- `session/new` → `drain_bootstrap_events` **设计性丢弃** cold-start broadcast（含 `PermissionModeChanged`/`ModelChanged`/`ModeChanged`/`ThinkingChanged`）
- 冷启动状态唯一可靠来源 = `replay_loopal_snapshot` → `build_replay_events`
- 但 `build_replay_events` 只重放 `bgTask`/`crons`/`tasks`/`mcp`，**漏发全部 config observables**

∴ AgentsMesh permission selector（及 model/mode/thinking console 镜像）在用户手动切换前显 \"—\"/空。

## 修复

`build_replay_events` 从 `state.agent.observable` 补发 4 项 config observable：`permission_mode` / `model` / `mode` / `thinking`。`thinking` 读 snapshot 的 `thinking_config` 字段但以 `thinking` 发出，匹配 live `ThinkingChanged` 通知字段名。空值跳过。

## 测试

`replays_config_observables_skipping_empty`：4 项重放 + 空值跳过 + `thinking_config`→`thinking` 映射 + data 字段名断言。本地 clippy + rustfmt + unit test 全绿。